### PR TITLE
bugfix: support a configurable port number

### DIFF
--- a/cmd/apiserver/app/serve.go
+++ b/cmd/apiserver/app/serve.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"strconv"
 
 	"buf.build/gen/go/datum-cloud/iam/grpc/go/datum/iam/v1alpha/iamv1alphagrpc"
 	iampb "buf.build/gen/go/datum-cloud/iam/protocolbuffers/go/datum/iam/v1alpha"
@@ -328,6 +329,14 @@ func getZitadelClient(cmd *cobra.Command, ctx context.Context) (*client.Client, 
 	zitadelOptions := []zitadel.Option{}
 	if zitadelConfig.Insecure {
 		zitadelOptions = append(zitadelOptions, zitadel.WithInsecure(zitadelConfig.Port))
+	}
+
+	if zitadelConfig.Port != "" {
+		port, err := strconv.Atoi(zitadelConfig.Port)
+		if err != nil {
+			return nil, fmt.Errorf("failed to convert ZITADEL port to int: %w", err)
+		}
+		zitadelOptions = append(zitadelOptions, zitadel.WithPort(uint16(port)))
 	}
 
 	zitadelClient, err := client.New(ctx, zitadel.New(zitadelConfig.Endpoint, zitadelOptions...),


### PR DESCRIPTION
This updates the Zitadel configuration to support connecting to a non-standard port when using a secure connection to the API. This is required for our deployment in Kubernetes. 

Error from connecting to the Zitadel client:

```
Get "https://zitadel.zitadel-system.svc.cluster.local/.well-known/openid-configuration": dial tcp 10.2.13.234:443: i/o timeout  
```

The endpoint configuration being used: 

```
- name: ZITADEL_ENDPOINT
  value: https://zitadel.zitadel-system.svc.cluster.local:8080/
```