### PR TITLE
Add Role Permission Inheritance

### DIFF
--- a/api/datum/iam/v1alpha/roles_resources.proto
+++ b/api/datum/iam/v1alpha/roles_resources.proto
@@ -103,6 +103,10 @@ message RoleSpec {
   // Defines the launch stage of the IAM Role. Must be one of: Early Access,
   // Alpha, Beta, Stable, Deprecated.
   string launch_stage = 2 [(google.api.field_behavior) = REQUIRED];
+
+  // The list of roles from which this role inherits permissions.
+  // Each entry must be a valid role resource name, e.g. "services/resourcemanager.datumapis.com/roles/projectAdmin".
+  repeated string inherited_roles = 3 [(google.api.field_behavior) = OPTIONAL];
 }
 
 // Provides status information on the Role.

--- a/cmd/apiserver/app/add-resources.go
+++ b/cmd/apiserver/app/add-resources.go
@@ -89,8 +89,9 @@ to the system.
 			}
 
 			roleReconciler := &openfga.RoleReconciler{
-				StoreID: storeID,
-				Client:  openFGAClient,
+				StoreID:     storeID,
+				Client:      openFGAClient,
+				RoleStorage: roleStorage,
 			}
 
 			policyReconciler := &openfga.PolicyReconciler{
@@ -120,6 +121,7 @@ to the system.
 			if err := addResources(cmd, roleStorage, func(role *iampb.Role) error {
 				if errs := validation.ValidateRole(role, &validation.RoleValidatorOptions{
 					PermissionValidator: validation.NewPermissionValidator(serviceStorage),
+					RoleValidator:       validation.NewRoleValidator(roleStorage),
 				}); len(errs) > 0 {
 					return errs.GRPCStatus().Err()
 				}

--- a/cmd/apiserver/app/serve.go
+++ b/cmd/apiserver/app/serve.go
@@ -142,6 +142,11 @@ func serve() *cobra.Command {
 				return err
 			})
 
+			databaseRoleResolver, err := role.DatabaseRoleResolver(db)
+			if err != nil {
+				return fmt.Errorf("failed to create database role resolver: %w", err)
+			}
+
 			zitadelClient, err := getZitadelClient(cmd, ctx)
 			if err != nil {
 				return err
@@ -239,6 +244,7 @@ func serve() *cobra.Command {
 				RoleResolver:           roleResolver,
 				AuthenticationProvider: authenticationProvider,
 				SubjectExtractor:       subjectExtractor,
+				DatabaseRoleResolver:   databaseRoleResolver,
 			}); err != nil {
 				return fmt.Errorf("failed to create IAM gRPC server: %w", err)
 			}

--- a/go.mod
+++ b/go.mod
@@ -3,9 +3,9 @@ module go.datum.net/iam
 go 1.23.1
 
 require (
-	buf.build/gen/go/datum-cloud/iam/grpc-ecosystem/gateway/v2 v2.26.3-20250508154930-4255cdb88b53.1
-	buf.build/gen/go/datum-cloud/iam/grpc/go v1.5.1-20250508154930-4255cdb88b53.2
-	buf.build/gen/go/datum-cloud/iam/protocolbuffers/go v1.36.6-20250508154930-4255cdb88b53.1
+	buf.build/gen/go/datum-cloud/iam/grpc-ecosystem/gateway/v2 v2.26.3-20250512132552-ef4f07e9750a.1
+	buf.build/gen/go/datum-cloud/iam/grpc/go v1.5.1-20250512132552-ef4f07e9750a.2
+	buf.build/gen/go/datum-cloud/iam/protocolbuffers/go v1.36.6-20250512132552-ef4f07e9750a.1
 	buf.build/go/protoyaml v0.3.2
 	cloud.google.com/go/longrunning v0.6.7
 	github.com/google/go-cmp v0.7.0
@@ -16,6 +16,7 @@ require (
 	github.com/lib/pq v1.10.9
 	github.com/mennanov/fmutils v0.3.0
 	github.com/openfga/api/proto v0.0.0-20250127102726-f9709139a369
+	github.com/prometheus/client_golang v1.17.0
 	github.com/simukti/sqldb-logger v0.0.0-20230108155151-646c1a075551
 	github.com/spf13/cobra v1.8.1
 	github.com/spf13/pflag v1.0.6
@@ -168,7 +169,6 @@ require (
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c // indirect
-	github.com/prometheus/client_golang v1.17.0 // indirect
 	github.com/prometheus/client_model v0.5.0 // indirect
 	github.com/prometheus/common v0.44.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,11 +1,11 @@
 buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.36.6-20250307204501-0409229c3780.1 h1:zgJPqo17m28+Lf5BW4xv3PvU20BnrmTcGYrog22lLIU=
 buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.36.6-20250307204501-0409229c3780.1/go.mod h1:avRlCjnFzl98VPaeCtJ24RrV/wwHFzB8sWXhj26+n/U=
-buf.build/gen/go/datum-cloud/iam/grpc-ecosystem/gateway/v2 v2.26.3-20250508154930-4255cdb88b53.1 h1:214mNgyIkhI3iqhKslU5nUChQ/Cc7BPRsyvecdcQDB0=
-buf.build/gen/go/datum-cloud/iam/grpc-ecosystem/gateway/v2 v2.26.3-20250508154930-4255cdb88b53.1/go.mod h1:L93kOc1oKYLo5JF9nqzBUHPFlO9TBAQFDd067N6rLLs=
-buf.build/gen/go/datum-cloud/iam/grpc/go v1.5.1-20250508154930-4255cdb88b53.2 h1:LNpqKEobVkQEdnT0iJ9QhMiO3ApJvNMHJijQlz7JUuE=
-buf.build/gen/go/datum-cloud/iam/grpc/go v1.5.1-20250508154930-4255cdb88b53.2/go.mod h1:UtR8Wp+S0GoX60tmpufgV/djJUDsJv6mH2AHBCiRs8s=
-buf.build/gen/go/datum-cloud/iam/protocolbuffers/go v1.36.6-20250508154930-4255cdb88b53.1 h1:gRiW6g44NIO54GhMT/8kWRvZDg3XuaPmiXvqpoexFd4=
-buf.build/gen/go/datum-cloud/iam/protocolbuffers/go v1.36.6-20250508154930-4255cdb88b53.1/go.mod h1:mBNXMGhmoM4v2WU3Ocr2xvv5E4UUopEGt6dYDMp7huc=
+buf.build/gen/go/datum-cloud/iam/grpc-ecosystem/gateway/v2 v2.26.3-20250512132552-ef4f07e9750a.1 h1:5KufFGnEnsjEHSoOo4v+dWj2/rz2MTbH78vJMXrNW3A=
+buf.build/gen/go/datum-cloud/iam/grpc-ecosystem/gateway/v2 v2.26.3-20250512132552-ef4f07e9750a.1/go.mod h1:I8SAKqMIbPi333n2k3sY8EPqnkQpN7LB4KCOPifx2VU=
+buf.build/gen/go/datum-cloud/iam/grpc/go v1.5.1-20250512132552-ef4f07e9750a.2 h1:8iMeXsrOhm5Vljdjcqn2fjEEnzelA7mo+37H/4lXU5k=
+buf.build/gen/go/datum-cloud/iam/grpc/go v1.5.1-20250512132552-ef4f07e9750a.2/go.mod h1:71iTt7LZEjBBjonwSqjs0VjKh7MsVuirxwwurVTHMMk=
+buf.build/gen/go/datum-cloud/iam/protocolbuffers/go v1.36.6-20250512132552-ef4f07e9750a.1 h1:TeO0jLXhzB0Jaa3U8wFuwGPfxjUo8riRgdcRq21dKIE=
+buf.build/gen/go/datum-cloud/iam/protocolbuffers/go v1.36.6-20250512132552-ef4f07e9750a.1/go.mod h1:mBNXMGhmoM4v2WU3Ocr2xvv5E4UUopEGt6dYDMp7huc=
 buf.build/go/protoyaml v0.3.2 h1:QJF3k7btMameIadLLcK3Rry81OK3gYA5nZMXirV1Bs4=
 buf.build/go/protoyaml v0.3.2/go.mod h1:rUlMqwfZeONS/BAt00wB6jV5ay/eHXUzxgiKSIyrvyc=
 cel.dev/expr v0.19.1 h1:NciYrtDRIR0lNCnH1LFJegdjspNx9fI59O7TWcua/W4=

--- a/internal/grpc/server/organization.go
+++ b/internal/grpc/server/organization.go
@@ -5,9 +5,9 @@ import (
 	"fmt"
 	"strings"
 
-	openfgav1 "github.com/openfga/api/proto/openfga/v1"
 	"cloud.google.com/go/longrunning/autogen/longrunningpb"
 	"github.com/google/uuid"
+	openfgav1 "github.com/openfga/api/proto/openfga/v1"
 	"go.datum.net/iam/internal/grpc/longrunning"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/timestamppb"

--- a/internal/grpc/server/roles.go
+++ b/internal/grpc/server/roles.go
@@ -22,6 +22,7 @@ func (s *Server) CreateRole(ctx context.Context, req *iampb.CreateRoleRequest) (
 	// Validate the role
 	if errs := validation.ValidateRole(role, &validation.RoleValidatorOptions{
 		PermissionValidator: validation.NewPermissionValidator(s.ServiceStorage),
+		RoleValidator:       validation.NewRoleValidator(s.RoleStorage),
 	}); len(errs) != 0 {
 		return nil, errs.GRPCStatus().Err()
 	}

--- a/internal/grpc/server/server.go
+++ b/internal/grpc/server/server.go
@@ -47,6 +47,7 @@ type Server struct {
 	AccessChecker                func(context.Context, *iampb.CheckAccessRequest) (*iampb.CheckAccessResponse, error)
 	AuthenticationProvider       authentication.Provider
 	SubjectExtractor             auth.SubjectExtractor
+	DatabaseRoleResolver         role.DatabaseResolver
 }
 
 type ServerOptions struct {
@@ -62,6 +63,7 @@ type ServerOptions struct {
 	RoleResolver           role.Resolver
 	SubjectExtractor       auth.SubjectExtractor
 	AuthenticationProvider authentication.Provider
+	DatabaseRoleResolver   role.DatabaseResolver
 }
 
 // Configures a new IAM Server
@@ -99,6 +101,7 @@ func NewServer(opts ServerOptions) error {
 		AccessChecker:          openfga.AccessChecker(schemaRegistry, opts.OpenFGAClient, opts.OpenFGAStoreID),
 		SubjectExtractor:       opts.SubjectExtractor,
 		AuthenticationProvider: opts.AuthenticationProvider,
+		DatabaseRoleResolver:   opts.DatabaseRoleResolver,
 	}
 
 	// Register all gRPC services with the gRPC server here.

--- a/internal/grpc/server/server.go
+++ b/internal/grpc/server/server.go
@@ -85,8 +85,9 @@ func NewServer(opts ServerOptions) error {
 			SubjectResolver: opts.SubjectResolver,
 		},
 		RoleReconciler: &openfga.RoleReconciler{
-			StoreID: opts.OpenFGAStoreID,
-			Client:  opts.OpenFGAClient,
+			StoreID:     opts.OpenFGAStoreID,
+			Client:      opts.OpenFGAClient,
+			RoleStorage: opts.RoleStorage,
 		},
 		SchemaRegistry:         schemaRegistry,
 		OpenFGAClient:          opts.OpenFGAClient,

--- a/internal/grpc/validation/roles.go
+++ b/internal/grpc/validation/roles.go
@@ -1,13 +1,21 @@
 package validation
 
 import (
+	"context"
+	"fmt"
+	"regexp"
+
 	iampb "buf.build/gen/go/datum-cloud/iam/protocolbuffers/go/datum/iam/v1alpha"
+	"go.datum.net/iam/internal/storage"
 	"go.datum.net/iam/internal/validation/field"
 	"go.datum.net/iam/internal/validation/meta"
 )
 
+type RoleValidator func(fieldPath *field.Path, role string) field.ErrorList
+
 type RoleValidatorOptions struct {
 	PermissionValidator PermissionValidator
+	RoleValidator       RoleValidator
 }
 
 func ValidateRole(role *iampb.Role, opts *RoleValidatorOptions) field.ErrorList {
@@ -22,13 +30,64 @@ func ValidateRole(role *iampb.Role, opts *RoleValidatorOptions) field.ErrorList 
 
 func validateRoleSpec(fieldPath *field.Path, roleSpec *iampb.RoleSpec, opts *RoleValidatorOptions) field.ErrorList {
 	errs := field.ErrorList{}
+
 	if roleSpec == nil {
-		return append(errs, field.Required(fieldPath.Child("spec"), "spec is required"))
+		return append(errs, field.Required(fieldPath, "spec is required"))
 	}
+
+	errs = append(errs, validateSpecIncludedPermissions(fieldPath, roleSpec, opts)...)
+	errs = append(errs, validateSpecInheritedRoles(fieldPath, roleSpec, opts)...)
+
+	return errs
+}
+
+func validateSpecIncludedPermissions(fieldPath *field.Path, roleSpec *iampb.RoleSpec, opts *RoleValidatorOptions) field.ErrorList {
+	errs := field.ErrorList{}
 
 	for index, permission := range roleSpec.GetIncludedPermissions() {
 		errs = append(errs, opts.PermissionValidator(fieldPath.Child("included_permissions").Index(index), permission)...)
 	}
 
 	return errs
+}
+
+func validateSpecInheritedRoles(fieldPath *field.Path, roleSpec *iampb.RoleSpec, opts *RoleValidatorOptions) field.ErrorList {
+	errs := field.ErrorList{}
+
+	for index, role := range roleSpec.GetInheritedRoles() {
+		errs = append(errs, opts.RoleValidator(fieldPath.Child("inherited_roles").Index(index), role)...)
+	}
+
+	return errs
+}
+
+var roleMatcher *regexp.Regexp
+
+func init() {
+	roleMatcher = regexp.MustCompile(`([a-zA-Z0-9\.\-]+)\/([a-zA-Z0-9\.\-]+)`)
+}
+
+func NewRoleValidator(services storage.ResourceGetter[*iampb.Role]) RoleValidator {
+	return func(fieldPath *field.Path, role string) field.ErrorList {
+		errs := field.ErrorList{}
+		matches := roleMatcher.FindStringSubmatch(role)
+		if len(matches) != 3 {
+			errs = append(errs, field.Invalid(fieldPath, role, "role must be in the format `{service_name}/{role_name}`"))
+			return errs
+		}
+
+		serviceName := matches[1]
+		roleName := matches[2]
+
+		resource, err := services.GetResource(context.Background(), &storage.GetResourceRequest{
+			Name: "services/" + serviceName + "/roles/" + roleName,
+		})
+		if len(resource.GetName()) == 0 && err != nil {
+			errs = append(errs, field.NotFound(fieldPath, role))
+		} else if err != nil {
+			errs = append(errs, field.InternalError(fieldPath, fmt.Errorf("internal error when validating role")))
+		}
+
+		return errs
+	}
 }

--- a/internal/grpc/validation/roles.go
+++ b/internal/grpc/validation/roles.go
@@ -64,7 +64,7 @@ func validateSpecInheritedRoles(fieldPath *field.Path, roleSpec *iampb.RoleSpec,
 var roleMatcher *regexp.Regexp
 
 func init() {
-	roleMatcher = regexp.MustCompile(`([a-zA-Z0-9\.\-]+)\/([a-zA-Z0-9\.\-]+)`)
+	roleMatcher = regexp.MustCompile(`services\/([a-zA-Z0-9\.\-]+)\/roles\/([a-zA-Z0-9\.\-]+)`)
 }
 
 func NewRoleValidator(services storage.ResourceGetter[*iampb.Role]) RoleValidator {
@@ -72,15 +72,12 @@ func NewRoleValidator(services storage.ResourceGetter[*iampb.Role]) RoleValidato
 		errs := field.ErrorList{}
 		matches := roleMatcher.FindStringSubmatch(role)
 		if len(matches) != 3 {
-			errs = append(errs, field.Invalid(fieldPath, role, "role must be in the format `{service_name}/{role_name}`"))
+			errs = append(errs, field.Invalid(fieldPath, role, "role must be in the format `services/{service_name}/roles/{role_name}`"))
 			return errs
 		}
 
-		serviceName := matches[1]
-		roleName := matches[2]
-
 		resource, err := services.GetResource(context.Background(), &storage.GetResourceRequest{
-			Name: "services/" + serviceName + "/roles/" + roleName,
+			Name: role,
 		})
 		if len(resource.GetName()) == 0 && err != nil {
 			errs = append(errs, field.NotFound(fieldPath, role))

--- a/internal/role/database.go
+++ b/internal/role/database.go
@@ -1,0 +1,55 @@
+package role
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+)
+
+type Kind string
+
+const (
+	InheritedRoleKind Kind = "InheritedRole"
+)
+
+type DatabaseResolver func(ctx context.Context, kind Kind, roleName string) ([]string, error)
+
+func DatabaseRoleResolver(db *sql.DB) (DatabaseResolver, error) {
+	// Prepares a statement to find all roles that inherit from a given role name.
+	inheritedRoleStmt, err := db.Prepare(`SELECT name FROM iam_datumapis_com_Role_resource WHERE data->'spec'->'inheritedRoles' @> $1::jsonb`)
+	if err != nil {
+		return nil, err
+	}
+
+	return func(ctx context.Context, kind Kind, roleName string) ([]string, error) {
+		var rows *sql.Rows
+		var err error
+
+		switch kind {
+		case InheritedRoleKind:
+			jsonArray := fmt.Sprintf(`["%s"]`, roleName)
+			rows, err = inheritedRoleStmt.QueryContext(ctx, jsonArray)
+			if err != nil {
+				return nil, err
+			}
+			defer rows.Close()
+		default:
+			return nil, fmt.Errorf("unsupported subject type provided: %s", string(kind))
+		}
+
+		var roles []string
+		for rows.Next() {
+			var role string
+			if err := rows.Scan(&role); err != nil {
+				return nil, err
+			}
+			roles = append(roles, role)
+		}
+
+		if err := rows.Err(); err != nil {
+			return nil, err
+		}
+
+		return roles, nil
+	}, nil
+}


### PR DESCRIPTION
This PR implements role inheritance functionality, allowing roles to inherit permissions from other roles. The inheritance process is recursive, ensuring that all permissions from the inheritance chain are properly propagated.

**Implementation details:**
- Recursively collects all permissions from inherited roles
- Includes the main role's `includedPermissions`
- Generates the expected OpenFGA tuples based on the complete permission set

- When a role is updated, all roles that are descendants of that role—both directly and indirectly—will be reconciled to update their permissions accordingly.

- When a role is deleted, the system will check whether any other role inherits from it. If so, the deletion will be prevented.

**Future improvements**:
- [x] Update main role when inherited roles are modified
- [x] Update main role when inherited roles are deleted