### PR TITLE
Automatically resolve resource parents

### DIFF
--- a/cmd/apiserver/app/add-resources.go
+++ b/cmd/apiserver/app/add-resources.go
@@ -94,13 +94,18 @@ to the system.
 				RoleStorage: roleStorage,
 			}
 
+			subjectResolver, err := subject.DatabaseResolver(db)
+			if err != nil {
+				return fmt.Errorf("failed to create database subject resolver: %w", err)
+			}
+
 			policyReconciler := &openfga.PolicyReconciler{
 				StoreID: storeID,
 				Client:  openFGAClient,
 				SchemaRegistry: &schema.Registry{
 					Services: serviceStorage,
 				},
-				SubjectResolver: subject.NoopResolver(),
+				SubjectResolver: subjectResolver,
 			}
 
 			// Add any IAM services that are defined and reconcile the authorization
@@ -140,7 +145,7 @@ to the system.
 						})
 						return err
 					},
-					SubjectResolver: subject.NoopResolver(),
+					SubjectResolver: subjectResolver,
 					Context:         context.Background(),
 				}); len(errs) > 0 {
 					return errs.GRPCStatus().Err()

--- a/cmd/apiserver/app/serve.go
+++ b/cmd/apiserver/app/serve.go
@@ -135,7 +135,7 @@ func serve() *cobra.Command {
 				return fmt.Errorf("failed to create database resolver: %w", err)
 			}
 
-			subjectExtractor, err := jwt.SubjectExtractor(authConfig, subjectResolver)
+			subjectExtractor, err := jwt.SubjectExtractor(authConfig)
 			if err != nil {
 				return err
 			}
@@ -253,6 +253,7 @@ func serve() *cobra.Command {
 				AuthenticationProvider: authenticationProvider,
 				SubjectExtractor:       subjectExtractor,
 				DatabaseRoleResolver:   databaseRoleResolver,
+				ParentResolver:         parentResolverRegistry,
 			}); err != nil {
 				return fmt.Errorf("failed to create IAM gRPC server: %w", err)
 			}

--- a/internal/grpc/auth/jwt/subject_extractor.go
+++ b/internal/grpc/auth/jwt/subject_extractor.go
@@ -9,14 +9,13 @@ import (
 
 	"github.com/lestrrat-go/jwx/v2/jwk"
 	"github.com/lestrrat-go/jwx/v2/jwt"
-	"go.datum.net/iam/internal/grpc/auth"
 	"go.datum.net/iam/internal/grpc/errors"
 	"go.datum.net/iam/internal/subject"
 	"google.golang.org/genproto/googleapis/api/serviceconfig"
 	"google.golang.org/grpc/metadata"
 )
 
-func SubjectExtractor(auth *serviceconfig.Authentication, subjectResolver subject.Resolver) (auth.SubjectExtractor, error) {
+func SubjectExtractor(auth *serviceconfig.Authentication) (subject.Extractor, error) {
 	// Create a set of token validators that should be checked against the JWT
 	// token that's retrieved from the request context.
 	cache := jwk.NewCache(context.Background(), jwk.WithRefreshWindow(time.Hour))
@@ -64,16 +63,8 @@ func SubjectExtractor(auth *serviceconfig.Authentication, subjectResolver subjec
 					return "", errors.Unauthenticated().Err()
 				}
 
-				if subjectResolver == nil {
-					return email, nil
-				}
-
-				subject, err := subjectResolver(ctx, subject.UserKind, email)
-				if err != nil {
-					return "", err
-				}
-
-				return subject, nil
+				// TODO: Resolve subject type to support machine accounts and groups
+				return fmt.Sprintf("user:%s", email), nil
 			} else {
 				slog.ErrorContext(
 					ctx,

--- a/internal/grpc/server/check.go
+++ b/internal/grpc/server/check.go
@@ -2,10 +2,83 @@ package server
 
 import (
 	"context"
+	"fmt"
+	"log/slog"
 
 	iampb "buf.build/gen/go/datum-cloud/iam/protocolbuffers/go/datum/iam/v1alpha"
+	"go.datum.net/iam/internal/storage"
+	"go.datum.net/iam/internal/subject"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	// schema "go.datum.net/iam/internal/schema" // No longer needed if s.SchemaRegistry is used directly and types are compatible
 )
 
 func (s *Server) CheckAccess(ctx context.Context, req *iampb.CheckAccessRequest) (*iampb.CheckAccessResponse, error) {
+	resolveCtx, span := otel.Tracer("").Start(ctx, "datum.server.CheckAccess.resolveParents")
+	defer span.End()
+
+	subjectID, subjectKind, err := subject.Parse(req.Subject)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse subject: %w", err)
+	}
+
+	subject, err := s.SubjectResolver(resolveCtx, subjectKind, subjectID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve subject: %w", err)
+	}
+
+	req.Subject = subject
+
+	// Use schema.Registry to resolve the resource URL into its components including type.
+	schemaRef, err := s.SchemaRegistry.ResolveResource(resolveCtx, req.Resource)
+	if err != nil {
+		slog.ErrorContext(resolveCtx, "Failed to resolve resource using schema registry", "error", err, "resource", req.Resource)
+		span.SetStatus(codes.Error, "Failed to resolve resource via schema registry")
+		return nil, fmt.Errorf("failed to resolve resource '%s' via schema registry: %w", req.Resource, err)
+	}
+
+	currentResourceRef := &storage.ResourceReference{
+		Name:     storage.ResourceName(schemaRef.Name), // Cast string to storage.ResourceName type if it exists and is used by ParentResolver
+		Type:     schemaRef.Type,
+		SelfLink: schemaRef.SelfLink, // This should be equivalent to req.Resource
+	}
+
+	slog.InfoContext(resolveCtx, "Attempting to resolve parents for", slog.Any("resource", currentResourceRef))
+
+	var resolvedParentRelationships []*iampb.ParentRelationship
+	loopResource := currentResourceRef
+	for {
+		parentStorageRef, err := s.ParentResolver.ResolveParent(resolveCtx, loopResource)
+		if err != nil {
+			span.SetStatus(codes.Error, err.Error())
+			slog.ErrorContext(resolveCtx, "Error resolving parent", slog.Any("resource", loopResource), "error", err)
+			return nil, fmt.Errorf("failed to resolve parent for %s: %w", loopResource.SelfLink, err)
+		} else if parentStorageRef == nil {
+			slog.DebugContext(resolveCtx, "Resource does not have a parent or no more parents", slog.Any("resource", loopResource))
+			break
+		}
+
+		slog.DebugContext(resolveCtx, "Found parent", slog.Any("parent", parentStorageRef), slog.Any("child", loopResource))
+		resolvedParentRelationships = append(resolvedParentRelationships, &iampb.ParentRelationship{
+			ParentResource: parentStorageRef.SelfLink,
+			ChildResource:  loopResource.SelfLink,
+		})
+
+		loopResource = parentStorageRef
+	}
+	span.SetAttributes(attribute.Int("resolved_parent_count", len(resolvedParentRelationships)))
+
+	if len(resolvedParentRelationships) > 0 {
+		for _, p := range resolvedParentRelationships {
+			req.Context = append(req.Context, &iampb.CheckContext{
+				ContextType: &iampb.CheckContext_ParentRelationship{
+					ParentRelationship: p,
+				},
+			})
+		}
+		slog.InfoContext(resolveCtx, "Augmented CheckAccessRequest with parent relationships", slog.Int("count", len(resolvedParentRelationships)))
+	}
+
 	return s.AccessChecker(ctx, req)
 }

--- a/internal/grpc/server/check.go
+++ b/internal/grpc/server/check.go
@@ -7,7 +7,6 @@ import (
 
 	iampb "buf.build/gen/go/datum-cloud/iam/protocolbuffers/go/datum/iam/v1alpha"
 	"go.datum.net/iam/internal/storage"
-	"go.datum.net/iam/internal/subject"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
@@ -18,12 +17,7 @@ func (s *Server) CheckAccess(ctx context.Context, req *iampb.CheckAccessRequest)
 	resolveCtx, span := otel.Tracer("").Start(ctx, "datum.server.CheckAccess.resolveParents")
 	defer span.End()
 
-	subjectID, _, err := subject.Parse(req.Subject)
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse subject: %w", err)
-	}
-
-	subjectReference, err := s.SubjectResolver(resolveCtx, subjectID)
+	subjectReference, err := s.SubjectResolver(resolveCtx, req.Subject)
 	if err != nil {
 		return nil, fmt.Errorf("failed to resolve subject: %w", err)
 	}

--- a/internal/grpc/server/iam_test.go
+++ b/internal/grpc/server/iam_test.go
@@ -356,6 +356,10 @@ func setupIAMClient(t *testing.T, ctx context.Context) (client *Client) {
 		t.Fatalf("failed to create new in-memory client: %s", err)
 	}
 
+	parentResolverRegistry := &storage.ParentResolverRegistry{}
+	// Register a new parent resolver for the Project resource.
+	parentResolverRegistry.RegisterResolver(&iampb.Service{}, storage.ResourceParentResolver(servicesStorage))
+
 	if err := server.NewServer(server.ServerOptions{
 		OpenFGAClient:   openFGAClient,
 		OpenFGAStoreID:  openFGAStoreID,
@@ -363,6 +367,7 @@ func setupIAMClient(t *testing.T, ctx context.Context) (client *Client) {
 		RoleStorage:     rolesStorage,
 		PolicyStorage:   policyStorage,
 		SubjectResolver: subject.NoopResolver(),
+		ParentResolver:  parentResolverRegistry,
 		GRPCServer:      grpcServer,
 		RoleResolver: func(ctx context.Context, roleName string) error {
 			_, err := rolesStorage.GetResource(ctx, &storage.GetResourceRequest{

--- a/internal/grpc/server/iam_test.go
+++ b/internal/grpc/server/iam_test.go
@@ -357,15 +357,13 @@ func setupIAMClient(t *testing.T, ctx context.Context) (client *Client) {
 	}
 
 	if err := server.NewServer(server.ServerOptions{
-		OpenFGAClient:  openFGAClient,
-		OpenFGAStoreID: openFGAStoreID,
-		ServiceStorage: servicesStorage,
-		RoleStorage:    rolesStorage,
-		PolicyStorage:  policyStorage,
-		SubjectResolver: func(_ context.Context, _ subject.Kind, subject string) (string, error) {
-			return subject, nil
-		},
-		GRPCServer: grpcServer,
+		OpenFGAClient:   openFGAClient,
+		OpenFGAStoreID:  openFGAStoreID,
+		ServiceStorage:  servicesStorage,
+		RoleStorage:     rolesStorage,
+		PolicyStorage:   policyStorage,
+		SubjectResolver: subject.NoopResolver(),
+		GRPCServer:      grpcServer,
 		RoleResolver: func(ctx context.Context, roleName string) error {
 			_, err := rolesStorage.GetResource(ctx, &storage.GetResourceRequest{
 				Name: roleName,

--- a/internal/grpc/server/organization.go
+++ b/internal/grpc/server/organization.go
@@ -9,7 +9,6 @@ import (
 	"github.com/google/uuid"
 	openfgav1 "github.com/openfga/api/proto/openfga/v1"
 	"go.datum.net/iam/internal/grpc/longrunning"
-	"go.datum.net/iam/internal/subject"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
@@ -58,13 +57,13 @@ func (s *Server) CreateOrganization(ctx context.Context, req *resourcemanagerpb.
 		return nil, err
 	}
 
-	subjectName, err := s.SubjectResolver(ctx, subject.UserKind, userEmail)
+	subjectReference, err := s.SubjectResolver(ctx, userEmail)
 	if err != nil {
 		return nil, err
 	}
 
 	user, err := s.UserStorage.GetResource(ctx, &storage.GetResourceRequest{
-		Name: subjectName,
+		Name: subjectReference.ResourceName,
 	})
 	if err != nil {
 		return nil, err
@@ -164,12 +163,12 @@ func (s *Server) UpdateOrganization(ctx context.Context, req *resourcemanagerpb.
 }
 
 func (s *Server) SearchOrganizations(ctx context.Context, req *resourcemanagerpb.SearchOrganizationsRequest) (*resourcemanagerpb.SearchOrganizationsResponse, error) {
-	userName, err := s.SubjectExtractor(ctx)
+	subjectIdentifier, err := s.SubjectExtractor(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	subjectName, err := s.SubjectResolver(ctx, subject.UserKind, userName)
+	subjectReference, err := s.SubjectResolver(ctx, subjectIdentifier)
 	if err != nil {
 		return nil, err
 	}
@@ -179,7 +178,7 @@ func (s *Server) SearchOrganizations(ctx context.Context, req *resourcemanagerpb
 	hashedPermission := openfga.HashPermission("resourcemanager.datumapis.com/organizations.get")
 	organizationsObjects, err := s.OpenFGAClient.ListObjects(ctx, &openfgav1.ListObjectsRequest{
 		StoreId:  s.OpenFGAStoreID,
-		User:     fmt.Sprintf("iam.datumapis.com/InternalUser:%s", subjectName),
+		User:     fmt.Sprintf("iam.datumapis.com/InternalUser:%s", subjectReference.ResourceName),
 		Relation: hashedPermission,
 		Type:     resourceType,
 	})

--- a/internal/grpc/server/server.go
+++ b/internal/grpc/server/server.go
@@ -11,7 +11,6 @@ import (
 	resourcemanagerpb "buf.build/gen/go/datum-cloud/iam/protocolbuffers/go/datum/resourcemanager/v1alpha"
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	openfgav1 "github.com/openfga/api/proto/openfga/v1"
-	"go.datum.net/iam/internal/grpc/auth"
 	"go.datum.net/iam/internal/providers/authentication"
 	"go.datum.net/iam/internal/providers/openfga"
 	"go.datum.net/iam/internal/role"
@@ -48,8 +47,9 @@ type Server struct {
 	RoleResolver                 role.Resolver
 	AccessChecker                func(context.Context, *iampb.CheckAccessRequest) (*iampb.CheckAccessResponse, error)
 	AuthenticationProvider       authentication.Provider
-	SubjectExtractor             auth.SubjectExtractor
 	DatabaseRoleResolver         role.DatabaseResolver
+	SubjectExtractor             subject.Extractor
+	ParentResolver               storage.ParentResolver
 }
 
 type ServerOptions struct {
@@ -64,9 +64,10 @@ type ServerOptions struct {
 	ProjectStorage         storage.ResourceServer[*resourcemanagerpb.Project]
 	SubjectResolver        subject.Resolver
 	RoleResolver           role.Resolver
-	SubjectExtractor       auth.SubjectExtractor
+	SubjectExtractor       subject.Extractor
 	AuthenticationProvider authentication.Provider
 	DatabaseRoleResolver   role.DatabaseResolver
+	ParentResolver         storage.ParentResolver
 }
 
 // Configures a new IAM Server
@@ -107,6 +108,7 @@ func NewServer(opts ServerOptions) error {
 		SubjectExtractor:       opts.SubjectExtractor,
 		AuthenticationProvider: opts.AuthenticationProvider,
 		DatabaseRoleResolver:   opts.DatabaseRoleResolver,
+		ParentResolver:         opts.ParentResolver,
 	}
 
 	// Register all gRPC services with the gRPC server here.

--- a/internal/grpc/validation/policies.go
+++ b/internal/grpc/validation/policies.go
@@ -74,10 +74,9 @@ func validatePolicySpec(fieldPath *field.Path, spec *iampb.PolicySpec, opts Poli
 					continue
 				}
 
-				subjectName, subjectType, err := subject.Parse(member)
-				if err != nil {
+				if _, _, err := subject.Parse(member); err != nil {
 					errs = append(errs, field.Invalid(membersPath.Index(index), member, "Invalid member provided. Must be in format 'allAuthenticatedUsers', 'user:*', 'serviceAccount:*', or 'group:*'"))
-				} else if _, err := opts.SubjectResolver(opts.Context, subjectType, subjectName); err != nil {
+				} else if _, err := opts.SubjectResolver(opts.Context, member); err != nil {
 					errs = append(errs, field.Invalid(membersPath.Index(index), member, "Member must be an active user, service account, or group."))
 				}
 			}

--- a/internal/providers/openfga/policy_reconciler.go
+++ b/internal/providers/openfga/policy_reconciler.go
@@ -57,16 +57,18 @@ func (r *PolicyReconciler) ReconcilePolicy(ctx context.Context, resource string,
 		)
 
 		for _, member := range binding.GetMembers() {
-			subjectName, subjectKind, err := subject.Parse(member)
+			subjectName, _, err := subject.Parse(member)
 			if err != nil {
 				return err
 			}
 
 			if subjectName != "*" {
-				subjectName, err = r.SubjectResolver(ctx, subjectKind, subjectName)
+				subjectReference, err := r.SubjectResolver(ctx, member)
 				if err != nil {
 					return fmt.Errorf("failed to resolve member '%s': %w", member, err)
 				}
+
+				subjectName = subjectReference.ResourceName
 			}
 
 			tuples = append(tuples, &openfgav1.TupleKey{

--- a/internal/role/resolver.go
+++ b/internal/role/resolver.go
@@ -5,7 +5,7 @@ import (
 
 	"buf.build/gen/go/datum-cloud/iam/grpc/go/datum/iam/v1alpha/iamv1alphagrpc"
 	iampb "buf.build/gen/go/datum-cloud/iam/protocolbuffers/go/datum/iam/v1alpha"
-	"go.datum.net/iam/internal/grpc/auth"
+	"go.datum.net/iam/internal/subject"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -15,7 +15,7 @@ type Resolver func(ctx context.Context, roleName string) error
 
 // IAMUseRoleResolver creates a role resolver that confirms the authorized user
 // in the context has access to use an IAM role.
-func IAMUseRoleResolver(client iamv1alphagrpc.AccessCheckClient, subjectExtractor auth.SubjectExtractor) Resolver {
+func IAMUseRoleResolver(client iamv1alphagrpc.AccessCheckClient, subjectExtractor subject.Extractor) Resolver {
 	return func(ctx context.Context, roleName string) error {
 		// TODO: Replace by having the access check endpoint determine the subject
 		//       from the authenticated user.

--- a/internal/subject/extractor.go
+++ b/internal/subject/extractor.go
@@ -1,0 +1,7 @@
+package subject
+
+import "context"
+
+// Extractor provides an interface for extracting an authenticated subject from
+// a context.
+type Extractor func(context.Context) (string, error)

--- a/internal/subject/noop.go
+++ b/internal/subject/noop.go
@@ -3,7 +3,16 @@ package subject
 import "context"
 
 func NoopResolver() Resolver {
-	return func(_ context.Context, _ Kind, name string) (string, error) {
-		return name, nil
+	return func(_ context.Context, subjectIdentifier string) (*SubjectReference, error) {
+		subjectName, subjectKind, err := Parse(subjectIdentifier)
+		if err != nil {
+			return nil, err
+		}
+
+		return &SubjectReference{
+			ResourceName:      subjectName,
+			Kind:              subjectKind,
+			SubjectIdentifier: subjectIdentifier,
+		}, nil
 	}
 }

--- a/internal/subject/resolver.go
+++ b/internal/subject/resolver.go
@@ -8,7 +8,23 @@ import (
 
 // Resolver can resolve a subject reference to the ID of the subject that can be
 // used when referencing the subject.
-type Resolver func(ctx context.Context, subjectType Kind, subject string) (string, error)
+type Resolver func(ctx context.Context, subjectIdentifier string) (*SubjectReference, error)
+
+// SubjectReference is a reference to a subject that can be used to look up the
+// subject in the resource storage system.
+type SubjectReference struct {
+	// The kind of the subject.
+	Kind Kind
+
+	// The resource name of the subject that can be used to look up the subject in
+	// the resource storage system.
+	ResourceName string
+
+	// The identifier of the subject that can be used to reference the subject
+	// across the system. This will be in the format
+	// `<subjectType>:<subjectIdentifier>` (e.g. `user:john.doe@example.com`).
+	SubjectIdentifier string
+}
 
 type Kind string
 
@@ -20,8 +36,8 @@ const (
 var ErrInvalidSubject = errors.New("invalid subject name format")
 var ErrSubjectNotFound = errors.New("subject not found")
 
-func Parse(subject string) (string, Kind, error) {
-	parts := strings.Split(subject, ":")
+func Parse(subjectIdentifier string) (string, Kind, error) {
+	parts := strings.Split(subjectIdentifier, ":")
 	var subjectType Kind
 
 	switch parts[0] {


### PR DESCRIPTION
This change modifies the subject extractor to resolve the subject name in the format`user:<email>` so it follows the correct subject name format that can be used with the `subject.Parse` function. The `SubjectExtractor` interface was moved to the `subject` package so it's coupled with the other subject related code. A new `SubjectReference` type was returned from the `SubjectResolver` interface so we can include additional metadata around the subject that was resolved.

The AccessCheck endpoint now also resolves the parent resources for the access check request so the context doesn't need to be provided by the client. The AccessCheck endpoint will also now do subject resolution so clients calling AccessCheck don't need to understand how to resolve the subject name.