### PR TITLE
Refactor Role Binding Object Name Generation with SHA-256 Hashing and Revert Zitadel Update

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -87,6 +87,10 @@ tasks:
     desc: Retrieves the OpenFGA model from the server
     cmd: |                                                       #resource identifier, hashed permission, resource type
       fga query list-objects --store-id $(task openfga:store-id) iam.datumapis.com/InternalUser:users/db2fcc5a-b98a-48e5-b5df-b282d910273b 7983b8fa resourcemanager.datumapis.com/Organization
-
-
+      
+  test:
+    desc: Runs the test suite
+    cmd: |
+      go clean -testcache
+      go test ./...
         

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -81,7 +81,7 @@ services:
       - "2112:2112" #prometheus metrics
   
   zitadel:
-    image: 'ghcr.io/zitadel/zitadel:v3.0.4'
+    image: 'ghcr.io/zitadel/zitadel:v2.71.7'
     command: >
       start-from-init
       --config /zitadel/config/defaults.yaml

--- a/internal/providers/openfga/policy_reconciler.go
+++ b/internal/providers/openfga/policy_reconciler.go
@@ -2,7 +2,8 @@ package openfga
 
 import (
 	"context"
-	"encoding/base64"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 
 	iampb "buf.build/gen/go/datum-cloud/iam/protocolbuffers/go/datum/iam/v1alpha"
@@ -178,7 +179,12 @@ func (r *PolicyReconciler) getExistingPolicyTuples(ctx context.Context, resource
 }
 
 func getBindingObjectName(resource, role string) string {
-	roleBindingHash := base64.RawStdEncoding.EncodeToString([]byte(resource + role))
+	hashInput := resource + role
+	// Creating a new hasher instance for each operation is straightforward
+	// and guarantees working with a clean state
+	hasher := sha256.New()
+	hasher.Write([]byte(hashInput))
+	roleBindingHash := hex.EncodeToString(hasher.Sum(nil))
 	return "iam.datumapis.com/RoleBinding:" + roleBindingHash
 }
 


### PR DESCRIPTION
This PR includes two main changes:

1. **Refactor Role Binding Object Name Generation**:
Replaces base64 encoding with SHA-256 hashing to generate role binding identifiers.
- Ensures deterministic and collision-resistant IDs.
- Guarantees the resulting bindingObjectName remains under the 100-character limit required by OpenFGA.

2. **Revert Zitadel Docker Image Update**:
Reverts commit #104, which updated the Zitadel Docker tag to v2.71.10.
- The update introduced breaking changes to the initialization configuration files and the existing database setup.
- This rollback restores system stability until those breaking changes can be properly handled.

>[!NOTE]
>
> Issue #120 has been created in order to evaluate Zitadel update