### PR TITLE
Fix JWT Authentication Failure Due to Improper Bearer Token Extraction

### DIFF
--- a/internal/grpc/auth/jwt/subject_extractor.go
+++ b/internal/grpc/auth/jwt/subject_extractor.go
@@ -102,5 +102,6 @@ func extractBearerToken(ctx context.Context) (string, error) {
 		return "", fmt.Errorf("invalid authorization header format")
 	}
 
-	return parts[1], nil // Return the token part
+	tokenPart := strings.Split(parts[1], "Bearer")[1]
+	return tokenPart, nil // Return the token part
 }


### PR DESCRIPTION
This PR fixes an issue where all authentication attempts were incorrectly returning HTTP 401 Unauthorized, even when a valid token was provided or when the token had insufficient permissions.

The root cause was traced to the extractBearerToken function, which was incorrectly returning the entire Authorization header value (i.e., Bearer <token>) instead of extracting just the token part. This led to a failure during JWT verification.

The following error was consistently logged by the server:

`{"time":"2025-05-20T14:34:08.394476333Z","level":"ERROR","msg":"failed to verify JWT bearer token against authentication provider","error":"failed to parse jws: failed to decode protected headers: failed to decode source: illegal base64 data at input byte 6","authentication_provider":"http://localhost:8082/oauth/v2/keys"}`

The fix ensures that the Bearer prefix is properly removed before passing the token to the JWT verification logic.

Reference: [extractBearerToken function](https://github.com/datum-cloud/milo/blob/872fa829b408d5ed11ad1964ed572156d92da625/internal/grpc/auth/jwt/subject_extractor.go#L85)