### PR TITLE
Publish Kustomize Manifests

### DIFF
--- a/.github/workflows/build-apiserver.yaml
+++ b/.github/workflows/build-apiserver.yaml
@@ -55,7 +55,7 @@ jobs:
       id-token: write
       contents: read
       packages: write
-    uses: datum-cloud/actions/.github/workflows/publish-kustomize-bundle.yaml@output-build-tags
+    uses: datum-cloud/actions/.github/workflows/publish-kustomize-bundle.yaml@v1.4.0
     with:
       bundle-name: ghcr.io/datum-cloud/milo-kustomize
       bundle-path: config

--- a/.github/workflows/build-apiserver.yaml
+++ b/.github/workflows/build-apiserver.yaml
@@ -48,3 +48,15 @@ jobs:
         push: true
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
+
+
+  publish-kustomize-bundles:
+    permissions:
+      id-token: write
+      contents: read
+      packages: write
+    uses: datum-cloud/actions/.github/workflows/publish-kustomize-bundle.yaml@output-build-tags
+    with:
+      bundle-name: ghcr.io/datum-cloud/milo-kustomize
+      bundle-path: config
+    secrets: inherit


### PR DESCRIPTION
Updates the GitHub action to publish the Kustomize manifest as an OCI repository so they can be referenced in a Flux Kustomization.