### PR TITLE
Implement Group controller with finalizers for resource cleanup

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -65,6 +65,15 @@ tasks:
           mkdir -p "config/crd/bases/$package_name"
           "{{.TOOL_DIR}}/controller-gen" crd paths="./$package_dir..." output:dir="./config/crd/bases/$package_name"
         done
+      - echo "Generating RBAC manifests for controller manager..."
+      - |
+        set -e
+        RBAC_OUTPUT_DIR="config/controller-manager"
+        "{{.TOOL_DIR}}/controller-gen" rbac:roleName=milo-controller-manager paths="./..." output:dir="$RBAC_OUTPUT_DIR"
+        # controller-gen outputs "role.yaml" by default; rename for consistency with existing kustomization reference
+        if [ -f "$RBAC_OUTPUT_DIR/role.yaml" ]; then
+          mv -f "$RBAC_OUTPUT_DIR/role.yaml" "$RBAC_OUTPUT_DIR/clusterrole.yaml"
+        fi
     silent: true
 
   api-docs:

--- a/cmd/milo/controller-manager/controllermanager.go
+++ b/cmd/milo/controller-manager/controllermanager.go
@@ -69,6 +69,7 @@ import (
 
 	// Datum webhook and API type imports
 	controlplane "go.miloapis.com/milo/internal/control-plane"
+	iamcontroller "go.miloapis.com/milo/internal/controllers/iam"
 	resourcemanagercontroller "go.miloapis.com/milo/internal/controllers/resourcemanager"
 	infracluster "go.miloapis.com/milo/internal/infra-cluster"
 	resourcemanagerv1alpha1webhook "go.miloapis.com/milo/internal/webhooks/resourcemanager/v1alpha1"
@@ -395,6 +396,14 @@ func Run(ctx context.Context, c *config.CompletedConfig, opts *Options) error {
 			}
 			if err := projectCtrl.SetupWithManager(ctrl, infraCluster); err != nil {
 				logger.Error(err, "Error setting up project controller")
+				klog.FlushAndExit(klog.ExitFlushTimeout, 1)
+			}
+
+			groupCtrl := iamcontroller.GroupController{
+				Client: ctrl.GetClient(),
+			}
+			if err := groupCtrl.SetupWithManager(ctrl); err != nil {
+				logger.Error(err, "Error setting up group controller")
 				klog.FlushAndExit(klog.ExitFlushTimeout, 1)
 			}
 

--- a/config/controller-manager/clusterrole.yaml
+++ b/config/controller-manager/clusterrole.yaml
@@ -1,8 +1,73 @@
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: system:controller:milo-controller-manager
+  name: milo-controller-manager
 rules:
-  - apiGroups: ["infrastructure.miloapis.com"]
-    resources: ["projectcontrolplanes"]
-    verbs: ["*"]
+- apiGroups:
+  - iam.miloapis.com
+  resources:
+  - groupmemberships
+  verbs:
+  - delete
+  - list
+- apiGroups:
+  - iam.miloapis.com
+  resources:
+  - groups
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - iam.miloapis.com
+  resources:
+  - groups/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - iam.miloapis.com
+  resources:
+  - groups/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - iam.miloapis.com
+  resources:
+  - policybindings
+  verbs:
+  - delete
+  - list
+  - update
+- apiGroups:
+  - resourcemanager.miloapis.com
+  resources:
+  - projects
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - resourcemanager.miloapis.com
+  resources:
+  - projects/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - resourcemanager.miloapis.com
+  resources:
+  - projects/status
+  verbs:
+  - get
+  - patch
+  - update

--- a/internal/controllers/iam/group_controller.go
+++ b/internal/controllers/iam/group_controller.go
@@ -213,7 +213,7 @@ func (r *GroupController) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 			log.Error(updateErr, "Failed to update Group after finalizer update")
 			return ctrl.Result{}, updateErr
 		}
-		return ctrl.Result{Requeue: true}, nil
+		return ctrl.Result{}, nil
 	}
 
 	if group.GetDeletionTimestamp() != nil {

--- a/internal/controllers/iam/group_controller.go
+++ b/internal/controllers/iam/group_controller.go
@@ -1,0 +1,257 @@
+package iam
+
+import (
+	"context"
+	"fmt"
+
+	iamv1alpha1 "go.miloapis.com/milo/pkg/apis/iam/v1alpha1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/finalizer"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+const (
+	groupFinalizerKey = "iam.miloapis.com/group"
+)
+
+// GroupReconciler reconciles a Group object
+type GroupController struct {
+	client.Client
+	Finalizers finalizer.Finalizers
+}
+
+// UserGroupFinalizer implements the finalizer.Finalizer interface for GroupMembership cleanup.
+// This is used to remove the group membership tuple from the OpenFGA store when the GroupMembership is deleted.
+type GroupFinalizer struct {
+	K8sClient client.Client
+}
+
+// UpdateResourcesParams holds the parameters for updating/deleting associated resources
+type UpdateResourcesParams struct {
+	Group        *iamv1alpha1.Group
+	List         client.ObjectList
+	MatchField   string
+	ResourceType string
+}
+
+// PolicyBindingUpdate contains a PolicyBinding and its updated subjects
+type PolicyBindingUpdate struct {
+	PolicyBinding *iamv1alpha1.PolicyBinding
+	Subjects      []iamv1alpha1.Subject
+}
+
+// cleanupAssociatedResources is a helper function to update/delete resources associated with a group
+func (f *GroupFinalizer) cleanupAssociatedResources(ctx context.Context, params UpdateResourcesParams) error {
+	log := logf.FromContext(ctx)
+	log.Info("Deleting associated resources associated with group", "groupName", params.Group.Name, "resourceType", params.ResourceType)
+
+	// List all resources in the namespace
+	err := f.K8sClient.List(ctx, params.List, client.InNamespace(params.Group.Namespace))
+	if err != nil {
+		log.Error(err, fmt.Sprintf("Failed to list %s", params.ResourceType), "groupName", params.Group.Name)
+		return err
+	}
+
+	// Get the items as a slice of client.Object, filtering based on resource type
+	var itemsToDelete []client.Object
+	var policiesToUpdate []PolicyBindingUpdate
+
+	switch v := params.List.(type) {
+	case *iamv1alpha1.GroupMembershipList:
+		// Delete all GroupMemberships that reference this group
+		for _, gm := range v.Items {
+			if gm.Spec.GroupRef.Name == params.Group.Name {
+				itemsToDelete = append(itemsToDelete, &gm)
+			}
+		}
+	case *iamv1alpha1.PolicyBindingList:
+		// Update all PolicyBindings that reference this group
+		for _, pb := range v.Items {
+			var updatedSubjects []iamv1alpha1.Subject
+			hasGroupRef := false
+
+			// Keep only subjects that don't reference this group
+			for _, subject := range pb.Spec.Subjects {
+				if subject.Kind == "Group" && subject.Name == params.Group.Name {
+					hasGroupRef = true
+					continue
+				}
+				updatedSubjects = append(updatedSubjects, subject)
+			}
+			// If the policy binding has a group reference
+			if hasGroupRef {
+				if len(updatedSubjects) == 0 {
+					// If there are no subjects left, delete the policy binding
+					itemsToDelete = append(itemsToDelete, &pb)
+				} else {
+					// Otherwise, update the policy binding with the remaining subjects
+					policiesToUpdate = append(policiesToUpdate, PolicyBindingUpdate{
+						PolicyBinding: pb.DeepCopy(),
+						Subjects:      updatedSubjects,
+					})
+				}
+			}
+		}
+	default:
+		return fmt.Errorf("unsupported list type: %T", params.List)
+	}
+
+	// Delete each filtered item
+	for _, item := range itemsToDelete {
+		if err := f.K8sClient.Delete(ctx, item); err != nil {
+			if !errors.IsNotFound(err) {
+				log.Error(err, fmt.Sprintf("Failed to delete %s", params.ResourceType), "name", item.GetName())
+				return err
+			}
+		}
+		log.Info("Deleted associated resource to group", "groupName", params.Group.Name, "resourceType", params.ResourceType, "name", item.GetName())
+	}
+
+	// Update policies with filtered subjects
+	for _, update := range policiesToUpdate {
+		update.PolicyBinding.Spec.Subjects = update.Subjects
+		if err := f.K8sClient.Update(ctx, update.PolicyBinding); err != nil {
+			log.Error(err, "Failed to update PolicyBinding", "name", update.PolicyBinding.GetName())
+			return err
+		}
+		log.Info("Updated PolicyBinding associated with group", "groupName", params.Group.Name, "policyBindingName", update.PolicyBinding.GetName())
+	}
+
+	log.Info("Successfully deleted associated resources", "groupName", params.Group.Name, "resourceType", params.ResourceType)
+	return nil
+}
+
+// deleteGroupMemberships deletes all GroupMembership objects associated with the given group
+func (f *GroupFinalizer) deleteGroupMemberships(ctx context.Context, group *iamv1alpha1.Group) error {
+	return f.cleanupAssociatedResources(ctx, UpdateResourcesParams{
+		Group:        group,
+		List:         &iamv1alpha1.GroupMembershipList{},
+		ResourceType: "GroupMembership",
+	})
+}
+
+// deletePolicyBindings deletes all PolicyBinding objects associated with the given group
+func (f *GroupFinalizer) updatePolicyBindings(ctx context.Context, group *iamv1alpha1.Group) error {
+	return f.cleanupAssociatedResources(ctx, UpdateResourcesParams{
+		Group:        group,
+		List:         &iamv1alpha1.PolicyBindingList{},
+		ResourceType: "PolicyBinding",
+	})
+}
+
+func (f *GroupFinalizer) Finalize(ctx context.Context, obj client.Object) (finalizer.Result, error) {
+	log := logf.FromContext(ctx)
+
+	// Type assertion to check if the object is a Group
+	group, ok := obj.(*iamv1alpha1.Group)
+	if !ok {
+		log.Error(fmt.Errorf("unexpected object type %T, expected Group", obj), "Failed to finalize Group")
+		return finalizer.Result{}, fmt.Errorf("unexpected object type %T, expected Group", obj)
+	}
+	log.Info("Finalizing Group", "groupName", obj.GetName())
+
+	// Update associated PolicyBindings
+	log.Info("Deleting PolicyBindings from Group", "groupName", group.Name)
+	if err := f.updatePolicyBindings(ctx, group); err != nil {
+		return finalizer.Result{}, err
+	}
+
+	// Delete associated GroupMemberships
+	log.Info("Deleting GroupMemberships from Group", "groupName", group.Name)
+	if err := f.deleteGroupMemberships(ctx, group); err != nil {
+		return finalizer.Result{}, err
+	}
+
+	log.Info("Successfully finalized Group (clenaed up PolicyBindings and GroupMemberships)")
+	return finalizer.Result{}, nil
+}
+
+// +kubebuilder:rbac:groups=iam.miloapis.com,resources=groups,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=iam.miloapis.com,resources=groups/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=iam.miloapis.com,resources=groups/finalizers,verbs=update
+
+// Reconcile is part of the main kubernetes reconciliation loop which aims to
+// move the current state of the cluster closer to the desired state.
+// TODO(user): Modify the Reconcile function to compare the state specified by
+// the Group object against the actual cluster state, and then
+// perform operations to make the cluster state reflect the state specified by
+// the user.
+//
+// For more details, check Reconcile and its Result here:
+// - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.21.0/pkg/reconcile
+func (r *GroupController) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	log := logf.FromContext(ctx)
+
+	// Get the Group resource
+	group := &iamv1alpha1.Group{}
+	err := r.Get(ctx, req.NamespacedName, group)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			log.Info("Group resource not found. Ignoring since object must be deleted")
+			return ctrl.Result{}, nil
+		}
+		log.Error(err, "Failed to get Group")
+		return ctrl.Result{}, err
+	}
+
+	log.Info("Reconciling Group", "groupName", group.Name)
+
+	// Run finalizers
+	finalizeResult, err := r.Finalizers.Finalize(ctx, group)
+	if err != nil {
+		log.Error(err, "Failed to run finalizers for Group")
+		return ctrl.Result{}, fmt.Errorf("failed to run finalizers for Group: %w", err)
+	}
+
+	if finalizeResult.Updated {
+		log.Info("finalizer updated the group object, updating API server")
+		if updateErr := r.Update(ctx, group); updateErr != nil {
+			log.Error(updateErr, "Failed to update Group after finalizer update")
+			return ctrl.Result{}, updateErr
+		}
+		return ctrl.Result{Requeue: true}, nil
+	}
+
+	if group.GetDeletionTimestamp() != nil {
+		log.Info("Group is marked for deletion, stopping reconciliation")
+		return ctrl.Result{}, nil
+	}
+
+	// Set the group condition to true
+	groupCondition := metav1.Condition{
+		Type:               "Ready",
+		Status:             metav1.ConditionTrue,
+		Reason:             "Reconciled",
+		Message:            "Group successfully reconciled",
+		LastTransitionTime: metav1.Now(),
+	}
+	meta.SetStatusCondition(&group.Status.Conditions, groupCondition)
+
+	if err := r.Status().Update(ctx, group); err != nil {
+		log.Error(err, "Failed to update Group status")
+		return ctrl.Result{}, err
+	}
+
+	// Return success
+	log.Info("Successfully reconciled Group", "groupName", group.Name)
+	return ctrl.Result{}, nil
+}
+
+// SetupWithManager sets up the controller with the Manager.
+func (r *GroupController) SetupWithManager(mgr ctrl.Manager) error {
+	r.Finalizers = finalizer.NewFinalizers()
+	if err := r.Finalizers.Register(groupFinalizerKey, &GroupFinalizer{
+		K8sClient: r.Client,
+	}); err != nil {
+		return fmt.Errorf("failed to register group finalizer: %w", err)
+	}
+
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&iamv1alpha1.Group{}).
+		Named("group").
+		Complete(r)
+}

--- a/internal/controllers/iam/group_controller.go
+++ b/internal/controllers/iam/group_controller.go
@@ -173,6 +173,8 @@ func (f *groupFinalizer) Finalize(ctx context.Context, obj client.Object) (final
 // +kubebuilder:rbac:groups=iam.miloapis.com,resources=groups,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=iam.miloapis.com,resources=groups/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=iam.miloapis.com,resources=groups/finalizers,verbs=update
+// +kubebuilder:rbac:groups=iam.miloapis.com,resources=groupmemberships,verbs=list;delete
+// +kubebuilder:rbac:groups=iam.miloapis.com,resources=policybindings,verbs=list;update;delete
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.

--- a/internal/controllers/iam/group_controller.go
+++ b/internal/controllers/iam/group_controller.go
@@ -20,7 +20,7 @@ const (
 
 // GroupReconciler reconciles a Group object
 type GroupController struct {
-	client.Client
+	Client     client.Client
 	Finalizers finalizer.Finalizers
 }
 
@@ -188,7 +188,7 @@ func (r *GroupController) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 
 	// Get the Group resource
 	group := &iamv1alpha1.Group{}
-	err := r.Get(ctx, req.NamespacedName, group)
+	err := r.Client.Get(ctx, req.NamespacedName, group)
 	if err != nil {
 		if errors.IsNotFound(err) {
 			log.Info("Group resource not found. Ignoring since object must be deleted")
@@ -209,7 +209,7 @@ func (r *GroupController) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 
 	if finalizeResult.Updated {
 		log.Info("finalizer updated the group object, updating API server")
-		if updateErr := r.Update(ctx, group); updateErr != nil {
+		if updateErr := r.Client.Update(ctx, group); updateErr != nil {
 			log.Error(updateErr, "Failed to update Group after finalizer update")
 			return ctrl.Result{}, updateErr
 		}
@@ -231,7 +231,7 @@ func (r *GroupController) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 	}
 	meta.SetStatusCondition(&group.Status.Conditions, groupCondition)
 
-	if err := r.Status().Update(ctx, group); err != nil {
+	if err := r.Client.Status().Update(ctx, group); err != nil {
 		log.Error(err, "Failed to update Group status")
 		return ctrl.Result{}, err
 	}

--- a/test/group/chainsaw-test.yaml
+++ b/test/group/chainsaw-test.yaml
@@ -1,0 +1,132 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: group
+spec:
+  steps:
+  - name: create-groups-and-policy-binding
+    try:
+    - apply:
+        file: resources/group.yaml
+        outputs:
+          - name: grp
+            value: (@)
+    - wait:
+        apiVersion: iam.miloapis.com/v1alpha1
+        kind: Group
+        name: test-group
+        namespace: ($namespace)
+        timeout: 5m
+        for:
+          condition:
+            name: Ready
+            value: 'true'
+    - assert:
+        file: resources/assert-group.yaml
+    - apply:
+        file: resources/persistant-group.yaml
+        outputs:
+          - name: testPersistantGroup
+            value: (@)
+    - wait:
+        apiVersion: iam.miloapis.com/v1alpha1
+        kind: Group
+        name: test-persistant-group
+        namespace: ($namespace)
+        timeout: 5m
+        for:
+          condition:
+            name: Ready
+            value: 'true'
+    - apply:
+        file: resources/role.yaml
+    - wait:
+        apiVersion: iam.miloapis.com/v1alpha1
+        kind: Role
+        namespace: ($namespace)
+        name: group.miloapis.com-test-group-role
+        timeout: 5m
+        for:
+          condition:
+            name: Ready
+            value: 'true'
+    - apply:
+        file: resources/organization.yaml
+        outputs:
+          - name: testGroupOrg
+            value: (@)
+    - apply:
+        file: resources/policy-binding.yaml
+    - assert:
+        file: resources/assert-policy-binding.yaml
+    - wait:
+        apiVersion: iam.miloapis.com/v1alpha1
+        kind: PolicyBinding
+        name: sample-test-group-binding
+        timeout: 5m
+        for:
+          condition:
+            name: Ready
+            value: 'true'
+  - name: create-memberships
+    try:
+    - apply:
+        file: resources/memberships.yaml
+    - assert:
+        file: resources/memberships.yaml
+  - name: delete-groups
+    try:
+    - delete: # Delete first group
+        file: resources/group.yaml
+    - wait:
+        apiVersion: iam.miloapis.com/v1alpha1
+        kind: Group
+        name: test-group
+        namespace: ($namespace)
+        timeout: 5m
+        for:
+          deletion: {}
+    - wait: # GroupMembership that reference the group should be deleted with the group deletion
+        apiVersion: iam.miloapis.com/v1alpha1
+        kind: GroupMembership
+        name: test-membership-1
+        namespace: ($namespace)
+        timeout: 5m
+        for:
+          deletion: {}
+    - wait: # GroupMembership that reference the group should be deleted with the group deletion
+        apiVersion: iam.miloapis.com/v1alpha1
+        kind: GroupMembership
+        name: test-membership-2
+        namespace: ($namespace)
+        timeout: 5m
+        for:
+          deletion: {}
+    - error: # Assert that the group memberships are deleted
+        file: resources/memberships.yaml
+    - error: # Assert that the group is deleted
+        file: resources/group.yaml
+    - sleep:
+        duration: 5s
+    - assert: # Assert that the policy binding is updated, and reference to previous group is removed
+        file: resources/assert-updated-policy-binding.yaml
+    - delete: # Delete second and last group
+        file: resources/persistant-group.yaml
+    - wait:
+        apiVersion: iam.miloapis.com/v1alpha1
+        kind: Group
+        name: test-persistant-group
+        namespace: ($namespace)
+        timeout: 5m
+        for:
+          deletion: {} 
+    - wait:
+        apiVersion: iam.miloapis.com/v1alpha1
+        kind: PolicyBinding
+        name: sample-test-group-binding
+        namespace: ($namespace)
+        timeout: 5m
+        for:
+          deletion: {} 
+    - error: # Assert that the policy binding is deleted by the Group Controller, as it does not hold any subjects
+        file: resources/policy-binding.yaml

--- a/test/group/resources/assert-group.yaml
+++ b/test/group/resources/assert-group.yaml
@@ -1,0 +1,14 @@
+apiVersion: iam.miloapis.com/v1alpha1
+kind: Group
+metadata:
+  name: test-group
+  namespace: ($namespace)
+status:
+  conditions:
+  - type: Ready 
+    status: "True"
+    reason: Reconciled
+    message: Group successfully reconciled
+    
+    
+   

--- a/test/group/resources/assert-policy-binding.yaml
+++ b/test/group/resources/assert-policy-binding.yaml
@@ -1,0 +1,12 @@
+apiVersion: iam.miloapis.com/v1alpha1
+kind: PolicyBinding
+metadata:
+  name: sample-test-group-binding
+spec:
+  subjects:
+    - kind: Group
+      name: "test-group"
+      namespace: ($namespace)
+    - kind: Group
+      name: "test-persistant-group"
+      namespace: ($namespace)

--- a/test/group/resources/assert-updated-policy-binding.yaml
+++ b/test/group/resources/assert-updated-policy-binding.yaml
@@ -1,0 +1,9 @@
+apiVersion: iam.miloapis.com/v1alpha1
+kind: PolicyBinding
+metadata:
+  name: sample-test-group-binding
+spec:
+  subjects:
+    - kind: Group
+      name: "test-persistant-group"
+      namespace: ($namespace)

--- a/test/group/resources/group.yaml
+++ b/test/group/resources/group.yaml
@@ -1,0 +1,5 @@
+apiVersion: iam.miloapis.com/v1alpha1
+kind: Group
+metadata:
+  name: test-group
+  namespace: ($namespace)

--- a/test/group/resources/memberships.yaml
+++ b/test/group/resources/memberships.yaml
@@ -1,0 +1,23 @@
+apiVersion: iam.miloapis.com/v1alpha1
+kind: GroupMembership
+metadata:
+  name: test-membership-1
+  namespace: ($namespace)
+spec:
+  userRef:
+    name: test-user-1
+  groupRef:
+    name: test-group
+    namespace: ($namespace)
+---
+apiVersion: iam.miloapis.com/v1alpha1
+kind: GroupMembership
+metadata:
+  name: test-membership-2
+  namespace: ($namespace)
+spec:
+  userRef:
+    name: test-user-2
+  groupRef:
+    name: test-group
+    namespace: ($namespace)

--- a/test/group/resources/organization.yaml
+++ b/test/group/resources/organization.yaml
@@ -1,0 +1,6 @@
+apiVersion: resourcemanager.miloapis.com/v1alpha1
+kind: Organization
+metadata:
+  name: test-group-org
+spec:
+  type: Business

--- a/test/group/resources/persistant-group.yaml
+++ b/test/group/resources/persistant-group.yaml
@@ -1,0 +1,5 @@
+apiVersion: iam.miloapis.com/v1alpha1
+kind: Group
+metadata:
+  name: test-persistant-group
+  namespace: ($namespace)

--- a/test/group/resources/policy-binding.yaml
+++ b/test/group/resources/policy-binding.yaml
@@ -1,0 +1,22 @@
+apiVersion: iam.miloapis.com/v1alpha1
+kind: PolicyBinding
+metadata:
+  name: sample-test-group-binding
+spec:
+  roleRef:
+    name: group.miloapis.com-test-group-role
+    namespace: ($namespace)
+  subjects:
+    - kind: Group
+      name: "test-group"
+      uid: ($grp.metadata.uid)
+      namespace: ($namespace)
+    - kind: Group
+      name: "test-persistant-group"
+      uid: ($testPersistantGroup.metadata.uid)
+      namespace: ($namespace)
+  targetRef:
+    apiGroup: "resourcemanager.miloapis.com"
+    kind: Organization
+    name: "test-group-org"
+    uid: ($testGroupOrg.metadata.uid)

--- a/test/group/resources/role.yaml
+++ b/test/group/resources/role.yaml
@@ -1,0 +1,15 @@
+apiVersion: iam.miloapis.com/v1alpha1
+kind: Role
+metadata:
+  name: group.miloapis.com-test-group-role
+  namespace: ($namespace)
+spec:
+  launchStage: Beta
+  includedPermissions:
+    - compute.miloapis.com/workloads.create
+    - compute.miloapis.com/workloads.get
+    - compute.miloapis.com/workloads.update
+    - compute.miloapis.com/workloads.delete
+    - compute.miloapis.com/workloads.list
+    - compute.miloapis.com/workloads.watch
+    - compute.miloapis.com/workloads.patch


### PR DESCRIPTION
# Add Group Controller with Finalizer Logic and Associated Tests

## Description
This PR implements the Group controller with comprehensive finalizer logic to handle group deletion and cleanup of associated resources. The implementation ensures proper cleanup of group memberships and policy bindings when a group is deleted.

### Key Features
- **Group Controller Implementation**
  - Added reconciler logic for Group resources
  - Implemented finalizer to handle group deletion
  - Added status conditions to track reconciliation state

- **Finalizer Logic**
  - Handles cleanup of associated GroupMemberships
  - Manages PolicyBinding updates and deletions:
    - Updates PolicyBindings by removing the deleted group from subjects
    - Deletes PolicyBindings when no subjects remain after group removal

### Test Coverage
Added comprehensive test scenarios using Chainsaw testing framework:

1. **Group Creation and Policy Binding**
   - Tests group creation and readiness
   - Verifies policy binding creation and association
   - Validates role and organization setup

2. **Group Membership Management**
   - Tests creation of group memberships
   - Verifies proper association with groups

3. **Group Deletion and Cleanup**
   - Tests deletion of groups with associated memberships
   - Verifies automatic cleanup of group memberships
   - Validates policy binding updates when group is removed
   - Tests policy binding deletion when no subjects remain

## Additional information

This PR moves code from [Implement Group controller with finalizers for resource cleanup](https://github.com/datum-cloud/auth-provider-openfga/pulls) (`auth-provider-openfga`) to the `milo` repo.

The test suite has not yet been implemented in the milo repo. However, the code was tested locally using the kind cluster provided by the `auth-provider-openfga` repo.

The tests added to the `./test` folder achieve 100% coverage and are intended to be run in this repository once complete end-to-end (e2e) tests are in place.

closes [Implement Group controller with finalizers for resource cleanup](https://github.com/datum-cloud/auth-provider-openfga/pulls) (`auth-provider-openfga`)