### PR TITLE
Fix organization membership sync

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -69,7 +69,7 @@ tasks:
       - "\"{{.TOOL_DIR}}/controller-gen\" webhook paths=\"./internal/webhooks/...\" output:dir=\"./config/webhook\""
       # Generate RBAC rules for the controllers.
       - echo "Generating RBAC rules for the controllers..."
-      - "\"{{.TOOL_DIR}}/controller-gen\" rbac:roleName=milo-controller-manager paths=\"./internal/controllers/...\" output:dir=\"./config/controller-manager\""
+      - "\"{{.TOOL_DIR}}/controller-gen\" rbac:roleName=milo-controller-manager paths=\"./internal/controllers/...\" output:dir=\"./config/controller-manager/overlays/core-control-plane/rbac\""
     silent: true
 
   api-docs:

--- a/config/crd/bases/resourcemanager/resourcemanager.miloapis.com_organizations.yaml
+++ b/config/crd/bases/resourcemanager/resourcemanager.miloapis.com_organizations.yaml
@@ -17,6 +17,12 @@ spec:
   scope: Cluster
   versions:
   - additionalPrinterColumns:
+    - jsonPath: .metadata.annotations.kubernetes\.io\/display-name
+      name: Display Name
+      type: string
+    - jsonPath: .spec.type
+      name: Type
+      type: string
     - jsonPath: .status.conditions[?(@.type=='Ready')].status
       name: Ready
       type: string

--- a/config/crd/bases/resourcemanager/resourcemanager.miloapis.com_organizations.yaml
+++ b/config/crd/bases/resourcemanager/resourcemanager.miloapis.com_organizations.yaml
@@ -60,12 +60,7 @@ spec:
                 description: The type of organization.
                 enum:
                 - Personal
-                - Business
-                - Government
-                - Research
-                - Education
-                - Nonprofit
-                - Other
+                - Standard
                 type: string
                 x-kubernetes-validations:
                 - message: organization type is immutable

--- a/internal/controllers/resourcemanager/organization_membership_controller.go
+++ b/internal/controllers/resourcemanager/organization_membership_controller.go
@@ -180,6 +180,8 @@ func (r *OrganizationMembershipController) SetupWithManager(mgr ctrl.Manager) er
 func (r *OrganizationMembershipController) findOrganizationMembershipsForOrganization(ctx context.Context, obj client.Object) []reconcile.Request {
 	organization := obj.(*resourcemanagerv1alpha.Organization)
 
+	log.FromContext(ctx).Info("finding organization memberships for organization", "organization", organization.Name)
+
 	var organizationMemberships resourcemanagerv1alpha.OrganizationMembershipList
 	if err := r.Client.List(ctx, &organizationMemberships, client.MatchingFields{
 		"spec.organizationRef.name": organization.Name,
@@ -203,6 +205,8 @@ func (r *OrganizationMembershipController) findOrganizationMembershipsForOrganiz
 // findOrganizationMembershipsForUser finds all OrganizationMembership resources that reference a given User
 func (r *OrganizationMembershipController) findOrganizationMembershipsForUser(ctx context.Context, obj client.Object) []reconcile.Request {
 	user := obj.(*iamv1alpha1.User)
+
+	log.FromContext(ctx).Info("finding organization memberships for user", "user", user.Name)
 
 	var organizationMemberships resourcemanagerv1alpha.OrganizationMembershipList
 	if err := r.Client.List(ctx, &organizationMemberships, client.MatchingFields{

--- a/internal/controllers/resourcemanager/organization_membership_controller.go
+++ b/internal/controllers/resourcemanager/organization_membership_controller.go
@@ -166,6 +166,26 @@ func (r *OrganizationMembershipController) Reconcile(ctx context.Context, req ct
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *OrganizationMembershipController) SetupWithManager(mgr ctrl.Manager) error {
+	if err := mgr.GetFieldIndexer().IndexField(context.Background(), &resourcemanagerv1alpha.OrganizationMembership{}, "spec.organizationRef.name", func(rawObj client.Object) []string {
+		obj := rawObj.(*resourcemanagerv1alpha.OrganizationMembership)
+		if obj.Spec.OrganizationRef.Name == "" {
+			return nil
+		}
+		return []string{obj.Spec.OrganizationRef.Name}
+	}); err != nil {
+		return err
+	}
+
+	if err := mgr.GetFieldIndexer().IndexField(context.Background(), &resourcemanagerv1alpha.OrganizationMembership{}, "spec.userRef.name", func(rawObj client.Object) []string {
+		obj := rawObj.(*resourcemanagerv1alpha.OrganizationMembership)
+		if obj.Spec.UserRef.Name == "" {
+			return nil
+		}
+		return []string{obj.Spec.UserRef.Name}
+	}); err != nil {
+		return err
+	}
+
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&resourcemanagerv1alpha.OrganizationMembership{}).
 		Watches(&resourcemanagerv1alpha.Organization{},

--- a/internal/controllers/resourcemanager/organization_membership_controller.go
+++ b/internal/controllers/resourcemanager/organization_membership_controller.go
@@ -186,6 +186,7 @@ func (r *OrganizationMembershipController) findOrganizationMembershipsForOrganiz
 	if err := r.Client.List(ctx, &organizationMemberships, client.MatchingFields{
 		"spec.organizationRef.name": organization.Name,
 	}); err != nil {
+		log.FromContext(ctx).Error(err, "failed to list organization memberships for organization", "organization", organization.Name)
 		return nil
 	}
 
@@ -212,6 +213,7 @@ func (r *OrganizationMembershipController) findOrganizationMembershipsForUser(ct
 	if err := r.Client.List(ctx, &organizationMemberships, client.MatchingFields{
 		"spec.userRef.name": user.Name,
 	}); err != nil {
+		log.FromContext(ctx).Error(err, "failed to list organization memberships for user", "user", user.Name)
 		return nil
 	}
 

--- a/pkg/apis/resourcemanager/v1alpha1/organization_types.go
+++ b/pkg/apis/resourcemanager/v1alpha1/organization_types.go
@@ -37,6 +37,8 @@ type OrganizationStatus struct {
 // +kubebuilder:subresource:status
 // Use lowercase for path, which influences plural name. Ensure kind is Organization.
 // +kubebuilder:resource:path=organizations,scope=Cluster,categories=datum,singular=organization
+// +kubebuilder:printcolumn:name="Display Name",type="string",JSONPath=".metadata.annotations.kubernetes\\.io\\/display-name"
+// +kubebuilder:printcolumn:name="Type",type="string",JSONPath=".spec.type"
 // +kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.conditions[?(@.type=='Ready')].status"
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=".metadata.creationTimestamp"
 // Organization is the Schema for the Organizations API

--- a/pkg/apis/resourcemanager/v1alpha1/organization_types.go
+++ b/pkg/apis/resourcemanager/v1alpha1/organization_types.go
@@ -10,7 +10,7 @@ import (
 type OrganizationSpec struct {
 	// The type of organization.
 	// +kubebuilder:validation:Required
-	// +kubebuilder:validation:Enum=Personal;Business;Government;Research;Education;Nonprofit;Other
+	// +kubebuilder:validation:Enum=Personal;Standard
 	// +kubebuilder:validation:XValidation:rule="type(oldSelf) == null_type || self == oldSelf",message="organization type is immutable"
 	Type string `json:"type"`
 }


### PR DESCRIPTION
This resolves an issue where the OrganizationMembership resource wasn't being updated when an Organization or User was updated. This was caused by the field indexers not being registered for the field selectors used in the watch handlers for the Organization and User resources. 

### Other Changes

- Fixed issue with RBAC configuration being created in the wrong spot after it was moved in #184
- Adds more printer columns to the Organization type