### PR TITLE
bugfix: use correct subject name in project webhook

### DIFF
--- a/internal/webhooks/resourcemanager/v1alpha1/project_webhook.go
+++ b/internal/webhooks/resourcemanager/v1alpha1/project_webhook.go
@@ -247,7 +247,7 @@ func (v *ProjectValidator) createOwnerPolicyBinding(ctx context.Context, project
 			Subjects: []iamv1alpha1.Subject{
 				{
 					Kind: "User",
-					Name: req.UserInfo.Username,
+					Name: foundUser.Name,
 					UID:  string(foundUser.GetUID()),
 				},
 			},


### PR DESCRIPTION
The subject name was being set to the username of the user which is not the correct name. The correct name to use is the metadata name of the user resource.