### PR TITLE
fix: Addressed race condition in user extra info handling as a result of caching present in the authorization layer.

### DIFF
--- a/pkg/server/filters/organizationmembership.go
+++ b/pkg/server/filters/organizationmembership.go
@@ -122,17 +122,13 @@ func UserContextAuthorizationDecorator(handler http.Handler) http.Handler {
 			return
 		}
 
-		if u.Extra == nil {
-			u.Extra = map[string][]string{}
+		extra := map[string][]string{
+			iamv1alpha1.ParentAPIGroupExtraKey: {iamv1alpha1.SchemeGroupVersion.Group},
+			iamv1alpha1.ParentKindExtraKey:     {"User"},
+			iamv1alpha1.ParentNameExtraKey:     {userID},
 		}
 
-		// Set the user information for the authorization check based on the user
-		// ID that was provided in the request context.
-		u.Extra[iamv1alpha1.ParentAPIGroupExtraKey] = []string{iamv1alpha1.SchemeGroupVersion.Group}
-		u.Extra[iamv1alpha1.ParentKindExtraKey] = []string{"User"}
-		u.Extra[iamv1alpha1.ParentNameExtraKey] = []string{userID}
-
-		req = req.WithContext(request.WithUser(ctx, u))
+		req = req.WithContext(request.WithUser(ctx, userWithExtra(u, extra)))
 
 		handler.ServeHTTP(w, req)
 	})

--- a/pkg/server/filters/utils.go
+++ b/pkg/server/filters/utils.go
@@ -1,0 +1,21 @@
+package filters
+
+import (
+	"maps"
+
+	"k8s.io/apiserver/pkg/authentication/user"
+)
+
+// Returns a copy of the given user.DefaultInfo with Extra data safely added
+//
+// User structs are cached in the auth layer and can be accessed concurrently
+// accross requests, so we need to perform a shallow copy and add extra info
+// into the new struct.
+func userWithExtra(u *user.DefaultInfo, extra map[string][]string) *user.DefaultInfo {
+	uCopy := *u
+	uCopy.Extra = make(map[string][]string, len(u.Extra)+len(extra))
+	maps.Copy(uCopy.Extra, u.Extra)
+	maps.Copy(uCopy.Extra, extra)
+
+	return &uCopy
+}

--- a/pkg/server/filters/utils_test.go
+++ b/pkg/server/filters/utils_test.go
@@ -1,0 +1,79 @@
+package filters
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apiserver/pkg/authentication/user"
+)
+
+func TestUserWithExtra(t *testing.T) {
+	tests := []struct {
+		name         string
+		user         *user.DefaultInfo
+		extra        map[string][]string
+		expectedUser *user.DefaultInfo
+	}{
+		{
+			name: "nil extra in source user",
+			user: &user.DefaultInfo{
+				Name:  "test",
+				Extra: nil,
+			},
+			extra: map[string][]string{
+				"test": {"value"},
+			},
+			expectedUser: &user.DefaultInfo{
+				Name: "test",
+				Extra: map[string][]string{
+					"test": {"value"},
+				},
+			},
+		},
+		{
+			name: "existing extra in source user",
+			user: &user.DefaultInfo{
+				Name: "test",
+				Extra: map[string][]string{
+					"existing": {"value"},
+				},
+			},
+			extra: map[string][]string{
+				"test": {"value"},
+			},
+			expectedUser: &user.DefaultInfo{
+				Name: "test",
+				Extra: map[string][]string{
+					"existing": {"value"},
+					"test":     {"value"},
+				},
+			},
+		},
+		{
+			name: "existing extra in source user with key overwrite",
+			user: &user.DefaultInfo{
+				Name: "test",
+				Extra: map[string][]string{
+					"existing": {"value"},
+				},
+			},
+			extra: map[string][]string{
+				"existing": {"new"},
+			},
+			expectedUser: &user.DefaultInfo{
+				Name: "test",
+				Extra: map[string][]string{
+					"existing": {"new"},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			u := userWithExtra(tt.user, tt.extra)
+			assert.NotSame(t, tt.user, u)
+			assert.Equal(t, tt.expectedUser, u)
+		})
+	}
+}


### PR DESCRIPTION
The authorization layer caches user information and uses the cached struct across requests, so manipulating the Extra field could result in a concurrent map write panic.

Also addressed a bug that was introduced in https://github.com/datum-cloud/milo/pull/17 which resulted in a failing test that didn't block the PR merge.