### PR TITLE
bugfix: align tagging conventions

### DIFF
--- a/.github/workflows/build-apiserver.yaml
+++ b/.github/workflows/build-apiserver.yaml
@@ -6,56 +6,23 @@ on:
     types: ["published"]
 
 jobs:
-  build-and-push:
+  publish-container-image:
     permissions:
+      id-token: write
       contents: read
       packages: write
       attestations: write
-      id-token: write
-
-    runs-on: ubuntu-latest
-
-    steps:
-    - name: Checkout repository
-      uses: actions/checkout@v4
-
-    - name: Log in to GitHub Container Registry
-      uses: docker/login-action@v3.4.0
-      with:
-        registry: ghcr.io
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
-
-    - name: Extract metadata
-      id: meta
-      uses: docker/metadata-action@v5
-      with:
-        images: ghcr.io/datum-cloud/milo
-        tags: |
-          type=schedule
-          type=ref,event=branch
-          type=ref,event=pr
-          type=ref,event=branch,suffix=-{{commit_date 'YYYYMMDD-HHmmss'}}
-          type=semver,pattern={{version}}
-          type=semver,pattern={{major}}.{{minor}}
-          type=semver,pattern={{major}}
-          type=sha
-
-    - name: Build Milo
-      id: push
-      uses: docker/build-push-action@v6.18.0
-      with:
-        push: true
-        tags: ${{ steps.meta.outputs.tags }}
-        labels: ${{ steps.meta.outputs.labels }}
-
+    uses: datum-cloud/actions/.github/workflows/publish-docker.yaml@v1.5.2
+    with:
+      image-name: telemetry-services-operator
+    secrets: inherit
 
   publish-kustomize-bundles:
     permissions:
       id-token: write
       contents: read
       packages: write
-    uses: datum-cloud/actions/.github/workflows/publish-kustomize-bundle.yaml@v1.5.1
+    uses: datum-cloud/actions/.github/workflows/publish-kustomize-bundle.yaml@v1.5.2
     with:
       bundle-name: ghcr.io/datum-cloud/milo-kustomize
       bundle-path: config


### PR DESCRIPTION
Uses the shared GitHub action to align tagging conventions between the kustomization manifests and the container image. The existing workflow was publishing the container image without a `v` prefix on the version number.