### PR TITLE
fix: Update authentication configuration in apiserver deployment to use webhook token file

### DIFF
--- a/config/apiserver/deployment.yaml
+++ b/config/apiserver/deployment.yaml
@@ -26,7 +26,7 @@ spec:
         args:
           - apiserver
           - --authorization-mode=$(AUTHORIZATION_MODE)
-          - --authentication-config=$(AUTHENTICATION_CONFIG)
+          - --authentication-token-webhook-config-file=$(AUTHENTICATION_WEBHOOK_CONFIG_FILE)
           - --authentication-token-webhook-version=$(AUTHENTICATION_TOKEN_WEBHOOK_VERSION)
           - --authorization-webhook-config-file=$(AUTHORIZATION_WEBHOOK_CONFIG_FILE)
           - --authorization-webhook-version=$(AUTHORIZATION_WEBHOOK_VERSION)
@@ -49,7 +49,7 @@ spec:
             value: "4"
           - name: AUTHORIZATION_MODE
             value: "RBAC,Webhook"
-          - name: AUTHENTICATION_CONFIG
+          - name: AUTHENTICATION_WEBHOOK_CONFIG_FILE
             value: "/etc/kubernetes/config/authentication-config.yaml"
           - name: AUTHENTICATION_TOKEN_WEBHOOK_VERSION
             value: "v1"


### PR DESCRIPTION
Update authentication configuration to leverage the use of the `Webhook Token Authentication`

https://kubernetes.io/docs/reference/access-authn-authz/authentication/#webhook-token-authentication