### PR TITLE
feat: shared union cacher

### DIFF
--- a/internal/apiserver/storage/project/decorator.go
+++ b/internal/apiserver/storage/project/decorator.go
@@ -11,7 +11,9 @@ import (
 	"k8s.io/client-go/tools/cache"
 )
 
-// ProjectAwareDecorator builds (and reuses) a child cacher per project prefix.
+// ProjectAwareDecorator builds one root child (default prefix) and lazily a single
+// shared “union” child under /projects. Project-scoped requests reuse the union
+// child’s watch cache by scoping keys to /projects/<project>/..., avoiding per-project cachers.
 func ProjectAwareDecorator(inner generic.StorageDecorator) generic.StorageDecorator {
 	return func(
 		cfg *storagebackend.ConfigForResource,

--- a/internal/apiserver/storage/project/mux.go
+++ b/internal/apiserver/storage/project/mux.go
@@ -1,211 +1,246 @@
 package projectstorage
 
 import (
-	"context"
-	"path"
-	"sync"
+    "context"
+    "path"
+    "strings"
+    "sync"
 
-	"go.miloapis.com/milo/pkg/request"
+    "go.miloapis.com/milo/pkg/request"
 
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/watch"
+    "k8s.io/apimachinery/pkg/runtime"
+    "k8s.io/apimachinery/pkg/watch"
 
-	generic "k8s.io/apiserver/pkg/registry/generic"
-	"k8s.io/apiserver/pkg/storage"
-	storagebackend "k8s.io/apiserver/pkg/storage/storagebackend"
-	factory "k8s.io/apiserver/pkg/storage/storagebackend/factory"
+    generic "k8s.io/apiserver/pkg/registry/generic"
+    "k8s.io/apiserver/pkg/storage"
+    storagebackend "k8s.io/apiserver/pkg/storage/storagebackend"
+    factory "k8s.io/apiserver/pkg/storage/storagebackend/factory"
 
-	"k8s.io/client-go/tools/cache"
+    "k8s.io/client-go/tools/cache"
 )
 
 type child struct {
-	s       storage.Interface
-	destroy factory.DestroyFunc
+    s       storage.Interface
+    destroy factory.DestroyFunc
 }
 
 type decoratorArgs struct {
-	resourcePrefix string
-	keyFunc        func(obj runtime.Object) (string, error)
-	newFunc        func() runtime.Object
-	newListFunc    func() runtime.Object
-	getAttrs       storage.AttrFunc
-	triggerFn      storage.IndexerFuncs
-	indexers       *cache.Indexers
+    resourcePrefix string
+    keyFunc        func(obj runtime.Object) (string, error)
+    newFunc        func() runtime.Object
+    newListFunc    func() runtime.Object
+    getAttrs       storage.AttrFunc
+    triggerFn      storage.IndexerFuncs
+    indexers       *cache.Indexers
 }
 
-// projectMux implements storage.Interface and routes to a per-project child.
+// projectMux implements storage.Interface and routes to root vs project-scoped storage.
 type projectMux struct {
-	mu        sync.RWMutex
-	children  map[string]*child
-	versioner storage.Versioner
+    mu        sync.RWMutex
+    children  map[string]*child // "" => root, "*" => union(/projects)
+    versioner storage.Versioner
 
-	inner generic.StorageDecorator
-	cfg   storagebackend.ConfigForResource
-	args  decoratorArgs
+    inner generic.StorageDecorator
+    cfg   storagebackend.ConfigForResource
+    args  decoratorArgs
 }
 
 func (m *projectMux) Versioner() storage.Versioner { return m.versioner }
 
-func (m *projectMux) childForProject(project string) (storage.Interface, error) {
-	m.mu.RLock()
-	if c, ok := m.children[project]; ok {
-		m.mu.RUnlock()
-		return c.s, nil
-	}
-	m.mu.RUnlock()
+// rootChild returns/creates the default (non-project) storage.
+func (m *projectMux) rootChild() (storage.Interface, error) {
+    m.mu.RLock()
+    if c := m.children[""]; c != nil {
+        m.mu.RUnlock()
+        return c.s, nil
+    }
+    m.mu.RUnlock()
 
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	if c, ok := m.children[project]; ok {
-		return c.s, nil
-	}
+    // Should already exist (built in decorator), but build defensively if missing.
+    m.mu.Lock()
+    defer m.mu.Unlock()
+    if c := m.children[""]; c != nil {
+        return c.s, nil
+    }
+    s, destroy, err := m.inner(
+        &m.cfg, m.args.resourcePrefix, m.args.keyFunc, m.args.newFunc, m.args.newListFunc,
+        m.args.getAttrs, m.args.triggerFn, m.args.indexers,
+    )
+    if err != nil {
+        return nil, err
+    }
+    if m.versioner == nil {
+        m.versioner = s.Versioner()
+    }
+    if m.children == nil {
+        m.children = make(map[string]*child, 2)
+    }
+    m.children[""] = &child{s: s, destroy: destroy}
+    return s, nil
+}
 
-	cfg2 := m.cfg // copy
-	cfg2.Config.Prefix = "/" + path.Join("projects", project)
+// unionChild returns/creates the shared storage rooted at /projects.
+func (m *projectMux) unionChild() (storage.Interface, error) {
+    m.mu.RLock()
+    if c := m.children["*"]; c != nil {
+        m.mu.RUnlock()
+        return c.s, nil
+    }
+    m.mu.RUnlock()
 
-	s, destroy, err := m.inner(
-		&cfg2,
-		m.args.resourcePrefix,
-		m.args.keyFunc,
-		m.args.newFunc,
-		m.args.newListFunc,
-		m.args.getAttrs,
-		m.args.triggerFn,
-		m.args.indexers,
-	)
-	if err != nil {
-		return nil, err
-	}
-	if m.versioner == nil {
-		m.versioner = s.Versioner()
-	}
-	if m.children == nil {
-		m.children = make(map[string]*child, 1)
-	}
-	m.children[project] = &child{s: s, destroy: destroy}
-	return s, nil
+    m.mu.Lock()
+    defer m.mu.Unlock()
+    if c := m.children["*"]; c != nil {
+        return c.s, nil
+    }
+
+    cfg2 := m.cfg // copy
+    cfg2.Config.Prefix = "/projects"
+
+    s, destroy, err := m.inner(
+        &cfg2,
+        m.args.resourcePrefix,
+        m.args.keyFunc,
+        m.args.newFunc,
+        m.args.newListFunc,
+        m.args.getAttrs,
+        m.args.triggerFn,
+        m.args.indexers,
+    )
+    if err != nil {
+        return nil, err
+    }
+    if m.versioner == nil {
+        m.versioner = s.Versioner()
+    }
+    if m.children == nil {
+        m.children = make(map[string]*child, 2)
+    }
+    m.children["*"] = &child{s: s, destroy: destroy}
+    return s, nil
 }
 
 func (m *projectMux) destroyAll() {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	for k, c := range m.children {
-		if c.destroy != nil {
-			c.destroy()
-		}
-		delete(m.children, k)
-	}
+    m.mu.Lock()
+    defer m.mu.Unlock()
+    for k, c := range m.children {
+        if c.destroy != nil {
+            c.destroy()
+        }
+        delete(m.children, k)
+    }
 }
 
-func (m *projectMux) pick(ctx context.Context) (storage.Interface, error) {
-	if proj, ok := request.ProjectID(ctx); ok && proj != "" {
-		return m.childForProject(proj)
-	}
-	return m.childForProject("")
+// pickWithProject returns the storage to use and the project ("" for root requests).
+func (m *projectMux) pickWithProject(ctx context.Context) (storage.Interface, string, error) {
+    if proj, ok := request.ProjectID(ctx); ok && proj != "" {
+        s, err := m.unionChild()
+        return s, proj, err
+    }
+    s, err := m.rootChild()
+    return s, "", err
+}
+
+// addProjectToKey inserts "<project>/" in front of the caller-provided key (which is
+// relative to the storage prefix), producing keys under "/projects/<project>/...".
+func addProjectToKey(project, key string) string {
+    if project == "" {
+        return key
+    }
+    // path.Join drops the left side if the right starts with '/', so trim it.
+    trimmed := strings.TrimPrefix(key, "/")
+    return path.Join(project, trimmed)
 }
 
 // ---------- storage.Interface forwarding ----------
 
 func (m *projectMux) Create(ctx context.Context, key string, obj, out runtime.Object, ttl uint64) error {
-	s, err := m.pick(ctx)
-	if err != nil {
-		return err
-	}
-	return s.Create(ctx, key, obj, out, ttl)
+    s, proj, err := m.pickWithProject(ctx)
+    if err != nil {
+        return err
+    }
+    return s.Create(ctx, addProjectToKey(proj, key), obj, out, ttl)
 }
 
 func (m *projectMux) Delete(
-	ctx context.Context,
-	key string,
-	out runtime.Object,
-	precond *storage.Preconditions,
-	validateDeletion storage.ValidateObjectFunc,
-	cachedExistingObject runtime.Object,
-	opts storage.DeleteOptions,
+    ctx context.Context,
+    key string,
+    out runtime.Object,
+    precond *storage.Preconditions,
+    validateDeletion storage.ValidateObjectFunc,
+    cachedExistingObject runtime.Object,
+    opts storage.DeleteOptions,
 ) error {
-	s, err := m.pick(ctx)
-	if err != nil {
-		return err
-	}
-	return s.Delete(ctx, key, out, precond, validateDeletion, cachedExistingObject, opts)
+    s, proj, err := m.pickWithProject(ctx)
+    if err != nil {
+        return err
+    }
+    return s.Delete(ctx, addProjectToKey(proj, key), out, precond, validateDeletion, cachedExistingObject, opts)
 }
 
 func (m *projectMux) Watch(ctx context.Context, key string, opts storage.ListOptions) (watch.Interface, error) {
-	s, err := m.pick(ctx)
-	if err != nil {
-		return nil, err
-	}
-	return s.Watch(ctx, key, opts)
+    s, proj, err := m.pickWithProject(ctx)
+    if err != nil {
+        return nil, err
+    }
+    return s.Watch(ctx, addProjectToKey(proj, key), opts)
 }
 
 func (m *projectMux) Get(ctx context.Context, key string, opts storage.GetOptions, objPtr runtime.Object) error {
-	s, err := m.pick(ctx)
-	if err != nil {
-		return err
-	}
-	return s.Get(ctx, key, opts, objPtr)
+    s, proj, err := m.pickWithProject(ctx)
+    if err != nil {
+        return err
+    }
+    return s.Get(ctx, addProjectToKey(proj, key), opts, objPtr)
 }
 
 func (m *projectMux) GetList(ctx context.Context, key string, opts storage.ListOptions, listObj runtime.Object) error {
-	s, err := m.pick(ctx)
-	if err != nil {
-		return err
-	}
-	return s.GetList(ctx, key, opts, listObj)
+    s, proj, err := m.pickWithProject(ctx)
+    if err != nil {
+        return err
+    }
+    return s.GetList(ctx, addProjectToKey(proj, key), opts, listObj)
 }
 
 func (m *projectMux) GuaranteedUpdate(
-	ctx context.Context,
-	key string,
-	out runtime.Object,
-	ignoreNotFound bool,
-	precond *storage.Preconditions,
-	tryUpdate storage.UpdateFunc,
-	suggestion runtime.Object,
+    ctx context.Context,
+    key string,
+    out runtime.Object,
+    ignoreNotFound bool,
+    precond *storage.Preconditions,
+    tryUpdate storage.UpdateFunc,
+    suggestion runtime.Object,
 ) error {
-	s, err := m.pick(ctx)
-	if err != nil {
-		return err
-	}
-	return s.GuaranteedUpdate(ctx, key, out, ignoreNotFound, precond, tryUpdate, suggestion)
+    s, proj, err := m.pickWithProject(ctx)
+    if err != nil {
+        return err
+    }
+    return s.GuaranteedUpdate(ctx, addProjectToKey(proj, key), out, ignoreNotFound, precond, tryUpdate, suggestion)
 }
 
 // If your k8s minor *doesn't* include Count in storage.Interface, delete this.
 func (m *projectMux) Count(key string) (int64, error) {
-	m.mu.RLock()
-	c := m.children[""]
-	m.mu.RUnlock()
-	if c == nil {
-		if _, err := m.childForProject(""); err != nil {
-			return 0, err
-		}
-		m.mu.RLock()
-		c = m.children[""]
-		m.mu.RUnlock()
-	}
-	return c.s.Count(key)
+    // Count is a root-space operation in your setup; use the root child.
+    s, err := m.rootChild()
+    if err != nil {
+        return 0, err
+    }
+    return s.Count(key)
 }
 
-// ReadinessCheck proxies to the appropriate child (defaults to the "" project).
+// ReadinessCheck proxies to the root child (defaults to the "" project / global).
 func (m *projectMux) ReadinessCheck() error {
-	m.mu.RLock()
-	c := m.children[""]
-	m.mu.RUnlock()
-	if c == nil {
-		if _, err := m.childForProject(""); err != nil {
-			return err
-		}
-		m.mu.RLock()
-		c = m.children[""]
-		m.mu.RUnlock()
-	}
-	return c.s.ReadinessCheck()
+    s, err := m.rootChild()
+    if err != nil {
+        return err
+    }
+    return s.ReadinessCheck()
 }
 
 func (m *projectMux) RequestWatchProgress(ctx context.Context) error {
-	s, err := m.pick(ctx)
-	if err != nil {
-		return err
-	}
-	return s.RequestWatchProgress(ctx)
+    s, _, err := m.pickWithProject(ctx)
+    if err != nil {
+        return err
+    }
+    return s.RequestWatchProgress(ctx)
 }

--- a/internal/apiserver/storage/project/mux_test.go
+++ b/internal/apiserver/storage/project/mux_test.go
@@ -18,7 +18,7 @@ import (
 type recorder struct {
 	rootCreates, unionCreates       int
 	rootDestroyed, unionDestroyed   bool
-	calls                           []string // e.g. "root:Get alpha/pods/x"
+	calls                           []string // e.g. "root:Get alpha/secrets/x"
 }
 
 func (r *recorder) record(where, what, key string) {
@@ -88,13 +88,13 @@ func TestRootRoutesToRootChild(t *testing.T) {
 	rec := &recorder{}
 	m := newMuxForTest(rec)
 
-	if err := m.Get(context.Background(), "pods/x", storage.GetOptions{}, nil); err != nil {
+	if err := m.Get(context.Background(), "secrets/x", storage.GetOptions{}, nil); err != nil {
 		t.Fatal(err)
 	}
 	if rec.rootCreates != 1 || rec.unionCreates != 0 {
 		t.Fatalf("expected root=1, union=0 creates; got %d, %d", rec.rootCreates, rec.unionCreates)
 	}
-	if want, got := "root:Get pods/x", rec.calls[0]; got != want {
+	if want, got := "root:Get secrets/x", rec.calls[0]; got != want {
 		t.Fatalf("want %q got %q", want, got)
 	}
 }
@@ -104,21 +104,21 @@ func TestProjectRoutesToUnionAndRewritesKey(t *testing.T) {
 	m := newMuxForTest(rec)
 	ctx := request.WithProject(context.Background(), "alpha")
 
-	if err := m.Get(ctx, "pods/x", storage.GetOptions{}, nil); err != nil {
+	if err := m.Get(ctx, "secrets/x", storage.GetOptions{}, nil); err != nil {
 		t.Fatal(err)
 	}
 	if rec.unionCreates != 1 {
 		t.Fatalf("expected one union create, got %d", rec.unionCreates)
 	}
-	if want, got := "union:Get alpha/pods/x", rec.calls[0]; got != want {
+	if want, got := "union:Get alpha/secrets/x", rec.calls[0]; got != want {
 		t.Fatalf("want %q got %q", want, got)
 	}
 
 	// Leading slash is trimmed
-	if err := m.Get(ctx, "/pods/y", storage.GetOptions{}, nil); err != nil {
+	if err := m.Get(ctx, "/secrets/y", storage.GetOptions{}, nil); err != nil {
 		t.Fatal(err)
 	}
-	if want, got := "union:Get alpha/pods/y", rec.calls[1]; got != want {
+	if want, got := "union:Get alpha/secrets/y", rec.calls[1]; got != want {
 		t.Fatalf("want %q got %q", want, got)
 	}
 }

--- a/internal/apiserver/storage/project/mux_test.go
+++ b/internal/apiserver/storage/project/mux_test.go
@@ -1,0 +1,185 @@
+package projectstorage
+
+import (
+	"context"
+	"testing"
+
+	"go.miloapis.com/milo/pkg/request"
+
+	"k8s.io/apiserver/pkg/storage"
+	storagebackend "k8s.io/apiserver/pkg/storage/storagebackend"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
+	generic "k8s.io/apiserver/pkg/registry/generic"
+	factory "k8s.io/apiserver/pkg/storage/storagebackend/factory"
+	"k8s.io/client-go/tools/cache"
+)
+
+type recorder struct {
+	rootCreates, unionCreates       int
+	rootDestroyed, unionDestroyed   bool
+	calls                           []string // e.g. "root:Get alpha/pods/x"
+}
+
+func (r *recorder) record(where, what, key string) {
+	r.calls = append(r.calls, where+":"+what+" "+key)
+}
+
+type fakeStorage struct {
+	where string // "root" or "union"
+	rec   *recorder
+}
+
+func (f *fakeStorage) Versioner() storage.Versioner { return nil }
+func (f *fakeStorage) Create(ctx context.Context, key string, obj, out runtime.Object, ttl uint64) error {
+	f.rec.record(f.where, "Create", key); return nil
+}
+func (f *fakeStorage) Delete(ctx context.Context, key string, out runtime.Object, precond *storage.Preconditions,
+	validateDeletion storage.ValidateObjectFunc, cachedExistingObject runtime.Object, opts storage.DeleteOptions) error {
+	f.rec.record(f.where, "Delete", key); return nil
+}
+func (f *fakeStorage) Watch(ctx context.Context, key string, opts storage.ListOptions) (watch.Interface, error) {
+	f.rec.record(f.where, "Watch", key); return watch.NewFake(), nil
+}
+func (f *fakeStorage) Get(ctx context.Context, key string, opts storage.GetOptions, objPtr runtime.Object) error {
+	f.rec.record(f.where, "Get", key); return nil
+}
+func (f *fakeStorage) GetList(ctx context.Context, key string, opts storage.ListOptions, listObj runtime.Object) error {
+	f.rec.record(f.where, "GetList", key); return nil
+}
+func (f *fakeStorage) GuaranteedUpdate(ctx context.Context, key string, out runtime.Object, ignoreNotFound bool,
+	precond *storage.Preconditions, tryUpdate storage.UpdateFunc, suggestion runtime.Object) error {
+	f.rec.record(f.where, "GuaranteedUpdate", key); return nil
+}
+func (f *fakeStorage) Count(key string) (int64, error) { f.rec.record(f.where, "Count", key); return 0, nil }
+func (f *fakeStorage) ReadinessCheck() error           { f.rec.record(f.where, "ReadinessCheck", ""); return nil }
+func (f *fakeStorage) RequestWatchProgress(ctx context.Context) error {
+	f.rec.record(f.where, "RequestWatchProgress", ""); return nil
+}
+
+func fakeDecorator(rec *recorder) generic.StorageDecorator {
+	return func(cfg *storagebackend.ConfigForResource, resourcePrefix string,
+		keyFunc func(obj runtime.Object) (string, error), newFunc func() runtime.Object,
+		newListFunc func() runtime.Object, getAttrs storage.AttrFunc,
+		triggerFn storage.IndexerFuncs, indexers *cache.Indexers,
+	) (storage.Interface, factory.DestroyFunc, error) {
+
+		if cfg.Config.Prefix == "/projects" {
+			rec.unionCreates++
+			fs := &fakeStorage{where: "union", rec: rec}
+			return fs, func() { rec.unionDestroyed = true }, nil
+		}
+		rec.rootCreates++
+		fs := &fakeStorage{where: "root", rec: rec}
+		return fs, func() { rec.rootDestroyed = true }, nil
+	}
+}
+
+func newMuxForTest(rec *recorder) *projectMux {
+	return &projectMux{
+		children: map[string]*child{}, // start empty; lazy-create
+		inner:    fakeDecorator(rec),
+		cfg:      storagebackend.ConfigForResource{Config: storagebackend.Config{Prefix: "/root"}},
+		args:     decoratorArgs{},
+	}
+}
+
+func TestRootRoutesToRootChild(t *testing.T) {
+	rec := &recorder{}
+	m := newMuxForTest(rec)
+
+	if err := m.Get(context.Background(), "pods/x", storage.GetOptions{}, nil); err != nil {
+		t.Fatal(err)
+	}
+	if rec.rootCreates != 1 || rec.unionCreates != 0 {
+		t.Fatalf("expected root=1, union=0 creates; got %d, %d", rec.rootCreates, rec.unionCreates)
+	}
+	if want, got := "root:Get pods/x", rec.calls[0]; got != want {
+		t.Fatalf("want %q got %q", want, got)
+	}
+}
+
+func TestProjectRoutesToUnionAndRewritesKey(t *testing.T) {
+	rec := &recorder{}
+	m := newMuxForTest(rec)
+	ctx := request.WithProject(context.Background(), "alpha")
+
+	if err := m.Get(ctx, "pods/x", storage.GetOptions{}, nil); err != nil {
+		t.Fatal(err)
+	}
+	if rec.unionCreates != 1 {
+		t.Fatalf("expected one union create, got %d", rec.unionCreates)
+	}
+	if want, got := "union:Get alpha/pods/x", rec.calls[0]; got != want {
+		t.Fatalf("want %q got %q", want, got)
+	}
+
+	// Leading slash is trimmed
+	if err := m.Get(ctx, "/pods/y", storage.GetOptions{}, nil); err != nil {
+		t.Fatal(err)
+	}
+	if want, got := "union:Get alpha/pods/y", rec.calls[1]; got != want {
+		t.Fatalf("want %q got %q", want, got)
+	}
+}
+
+func TestUnionChildCreatedOnceAcrossProjects(t *testing.T) {
+	rec := &recorder{}
+	m := newMuxForTest(rec)
+
+	if err := m.Get(request.WithProject(context.Background(), "alpha"), "k/x", storage.GetOptions{}, nil); err != nil {
+		t.Fatal(err)
+	}
+	if err := m.Get(request.WithProject(context.Background(), "beta"), "k/y", storage.GetOptions{}, nil); err != nil {
+		t.Fatal(err)
+	}
+	if rec.unionCreates != 1 {
+		t.Fatalf("expected union created once, got %d", rec.unionCreates)
+	}
+}
+
+func TestCountAndReadinessUseRoot(t *testing.T) {
+	rec := &recorder{}
+	m := newMuxForTest(rec)
+
+	if _, err := m.Count("anything"); err != nil {
+		t.Fatal(err)
+	}
+	if err := m.ReadinessCheck(); err != nil {
+		t.Fatal(err)
+	}
+	if rec.rootCreates != 1 {
+		t.Fatalf("root should be created once; got %d", rec.rootCreates)
+	}
+	// Ensure calls were recorded on root
+	foundCount, foundReady := false, false
+	for _, c := range rec.calls {
+		if c == "root:Count anything" {
+			foundCount = true
+		}
+		if c == "root:ReadinessCheck " {
+			foundReady = true
+		}
+	}
+	if !foundCount || !foundReady {
+		t.Fatalf("root Count/ReadinessCheck not invoked as expected: %v", rec.calls)
+	}
+}
+
+func TestDestroyAllInvokesDestroys(t *testing.T) {
+	rec := &recorder{}
+	m := newMuxForTest(rec)
+
+	// Touch both children
+	if err := m.Get(context.Background(), "k/x", storage.GetOptions{}, nil); err != nil {
+		t.Fatal(err)
+	}
+	if err := m.Get(request.WithProject(context.Background(), "alpha"), "k/y", storage.GetOptions{}, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	m.destroyAll()
+	if !rec.rootDestroyed || !rec.unionDestroyed {
+		t.Fatalf("expected both destroys true; root=%v union=%v", rec.rootDestroyed, rec.unionDestroyed)
+	}
+}


### PR DESCRIPTION
Replace per-project watch caches with a single shared cache rooted at /projects.

Project-scoped requests are routed by the HTTP filter (which injects the project into context); the storage mux rewrites keys to projects/<project>/... and serves them from the shared cache.

Root (non-project) requests continue to use the existing root storage/prefix; CRD definitions remain global.

Eliminates one cacher/watch per virtual API server → dramatic memory savings (~30 MB per virtual) and fewer etcd watches per GVR.

No API surface changes; behavior is preserved. ResourceVersions remain global (per GVR) and may skip across projects, which is Kubernetes-legal.

Auth/tenancy is enforced by key-range scoping under /projects/<project>/….

Readiness/Count logic stays on the root child; provider wrappers and REST options remain unchanged aside from wiring the decorator.

Net effect: lower memory, lower etcd load, faster List/Watch via a single union cache, while keeping root and project scopes working side by side.