### PR TITLE
fix: bitnamilegacy etcd

### DIFF
--- a/config/dependencies/etcd/helmrelease.yaml
+++ b/config/dependencies/etcd/helmrelease.yaml
@@ -13,6 +13,12 @@ spec:
         name: bitnami
       interval: 5m
   values:
+    image:
+      registry: docker.io
+      repository: bitnamilegacy/etcd
+      tag: "3.5.15-debian-12-r6"
+      pullPolicy: IfNotPresent
+
     # Disable persistence for test infrastructure (ephemeral)
     persistence:
       enabled: false


### PR DESCRIPTION
bitnami docker images have been pruned in favor of their subscription for hardened images. bitnamilegacy org is available for now in docker hub but no changes will come to those images.