### PR TITLE
chore: add taskfile version for remote include

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -14,7 +14,7 @@ vars:
   MILO_IMAGE_TAG: "dev"
   TEST_INFRA_CLUSTER_NAME: "test-infra"
   # Test infra repository configuration - can be overridden with environment variable
-  TEST_INFRA_REPO_REF: 'parallelize-component-install'
+  TEST_INFRA_REPO_REF: 'v0.3.0'
 
 includes:
   # Must set TASK_X_REMOTE_TASKFILES=1 to use this feature.


### PR DESCRIPTION
Updates the Taskfile to use the [new v0.3.0 release of the test-infra](https://github.com/datum-cloud/test-infra/releases/tag/v0.3.0). 