### PR TITLE
Garbage collect resources on user deletion

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -134,16 +134,6 @@ tasks:
         # Update kubeconfig for easy developer access
         echo "📝 Updating kubeconfig for developer access..."
 
-        # Step 9: Restart deployments to ensure they pick up the latest image
-        echo "🔄 Restarting deployments to pick up latest image..."
-        task test-infra:kubectl -- rollout restart deployment/milo-apiserver -n milo-system
-        task test-infra:kubectl -- rollout restart deployment/milo-controller-manager -n milo-system
-
-        # Wait for rollouts to complete
-        echo "⏳ Waiting for deployments to restart..."
-        task test-infra:kubectl -- rollout status deployment/milo-apiserver -n milo-system --timeout=120s
-        task test-infra:kubectl -- rollout status deployment/milo-controller-manager -n milo-system --timeout=120s
-
         echo ""
         echo "✅ Milo API server and storage deployed successfully!"
         echo ""

--- a/cmd/milo/controller-manager/controllermanager.go
+++ b/cmd/milo/controller-manager/controllermanager.go
@@ -68,6 +68,9 @@ import (
 	kubefeatures "k8s.io/kubernetes/pkg/features"
 	"sigs.k8s.io/controller-runtime/pkg/cluster"
 
+	// Register JSON logging format
+	_ "k8s.io/component-base/logs/json/register"
+
 	// Datum webhook and API type imports
 	controlplane "go.miloapis.com/milo/internal/control-plane"
 	iamcontroller "go.miloapis.com/milo/internal/controllers/iam"
@@ -104,6 +107,8 @@ var (
 func init() {
 	utilruntime.Must(logsapi.AddFeatureGates(utilfeature.DefaultMutableFeatureGate))
 	utilruntime.Must(metricsfeatures.AddFeatureGates(utilfeature.DefaultMutableFeatureGate))
+	// Enable JSON logging support by default
+	utilfeature.DefaultMutableFeatureGate.Set("LoggingBetaOptions=true")
 	utilruntime.Must(corev1.AddToScheme(Scheme))
 
 	// Add Milo API types to the global scheme

--- a/config/apiserver/deployment.yaml
+++ b/config/apiserver/deployment.yaml
@@ -45,10 +45,13 @@ spec:
           - --client-ca-file=$(CLIENT_CA_FILE)
           - --tracing-config-file=$(TRACING_CONFIG_FILE)
           - --token-auth-file=$(TOKEN_AUTH_FILE)
+          - --logging-format=$(LOGGING_FORMAT)
           - --v=$(LOG_LEVEL)
         env:
           - name: LOG_LEVEL
             value: "4"
+          - name: LOGGING_FORMAT
+            value: "json"
           - name: AUTHORIZATION_MODE
             value: "RBAC,Webhook"
           - name: AUTHENTICATION_CONFIG

--- a/config/controller-manager/base/deployment.yaml
+++ b/config/controller-manager/base/deployment.yaml
@@ -38,6 +38,7 @@ spec:
           - --cert-dir=$(CERT_DIR)
           - --tls-cert-file=$(TLS_CERT_FILE)
           - --tls-private-key-file=$(TLS_PRIVATE_KEY_FILE)
+          - --logging-format=$(LOGGING_FORMAT)
           - --v=$(LOG_LEVEL)
           - --control-plane-scope=$(CONTROL_PLANE_SCOPE)
         env:
@@ -46,6 +47,8 @@ spec:
           # Default to INFO level logging
           - name: LOG_LEVEL
             value: "4"
+          - name: LOGGING_FORMAT
+            value: "json"
           - name: KUBECONFIG
             value: /etc/kubernetes/config/kubeconfig
           # Default to using the in-cluster config to connect to the

--- a/config/controller-manager/overlays/core-control-plane/rbac/role.yaml
+++ b/config/controller-manager/overlays/core-control-plane/rbac/role.yaml
@@ -17,12 +17,6 @@ rules:
   - update
   - watch
 - apiGroups:
-  - '*'
-  resources:
-  - '*'
-  verbs:
-  - get
-- apiGroups:
   - gateway.networking.k8s.io
   resources:
   - gatewayclasses

--- a/config/controller-manager/overlays/core-control-plane/rbac/role.yaml
+++ b/config/controller-manager/overlays/core-control-plane/rbac/role.yaml
@@ -17,6 +17,12 @@ rules:
   - update
   - watch
 - apiGroups:
+  - '*'
+  resources:
+  - '*'
+  verbs:
+  - get
+- apiGroups:
   - gateway.networking.k8s.io
   resources:
   - gatewayclasses
@@ -68,8 +74,11 @@ rules:
   - policybindings
   verbs:
   - delete
+  - get
   - list
+  - patch
   - update
+  - watch
 - apiGroups:
   - iam.miloapis.com
   resources:
@@ -77,6 +86,16 @@ rules:
   verbs:
   - get
   - list
+  - watch
+- apiGroups:
+  - iam.miloapis.com
+  resources:
+  - userpreferences
+  verbs:
+  - get
+  - list
+  - patch
+  - update
   - watch
 - apiGroups:
   - iam.miloapis.com

--- a/go.mod
+++ b/go.mod
@@ -46,6 +46,7 @@ require (
 	github.com/fsnotify/fsnotify v1.7.0 // indirect
 	github.com/fxamacker/cbor/v2 v2.7.0 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
+	github.com/go-logr/zapr v1.3.0 // indirect
 	github.com/go-openapi/jsonpointer v0.21.0 // indirect
 	github.com/go-openapi/jsonreference v0.21.0 // indirect
 	github.com/go-openapi/swag v0.23.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -181,8 +181,6 @@ github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
-github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
-github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20220101234140-673ab2c3ae75 h1:6fotK7otjonDflCTK0BCfls4SPy3NcCVb5dqqmbRknE=
@@ -257,8 +255,6 @@ golang.org/x/oauth2 v0.27.0/go.mod h1:onh5ek6nERTohokkhCD/y2cV4Do3fxFHFuAejCkRWT
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
-golang.org/x/sync v0.13.0 h1:AauUjRAJ9OSnvULf/ARrrVywoJDy0YS2AwQ98I37610=
-golang.org/x/sync v0.13.0/go.mod h1:1dzgHSNfp02xaA81J2MS99Qcpr2w7fw1gpm99rleRqA=
 golang.org/x/sync v0.16.0 h1:ycBJEhp9p4vXvUZNszeOq0kGTPghopOL8q0fq3vstxw=
 golang.org/x/sync v0.16.0/go.mod h1:1dzgHSNfp02xaA81J2MS99Qcpr2w7fw1gpm99rleRqA=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
@@ -273,8 +269,6 @@ golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.24.0 h1:dd5Bzh4yt5KYA8f9CJHCP4FB4D51c2c6JvN37xJJkJ0=
 golang.org/x/text v0.24.0/go.mod h1:L8rBsPeo2pSS+xqN0d5u2ikmjtmoJbDBT1b7nHvFCdU=
-golang.org/x/time v0.9.0 h1:EsRrnYcQiGH+5FfbgvV4AP7qEZstoyrHB0DzarOQ4ZY=
-golang.org/x/time v0.9.0/go.mod h1:3BpzKBy/shNhVucY/MWOyx10tF3SFh9QdLuxbVysPQM=
 golang.org/x/time v0.12.0 h1:ScB/8o8olJvc+CQPWrK3fPZNfh7qgwCrY0zJmoEQLSE=
 golang.org/x/time v0.12.0/go.mod h1:CDIdPxbZBQxdj6cxyCIdrNogrJKMJ7pr37NYpMcMDSg=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=

--- a/internal/controllers/iam/user_controller.go
+++ b/internal/controllers/iam/user_controller.go
@@ -30,6 +30,8 @@ type UserController struct {
 // +kubebuilder:rbac:groups=iam.miloapis.com,resources=users,verbs=get;list;watch;update
 // +kubebuilder:rbac:groups=iam.miloapis.com,resources=users/status,verbs=update
 // +kubebuilder:rbac:groups=iam.miloapis.com,resources=userdeactivations,verbs=get;list;watch
+// +kubebuilder:rbac:groups=iam.miloapis.com,resources=policybindings,verbs=get;list;watch;update;patch
+// +kubebuilder:rbac:groups=iam.miloapis.com,resources=userpreferences,verbs=get;list;watch;update;patch
 
 // Reconcile is the main reconciliation loop for the UserController.
 func (r *UserController) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
@@ -49,6 +51,12 @@ func (r *UserController) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 	if !user.DeletionTimestamp.IsZero() {
 		log.Info("User is being deleted, skipping reconciliation", "user", user.Name)
 		return ctrl.Result{}, nil
+	}
+
+	// Ensure owner references are set on PolicyBinding and UserPreference resources
+	if err := r.ensureOwnerReferences(ctx, user); err != nil {
+		log.Error(err, "Failed to ensure owner references")
+		return ctrl.Result{}, err
 	}
 
 	// Determine desired state based on existence of any UserDeactivation for this user
@@ -101,6 +109,65 @@ func (r *UserController) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 	}
 
 	return ctrl.Result{}, nil
+}
+
+// ensureOwnerReferences ensures that PolicyBinding and UserPreference resources have proper owner references
+func (r *UserController) ensureOwnerReferences(ctx context.Context, user *iamv1alpha1.User) error {
+	log := log.FromContext(ctx).WithName("ensure-owner-references")
+
+	// Create owner reference for the user
+	ownerRef := metav1.OwnerReference{
+		APIVersion: iamv1alpha1.SchemeGroupVersion.String(),
+		Kind:       "User",
+		Name:       user.Name,
+		UID:        user.UID,
+	}
+
+	// Update PolicyBinding for user self-management
+	policyBindingName := fmt.Sprintf("user-self-manage-%s", user.Name)
+	policyBinding := &iamv1alpha1.PolicyBinding{}
+	err := r.Client.Get(ctx, types.NamespacedName{Name: policyBindingName, Namespace: "milo-system"}, policyBinding)
+	if apierrors.IsNotFound(err) {
+		// PolicyBinding doesn't exist, webhook should have created it
+		log.Info("PolicyBinding not found, skipping (webhook should create it)", "user", user.Name, "policyBinding", policyBindingName)
+	} else if err != nil {
+		return fmt.Errorf("failed to get policy binding: %w", err)
+	} else if !hasOwnerReference(policyBinding.OwnerReferences, ownerRef) {
+		policyBinding.OwnerReferences = append(policyBinding.OwnerReferences, ownerRef)
+		if err := r.Client.Update(ctx, policyBinding); err != nil {
+			return fmt.Errorf("failed to update policy binding with owner reference: %w", err)
+		}
+		log.Info("Updated PolicyBinding with owner reference", "user", user.Name)
+	}
+
+	// Update UserPreference
+	userPreferenceName := fmt.Sprintf("userpreference-%s", user.Name)
+	userPreference := &iamv1alpha1.UserPreference{}
+	err = r.Client.Get(ctx, types.NamespacedName{Name: userPreferenceName}, userPreference)
+	if apierrors.IsNotFound(err) {
+		// UserPreference doesn't exist, webhook should have created it
+		log.Info("UserPreference not found, skipping (webhook should create it)", "user", user.Name, "userPreference", userPreferenceName)
+	} else if err != nil {
+		return fmt.Errorf("failed to get user preference: %w", err)
+	} else if !hasOwnerReference(userPreference.OwnerReferences, ownerRef) {
+		userPreference.OwnerReferences = append(userPreference.OwnerReferences, ownerRef)
+		if err := r.Client.Update(ctx, userPreference); err != nil {
+			return fmt.Errorf("failed to update user preference with owner reference: %w", err)
+		}
+		log.Info("Updated UserPreference with owner reference", "user", user.Name)
+	}
+
+	return nil
+}
+
+// hasOwnerReference checks if the owner reference already exists
+func hasOwnerReference(refs []metav1.OwnerReference, ref metav1.OwnerReference) bool {
+	for _, r := range refs {
+		if r.UID == ref.UID {
+			return true
+		}
+	}
+	return false
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/test/iam/user-deletion-garbage-collection/assertions/policy-binding-with-owner-ref.yaml
+++ b/test/iam/user-deletion-garbage-collection/assertions/policy-binding-with-owner-ref.yaml
@@ -1,0 +1,9 @@
+apiVersion: iam.miloapis.com/v1alpha1
+kind: PolicyBinding
+metadata:
+  name: user-self-manage-test-gc-user
+  namespace: milo-system
+  ownerReferences:
+  - apiVersion: iam.miloapis.com/v1alpha1
+    kind: User
+    name: test-gc-user

--- a/test/iam/user-deletion-garbage-collection/assertions/user-preference-policy-binding-with-owner-ref.yaml
+++ b/test/iam/user-deletion-garbage-collection/assertions/user-preference-policy-binding-with-owner-ref.yaml
@@ -1,0 +1,9 @@
+apiVersion: iam.miloapis.com/v1alpha1
+kind: PolicyBinding
+metadata:
+  name: userpreference-self-manage-test-gc-user
+  namespace: milo-system
+  ownerReferences:
+  - apiVersion: iam.miloapis.com/v1alpha1
+    kind: User
+    name: test-gc-user

--- a/test/iam/user-deletion-garbage-collection/assertions/user-preference-with-owner-ref.yaml
+++ b/test/iam/user-deletion-garbage-collection/assertions/user-preference-with-owner-ref.yaml
@@ -1,0 +1,8 @@
+apiVersion: iam.miloapis.com/v1alpha1
+kind: UserPreference
+metadata:
+  name: userpreference-test-gc-user
+  ownerReferences:
+  - apiVersion: iam.miloapis.com/v1alpha1
+    kind: User
+    name: test-gc-user

--- a/test/iam/user-deletion-garbage-collection/chainsaw-test.yaml
+++ b/test/iam/user-deletion-garbage-collection/chainsaw-test.yaml
@@ -25,41 +25,35 @@ spec:
             - type: Ready
               status: "True"
         timeout: 30s
-    - assert:
-        resource:
-          apiVersion: iam.miloapis.com/v1alpha1
-          kind: PolicyBinding
-          metadata:
-            name: user-self-manage-test-gc-user
-            namespace: milo-system
-            ownerReferences:
-            - apiVersion: iam.miloapis.com/v1alpha1
-              kind: User
-              name: test-gc-user
-        timeout: 10s
-    - assert:
-        resource:
-          apiVersion: iam.miloapis.com/v1alpha1
-          kind: UserPreference
-          metadata:
-            name: userpreference-test-gc-user
-            ownerReferences:
-            - apiVersion: iam.miloapis.com/v1alpha1
-              kind: User
-              name: test-gc-user
-        timeout: 10s
-    - assert:
-        resource:
-          apiVersion: iam.miloapis.com/v1alpha1
-          kind: PolicyBinding
-          metadata:
-            name: userpreference-self-manage-test-gc-user
-            namespace: milo-system
-            ownerReferences:
-            - apiVersion: iam.miloapis.com/v1alpha1
-              kind: User
-              name: test-gc-user
-        timeout: 10s
+    - wait:
+        apiVersion: iam.miloapis.com/v1alpha1
+        kind: PolicyBinding
+        name: user-self-manage-test-gc-user
+        namespace: milo-system
+        timeout: 30s
+        for:
+          jsonPath:
+            path: '{.metadata.ownerReferences[0].name}'
+            value: test-gc-user
+    - wait:
+        apiVersion: iam.miloapis.com/v1alpha1
+        kind: UserPreference
+        name: userpreference-test-gc-user
+        timeout: 30s
+        for:
+          jsonPath:
+            path: '{.metadata.ownerReferences[0].name}'
+            value: test-gc-user
+    - wait:
+        apiVersion: iam.miloapis.com/v1alpha1
+        kind: PolicyBinding
+        name: userpreference-self-manage-test-gc-user
+        namespace: milo-system
+        timeout: 30s
+        for:
+          jsonPath:
+            path: '{.metadata.ownerReferences[0].name}'
+            value: test-gc-user
 
   - name: delete-user
     description: Delete the User resource and verify associated resources are garbage collected

--- a/test/iam/user-deletion-garbage-collection/chainsaw-test.yaml
+++ b/test/iam/user-deletion-garbage-collection/chainsaw-test.yaml
@@ -1,0 +1,101 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: user-deletion-garbage-collection
+spec:
+  description: |
+    Validates that User resource deletion properly triggers garbage collection of associated
+    PolicyBinding and UserPreference resources. This test ensures the webhook creates resources
+    with correct owner references and the controller adds them post-creation, allowing
+    Kubernetes garbage collector to clean them up when the User is deleted.
+  steps:
+  - name: create-user
+    description: Create a User resource and verify webhook creates associated resources
+    try:
+    - apply:
+        file: test-user.yaml
+    - assert:
+        resource:
+          apiVersion: iam.miloapis.com/v1alpha1
+          kind: User
+          metadata:
+            name: test-gc-user
+          status:
+            conditions:
+            - type: Ready
+              status: "True"
+        timeout: 30s
+    - assert:
+        resource:
+          apiVersion: iam.miloapis.com/v1alpha1
+          kind: PolicyBinding
+          metadata:
+            name: user-self-manage-test-gc-user
+            namespace: milo-system
+            ownerReferences:
+            - apiVersion: iam.miloapis.com/v1alpha1
+              kind: User
+              name: test-gc-user
+        timeout: 10s
+    - assert:
+        resource:
+          apiVersion: iam.miloapis.com/v1alpha1
+          kind: UserPreference
+          metadata:
+            name: userpreference-test-gc-user
+            ownerReferences:
+            - apiVersion: iam.miloapis.com/v1alpha1
+              kind: User
+              name: test-gc-user
+        timeout: 10s
+    - assert:
+        resource:
+          apiVersion: iam.miloapis.com/v1alpha1
+          kind: PolicyBinding
+          metadata:
+            name: userpreference-self-manage-test-gc-user
+            namespace: milo-system
+            ownerReferences:
+            - apiVersion: iam.miloapis.com/v1alpha1
+              kind: User
+              name: test-gc-user
+        timeout: 10s
+
+  - name: delete-user
+    description: Delete the User resource and verify associated resources are garbage collected
+    try:
+    - delete:
+        ref:
+          apiVersion: iam.miloapis.com/v1alpha1
+          kind: User
+          name: test-gc-user
+    - error:
+        resource:
+          apiVersion: iam.miloapis.com/v1alpha1
+          kind: User
+          metadata:
+            name: test-gc-user
+        timeout: 30s
+    - error:
+        resource:
+          apiVersion: iam.miloapis.com/v1alpha1
+          kind: PolicyBinding
+          metadata:
+            name: user-self-manage-test-gc-user
+            namespace: milo-system
+        timeout: 30s
+    - error:
+        resource:
+          apiVersion: iam.miloapis.com/v1alpha1
+          kind: UserPreference
+          metadata:
+            name: userpreference-test-gc-user
+        timeout: 30s
+    - error:
+        resource:
+          apiVersion: iam.miloapis.com/v1alpha1
+          kind: PolicyBinding
+          metadata:
+            name: userpreference-self-manage-test-gc-user
+            namespace: milo-system
+        timeout: 30s

--- a/test/iam/user-deletion-garbage-collection/test-user.yaml
+++ b/test/iam/user-deletion-garbage-collection/test-user.yaml
@@ -1,0 +1,8 @@
+apiVersion: iam.miloapis.com/v1alpha1
+kind: User
+metadata:
+  name: test-gc-user
+spec:
+  email: test-gc@example.com
+  givenName: Test
+  familyName: User


### PR DESCRIPTION
### Summary

This makes several updates to improve testing reliability and ensure resources for users are garbage collected when a user is deleted. 

### Details

- Updates the UserPreference and PolicyBinding resource created by the user's validating admission webhook to set an owner reference for the User enabling them to be garbage collected when the user resource is deleted.
- Enabled JSON formatted logging by default with the apiserver / controller manager when deployed via kustomize.
- Removes a rolling restart of the apiserver and controller manager components during deployment because it would cause the controller manager to loose leadership election. Tests would be executed right after the restart was complete and before the controller was able to get leadership election resulting in tests to fail. 