### PR TITLE
add: prometheus rules unit tests

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -434,3 +434,45 @@ tasks:
             echo "🎉 All kustomizations are valid."
           fi
       silent: false
+
+  test-prometheus-rules:
+      desc: Run unit tests for Prometheus alerting rules
+      cmds:
+        - echo "# Prometheus Rules Test Results"
+        - echo ""
+        - |
+          HAS_ERRORS=0
+          TEST_FILES=$(find test/prometheus-rules -name "*-tests.yaml" 2>/dev/null)
+          
+          if [ -z "$TEST_FILES" ]; then
+            echo "⚠️  No Prometheus test files found in test/prometheus-rules/"
+            exit 0
+          fi
+          
+          for test_file in $TEST_FILES; do
+            test_dir=$(dirname "$test_file")
+            test_name=$(basename "$test_file")
+            echo "🔍 Testing: $test_file"
+            
+            if ! OUTPUT=$(cd "$test_dir" && promtool test rules "$test_name" 2>&1); then
+              echo ""
+              echo "❌ Test failed for '$test_file':"
+              echo "----------------------------------------"
+              echo "$OUTPUT"
+              echo "----------------------------------------"
+              echo ""
+              HAS_ERRORS=1
+            else
+              echo "✅ $test_file passed"
+            fi
+          done
+          
+          if [ "$HAS_ERRORS" -eq 1 ]; then
+            echo ""
+            echo "🚨 One or more Prometheus rule tests failed."
+            exit 1
+          else
+            echo ""
+            echo "🎉 All Prometheus rule tests passed."
+          fi
+      silent: false

--- a/test/prometheus-rules/resources-manager/projects/projects-slo-rules.yaml
+++ b/test/prometheus-rules/resources-manager/projects/projects-slo-rules.yaml
@@ -1,0 +1,15 @@
+groups:
+- name: resourcemanager-projects-slo
+  interval: 30s
+  rules:
+  - alert: ProjectStuckCreatingSLOViolation
+    expr: |
+      (time() - milo_projects_created_timestamp) > 60
+      unless ignoring(type, reason) (milo_projects_status_condition{type="Ready"} == 1)
+    for: 0s
+    labels:
+      severity: critical
+      slo_violation: "true"
+    annotations:
+      summary: "Project {{ $labels.resource_name }} is stuck creating for over 60 seconds"
+      description: "Project {{ $labels.resource_name }} has been in creation state for {{ $value }} seconds without reaching Ready status, which exceeds the 60-second SLO threshold."

--- a/test/prometheus-rules/resources-manager/projects/projects-slo-tests.yaml
+++ b/test/prometheus-rules/resources-manager/projects/projects-slo-tests.yaml
@@ -1,0 +1,101 @@
+rule_files:
+  - projects-slo-rules.yaml
+
+evaluation_interval: 30s
+
+tests:
+  # Test for ProjectStuckCreatingSLOViolation - Project created more than 60s ago but not ready
+  - interval: 1m
+    input_series:
+      # Project created 120 seconds ago (eval_time 60s - 120s = timestamp -60)
+      - series: 'milo_projects_created_timestamp{resource_name="test-project"}'
+        values: '-60+0x3'
+      # Project status condition Ready is False (0)
+      - series: 'milo_projects_status_condition{resource_name="test-project", type="Ready"}'
+        values: '0+0x3'
+    alert_rule_test:
+      - eval_time: 1m
+        alertname: ProjectStuckCreatingSLOViolation
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+              slo_violation: "true"
+              resource_name: test-project
+            exp_annotations:
+              summary: "Project test-project is stuck creating for over 60 seconds"
+              description: "Project test-project has been in creation state for 120 seconds without reaching Ready status, which exceeds the 60-second SLO threshold."
+
+  # Test for ProjectStuckCreatingSLOViolation - Project ready (should NOT alert)
+  - interval: 1m
+    input_series:
+      # Project created 120 seconds ago
+      - series: 'milo_projects_created_timestamp{resource_name="ready-project"}'
+        values: '-60+0x3'
+      # Project status condition Ready is True (1)
+      - series: 'milo_projects_status_condition{resource_name="ready-project", type="Ready"}'
+        values: '1+0x3'
+    alert_rule_test:
+      - eval_time: 1m
+        alertname: ProjectStuckCreatingSLOViolation
+        exp_alerts: []
+
+  # Edge case test - Project created exactly 60s ago (should NOT alert)
+  - interval: 1m
+    input_series:
+      # Project created exactly 60 seconds ago (time() - created = 60)
+      # If eval_time is 1m (60s), then created should be 0
+      - series: 'milo_projects_created_timestamp{resource_name="edge-case-project"}'
+        values: '0+0x3'
+      # Project status condition Ready is False (0)
+      - series: 'milo_projects_status_condition{resource_name="edge-case-project", type="Ready"}'
+        values: '0+0x3'
+    alert_rule_test:
+      - eval_time: 1m
+        alertname: ProjectStuckCreatingSLOViolation
+        exp_alerts: []
+
+  # Test for ProjectStuckCreatingSLOViolation - Project created 90s ago but not ready (should alert)
+  - interval: 1m
+    input_series:
+      # Project created 90 seconds ago (eval_time 60s - 90s = timestamp -30)
+      - series: 'milo_projects_created_timestamp{resource_name="stuck-project"}'
+        values: '-30+0x3'
+      # Project status condition Ready is False (0)
+      - series: 'milo_projects_status_condition{resource_name="stuck-project", type="Ready"}'
+        values: '0+0x3'
+    alert_rule_test:
+      - eval_time: 1m
+        alertname: ProjectStuckCreatingSLOViolation
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+              slo_violation: "true"
+              resource_name: stuck-project
+            exp_annotations:
+              summary: "Project stuck-project is stuck creating for over 60 seconds"
+              description: "Project stuck-project has been in creation state for 90 seconds without reaching Ready status, which exceeds the 60-second SLO threshold."
+
+  # Test with multiple projects - only the stuck one should alert
+  - interval: 1m
+    input_series:
+      # Stuck project created 150 seconds ago
+      - series: 'milo_projects_created_timestamp{resource_name="multi-stuck-project"}'
+        values: '-90+0x3'
+      - series: 'milo_projects_status_condition{resource_name="multi-stuck-project", type="Ready"}'
+        values: '0+0x3'
+      # Ready project created 150 seconds ago but is ready
+      - series: 'milo_projects_created_timestamp{resource_name="multi-ready-project"}'
+        values: '-90+0x3'
+      - series: 'milo_projects_status_condition{resource_name="multi-ready-project", type="Ready"}'
+        values: '1+0x3'
+    alert_rule_test:
+      - eval_time: 1m
+        alertname: ProjectStuckCreatingSLOViolation
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+              slo_violation: "true"
+              resource_name: multi-stuck-project
+            exp_annotations:
+              summary: "Project multi-stuck-project is stuck creating for over 60 seconds"
+              description: "Project multi-stuck-project has been in creation state for 150 seconds without reaching Ready status, which exceeds the 60-second SLO threshold."


### PR DESCRIPTION
Added unit tests for prometheus rule ProjectStuckCreatingSLOViolation

### Output

```bash
> promtool test rules projects-slo-tests.yaml
  SUCCESS
  
> promtool test rules projects-slo-tests.yaml --debug
DEBUG: Starting test unnamed#0
DEBUG: Dump of all data (input_series and rules) at 1m1s:
{__name__="ALERTS", alertname="ProjectStuckCreatingSLOViolation", alertstate="firing", resource_name="test-project", severity="critical", slo_violation="true"} =>
1 @[30000]
1 @[60000]
{__name__="ALERTS_FOR_STATE", alertname="ProjectStuckCreatingSLOViolation", resource_name="test-project", severity="critical", slo_violation="true"} =>
30 @[30000]
30 @[60000]
{__name__="milo_projects_created_timestamp", resource_name="test-project"} =>
-60 @[60000]
{__name__="milo_projects_status_condition", resource_name="test-project", type="Ready"} =>
0 @[60000]
DEBUG: Test unnamed#0 finished, took 11.461081ms
DEBUG: Starting test unnamed#1
DEBUG: Dump of all data (input_series and rules) at 1m1s:
{__name__="milo_projects_created_timestamp", resource_name="ready-project"} =>
-60 @[60000]
{__name__="milo_projects_status_condition", resource_name="ready-project", type="Ready"} =>
1 @[60000]
DEBUG: Test unnamed#1 finished, took 11.066764ms
DEBUG: Starting test unnamed#2
DEBUG: Dump of all data (input_series and rules) at 1m1s:
{__name__="milo_projects_created_timestamp", resource_name="edge-case-project"} =>
0 @[60000]
{__name__="milo_projects_status_condition", resource_name="edge-case-project", type="Ready"} =>
0 @[60000]
DEBUG: Test unnamed#2 finished, took 12.101186ms
DEBUG: Starting test unnamed#3
DEBUG: Dump of all data (input_series and rules) at 1m1s:
{__name__="ALERTS", alertname="ProjectStuckCreatingSLOViolation", alertstate="firing", resource_name="stuck-project", severity="critical", slo_violation="true"} =>
1 @[60000]
{__name__="ALERTS_FOR_STATE", alertname="ProjectStuckCreatingSLOViolation", resource_name="stuck-project", severity="critical", slo_violation="true"} =>
60 @[60000]
{__name__="milo_projects_created_timestamp", resource_name="stuck-project"} =>
-30 @[60000]
{__name__="milo_projects_status_condition", resource_name="stuck-project", type="Ready"} =>
0 @[60000]
DEBUG: Test unnamed#3 finished, took 11.126186ms
DEBUG: Starting test unnamed#4
DEBUG: Dump of all data (input_series and rules) at 1m1s:
{__name__="ALERTS", alertname="ProjectStuckCreatingSLOViolation", alertstate="firing", resource_name="multi-stuck-project", severity="critical", slo_violation="true"} =>
1 @[30000]
1 @[60000]
{__name__="ALERTS_FOR_STATE", alertname="ProjectStuckCreatingSLOViolation", resource_name="multi-stuck-project", severity="critical", slo_violation="true"} =>
0 @[30000]
0 @[60000]
{__name__="milo_projects_created_timestamp", resource_name="multi-ready-project"} =>
-90 @[60000]
{__name__="milo_projects_created_timestamp", resource_name="multi-stuck-project"} =>
-90 @[60000]
{__name__="milo_projects_status_condition", resource_name="multi-ready-project", type="Ready"} =>
1 @[60000]
{__name__="milo_projects_status_condition", resource_name="multi-stuck-project", type="Ready"} =>
0 @[60000]
DEBUG: Test unnamed#4 finished, took 13.685315ms
  SUCCESS
  
 # A failing unit test result would look like this
  > promtool test rules projects-slo-tests.yaml
  FAILED:
    alertname: ProjectStuckCreatingSLOViolation, time: 1m, 
        exp:[], 
        got:[
            0:
              Labels:{alertname="ProjectStuckCreatingSLOViolation", resource_name="stuck-project", severity="critical", slo_violation="true"}
              Annotations:{description="Project stuck-project has been in creation state for 90 seconds without reaching Ready status, which exceeds the 60-second SLO threshold.", summary="Project stuck-project is stuck creating for over 60 seconds"}
            ]
  
```