### PR TITLE
fix: fallback for org audit

### DIFF
--- a/config/telemetry/vector-audit-log-processor/vector-config.yaml
+++ b/config/telemetry/vector-audit-log-processor/vector-config.yaml
@@ -125,6 +125,21 @@ transforms:
           }
         }
 
+        # Fallback: derive organization from responseObject metadata.labels when present (RequestResponse level)
+        if organization_name == null && exists(log.responseObject) {
+          if exists(log.responseObject.metadata) && exists(log.responseObject.metadata.labels) {
+            labels_map = object!(log.responseObject.metadata.labels)
+            if exists(labels_map."resourcemanager.miloapis.com/organization-name") {
+              organization_name = to_string!(labels_map."resourcemanager.miloapis.com/organization-name")
+            }
+          }
+        }
+
+        # Ensure organization annotation is present if resolved via any path
+        if organization_name != null {
+          annotations = set!(value: annotations, path: ["resourcemanager.miloapis.com/organization-name"], data: organization_name)
+        }
+
         # Set control plane metadata. If a project was identified via user extra,
         # classify as project control-plane for downstream filtering; else core.
         if project_name != null {
@@ -207,3 +222,5 @@ sinks:
       resource_kind: "{{ objectRef.resource }}"
       user_name: "{{ user.username }}"
       control_plane_type: '{{ annotations."telemetry.miloapis.com/control-plane-type" }}'
+      organization_name: '{{ annotations."resourcemanager.miloapis.com/organization-name" }}'
+      project_name: '{{ annotations."resourcemanager.miloapis.com/project-name" }}'


### PR DESCRIPTION
This pull request updates the audit log processing pipeline to improve how organization and project metadata are extracted and annotated, ensuring more consistent downstream telemetry. The main changes focus on reliably populating organization and project names from multiple sources and including them in the output sink.

**Enhancements to organization and project metadata extraction:**

* Added a fallback mechanism to derive `organization_name` from `responseObject.metadata.labels` when not present in the primary location. This increases reliability for organization identification.
* Ensured the `organization_name` annotation is set in `annotations` if it is resolved by any extraction path, improving consistency for downstream consumers.

**Improvements to output sink fields:**

* Updated the sink mapping to include `organization_name` and `project_name` fields, sourcing them from the resolved annotations for better traceability in telemetry data.

Fixes: https://github.com/datum-cloud/milo/issues/274