### PR TITLE
chore: bump test-infra

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -14,7 +14,7 @@ vars:
   MILO_IMAGE_TAG: "dev"
   TEST_INFRA_CLUSTER_NAME: "test-infra"
   # Test infra repository configuration - can be overridden with environment variable
-  TEST_INFRA_REPO_REF: 'v0.4.0'
+  TEST_INFRA_REPO_REF: 'v0.4.1'
 
 includes:
   # Must set TASK_X_REMOTE_TASKFILES=1 to use this feature.


### PR DESCRIPTION
This pull request updates the test infrastructure repository version in the `Taskfile.yaml` configuration to ensure the project uses the latest available reference.

* Configuration update:
  * Changed the value of `TEST_INFRA_REPO_REF` from `'v0.4.0'` to `'v0.4.1'` in `Taskfile.yaml` to use the newer test infrastructure repository version.