### PR TITLE
hotfix: remove version from binary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,15 +20,8 @@ ARG VERSION=v0.0.0-master+dev
 ARG GIT_COMMIT=unknown
 ARG GIT_TREE_STATE=dirty
 ARG BUILD_DATE=unknown
-RUN echo "Building with version: ${VERSION}, commit: ${GIT_COMMIT}, tree: ${GIT_TREE_STATE}, date: ${BUILD_DATE}" && \
-    CGO_ENABLED=0 GOOS=linux GOARCH=amd64 \
-    go build \
-    -ldflags="-w -s \
-    -X k8s.io/component-base/version.gitVersion=${VERSION} \
-    -X k8s.io/component-base/version.gitCommit=${GIT_COMMIT} \
-    -X k8s.io/component-base/version.gitTreeState=${GIT_TREE_STATE} \
-    -X k8s.io/component-base/version.buildDate=${BUILD_DATE}" \
-    -trimpath -o milo ./cmd/milo
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 \
+    go build -trimpath -o milo ./cmd/milo
 
 # Final stage: minimal runtime image
 FROM gcr.io/distroless/static


### PR DESCRIPTION
The version number was causing feature flags to be disabled in the apiserver because the version numbers didn't align with kubernetes.