### PR TITLE
chore: add tests for admissions and field selector

### DIFF
--- a/config/overlays/test-infra/components/auth/auth-tokens-secret.yaml
+++ b/config/overlays/test-infra/components/auth/auth-tokens-secret.yaml
@@ -5,5 +5,5 @@ metadata:
 type: Opaque
 stringData:
   tokens.csv: |
-    test-admin-token,admin,1001,"system:masters"
-    test-user-token,test-user,1002,"system:authenticated"
+    test-admin-token,admin,admin,"system:masters"
+    test-user-token,test-user,test-user,"system:authenticated"

--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	k8s.io/utils v0.0.0-20241104100929-3ea5e8cea738
 	sigs.k8s.io/controller-runtime v0.20.4
 	sigs.k8s.io/multicluster-runtime v0.20.4-alpha.6
+	sigs.k8s.io/yaml v1.4.0
 )
 
 require (
@@ -137,5 +138,4 @@ require (
 	sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.31.0 // indirect
 	sigs.k8s.io/json v0.0.0-20241010143419-9aa6b5e7a4b3 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.7.0 // indirect
-	sigs.k8s.io/yaml v1.4.0 // indirect
 )

--- a/test/admission/validating-admission-policy/assertions/assert-project-a-owner.yaml
+++ b/test/admission/validating-admission-policy/assertions/assert-project-a-owner.yaml
@@ -1,0 +1,16 @@
+apiVersion: resourcemanager.miloapis.com/v1alpha1
+kind: Project
+metadata:
+  name: vap-ok-good-a
+  labels:
+    resourcemanager.miloapis.com/organization-name: test-vap-org-a
+  ownerReferences:
+  - apiVersion: resourcemanager.miloapis.com/v1alpha1
+    kind: Organization
+    name: test-vap-org-a
+spec:
+  ownerRef:
+    kind: Organization
+    name: test-vap-org-a
+
+

--- a/test/admission/validating-admission-policy/assertions/assert-project-b-owner.yaml
+++ b/test/admission/validating-admission-policy/assertions/assert-project-b-owner.yaml
@@ -1,0 +1,16 @@
+apiVersion: resourcemanager.miloapis.com/v1alpha1
+kind: Project
+metadata:
+  name: vap-ok-good-b
+  labels:
+    resourcemanager.miloapis.com/organization-name: test-vap-org-b
+  ownerReferences:
+  - apiVersion: resourcemanager.miloapis.com/v1alpha1
+    kind: Organization
+    name: test-vap-org-b
+spec:
+  ownerRef:
+    kind: Organization
+    name: test-vap-org-b
+
+

--- a/test/admission/validating-admission-policy/chainsaw-test.yaml
+++ b/test/admission/validating-admission-policy/chainsaw-test.yaml
@@ -1,0 +1,78 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: validating-admission-policy-project
+spec:
+  clusters:
+    orgA:
+      kubeconfig: kubeconfig-org-a
+    orgB:
+      kubeconfig: kubeconfig-org-b
+  steps:
+  - name: apply-policy-and-orgs
+    try:
+    - apply:
+        file: resources/policy.yaml
+    - sleep:
+        duration: 2s
+    - apply:
+        file: resources/org-a.yaml
+    - apply:
+        file: resources/org-b.yaml
+
+  - name: deny-projects-with-bad-names-orgA
+    cluster: orgA
+    try:
+    - error:
+        file: resources/project-bad-a.yaml
+  - name: deny-projects-with-bad-names-orgB
+    cluster: orgB
+    try:
+    - error:
+        file: resources/project-bad-b.yaml
+
+  - name: allow-projects-with-ok-prefix-orgA
+    cluster: orgA
+    try:
+    - apply:
+        file: resources/project-good-a.yaml
+    - wait:
+        apiVersion: resourcemanager.miloapis.com/v1alpha1
+        kind: Project
+        name: vap-ok-good-a
+        timeout: 30s
+        for:
+          condition:
+            name: Ready
+            value: 'true'
+    - assert:
+        file: assertions/assert-project-a-owner.yaml
+  - name: allow-projects-with-ok-prefix-orgB
+    cluster: orgB
+    try:
+    - apply:
+        file: resources/project-good-b.yaml
+    - wait:
+        apiVersion: resourcemanager.miloapis.com/v1alpha1
+        kind: Project
+        name: vap-ok-good-b
+        timeout: 30s
+        for:
+          condition:
+            name: Ready
+            value: 'true'
+    - assert:
+        file: assertions/assert-project-b-owner.yaml
+
+  - name: cleanup
+    finally:
+    - delete:
+        file: resources/project-good-a.yaml
+    - delete:
+        file: resources/project-good-b.yaml
+    - delete:
+        file: resources/org-a.yaml
+    - delete:
+        file: resources/org-b.yaml
+    - delete:
+        file: resources/policy.yaml

--- a/test/admission/validating-admission-policy/kubeconfig-org-a
+++ b/test/admission/validating-admission-policy/kubeconfig-org-a
@@ -1,0 +1,20 @@
+apiVersion: v1
+clusters:
+- cluster:
+    insecure-skip-tls-verify: true
+    server: https://localhost:30443/apis/resourcemanager.miloapis.com/v1alpha1/organizations/test-vap-org-a/control-plane
+  name: org-test-vap-org-a
+contexts:
+- context:
+    cluster: org-test-vap-org-a
+    user: user-1001
+  name: org-test-vap-org-a
+current-context: org-test-vap-org-a
+kind: Config
+preferences: {}
+users:
+- name: user-1001
+  user:
+    token: test-admin-token
+
+

--- a/test/admission/validating-admission-policy/kubeconfig-org-b
+++ b/test/admission/validating-admission-policy/kubeconfig-org-b
@@ -1,0 +1,20 @@
+apiVersion: v1
+clusters:
+- cluster:
+    insecure-skip-tls-verify: true
+    server: https://localhost:30443/apis/resourcemanager.miloapis.com/v1alpha1/organizations/test-vap-org-b/control-plane
+  name: org-test-vap-org-b
+contexts:
+- context:
+    cluster: org-test-vap-org-b
+    user: user-1001
+  name: org-test-vap-org-b
+current-context: org-test-vap-org-b
+kind: Config
+preferences: {}
+users:
+- name: user-1001
+  user:
+    token: test-admin-token
+
+

--- a/test/admission/validating-admission-policy/kubeconfig-org-template
+++ b/test/admission/validating-admission-policy/kubeconfig-org-template
@@ -1,0 +1,18 @@
+apiVersion: v1
+clusters:
+- cluster:
+    insecure-skip-tls-verify: true
+    server: https://localhost:30443/apis/resourcemanager.miloapis.com/v1alpha1/organizations/test-vap-org-a/control-plane
+  name: org-test-vap-org-a
+contexts:
+- context:
+    cluster: org-test-vap-org-a
+    user: user-1001
+  name: org-test-vap-org-a
+current-context: org-test-vap-org-a
+kind: Config
+preferences: {}
+users:
+- name: user-1001
+  user:
+    token: test-admin-token

--- a/test/admission/validating-admission-policy/resources/org-a.yaml
+++ b/test/admission/validating-admission-policy/resources/org-a.yaml
@@ -1,0 +1,6 @@
+apiVersion: resourcemanager.miloapis.com/v1alpha1
+kind: Organization
+metadata:
+  name: test-vap-org-a
+spec:
+  type: Standard

--- a/test/admission/validating-admission-policy/resources/org-b.yaml
+++ b/test/admission/validating-admission-policy/resources/org-b.yaml
@@ -1,0 +1,6 @@
+apiVersion: resourcemanager.miloapis.com/v1alpha1
+kind: Organization
+metadata:
+  name: test-vap-org-b
+spec:
+  type: Standard

--- a/test/admission/validating-admission-policy/resources/policy.yaml
+++ b/test/admission/validating-admission-policy/resources/policy.yaml
@@ -1,0 +1,25 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: project-name-requires-ok-prefix
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+    - apiGroups: ["resourcemanager.miloapis.com"]
+      apiVersions: ["v1alpha1"]
+      operations: ["CREATE","UPDATE"]
+      resources: ["projects"]
+  validations:
+  - expression: object.metadata.name.startsWith("vap-ok-")
+    message: "Project name must start with 'vap-ok-'."
+
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  name: project-name-requires-ok-prefix
+spec:
+  policyName: project-name-requires-ok-prefix
+  validationActions:
+  - Deny

--- a/test/admission/validating-admission-policy/resources/project-bad-a.yaml
+++ b/test/admission/validating-admission-policy/resources/project-bad-a.yaml
@@ -1,0 +1,4 @@
+apiVersion: resourcemanager.miloapis.com/v1alpha1
+kind: Project
+metadata:
+  name: bad-vap-proj-a

--- a/test/admission/validating-admission-policy/resources/project-bad-b.yaml
+++ b/test/admission/validating-admission-policy/resources/project-bad-b.yaml
@@ -1,0 +1,4 @@
+apiVersion: resourcemanager.miloapis.com/v1alpha1
+kind: Project
+metadata:
+  name: bad-vap-proj-b

--- a/test/admission/validating-admission-policy/resources/project-good-a.yaml
+++ b/test/admission/validating-admission-policy/resources/project-good-a.yaml
@@ -1,0 +1,4 @@
+apiVersion: resourcemanager.miloapis.com/v1alpha1
+kind: Project
+metadata:
+  name: vap-ok-good-a

--- a/test/admission/validating-admission-policy/resources/project-good-b.yaml
+++ b/test/admission/validating-admission-policy/resources/project-good-b.yaml
@@ -1,0 +1,4 @@
+apiVersion: resourcemanager.miloapis.com/v1alpha1
+kind: Project
+metadata:
+  name: vap-ok-good-b

--- a/test/resource-management/organizationmembership-fieldselector/chainsaw-test.yaml
+++ b/test/resource-management/organizationmembership-fieldselector/chainsaw-test.yaml
@@ -1,0 +1,85 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: organizationmembership-fieldselector
+spec:
+  clusters:
+    org:
+      kubeconfig: kubeconfig-org-template
+  steps:
+  - name: setup
+    try:
+    - apply:
+        file: resources/org.yaml
+    - wait:
+        apiVersion: v1
+        kind: Namespace
+        name: organization-fieldsel-org
+        timeout: 60s
+        for:
+          jsonPath:
+            path: '{.status.phase}'
+            value: Active
+    - apply:
+        file: resources/user-1001.yaml
+    - apply:
+        file: resources/user-1002.yaml
+    - apply:
+        file: resources/membership-1001.yaml
+    - apply:
+        file: resources/membership-1002.yaml
+    - wait:
+        apiVersion: resourcemanager.miloapis.com/v1alpha1
+        kind: OrganizationMembership
+        name: m-1001
+        namespace: organization-fieldsel-org
+        timeout: 60s
+        for:
+          condition:
+            name: Ready
+            value: 'True'
+
+  - name: direct-field-selector-on-org-cluster
+    cluster: org
+    try:
+    - script:
+        timeout: 60s
+        content: |
+          set -euo pipefail
+          # spec.userRef.name filter matches exactly one
+          test "$(kubectl get organizationmemberships -n organization-fieldsel-org \
+            --field-selector spec.userRef.name=1001 -o json | jq '.items | length')" -eq 1
+          # non-matching user yields zero
+          test "$(kubectl get organizationmemberships -n organization-fieldsel-org \
+            --field-selector spec.userRef.name=does-not-exist -o json | jq '.items | length')" -eq 0
+          # organization filter matches both memberships
+          test "$(kubectl get organizationmemberships -n organization-fieldsel-org \
+            --field-selector spec.organizationRef.name=fieldsel-org -o json | jq '.items | length')" -eq 2
+
+  - name: org-scoped-fieldselector-behavior
+    cluster: org
+    try:
+    - script:
+        timeout: 60s
+        content: |
+          set -euo pipefail
+          # Plain list returns both memberships
+          test "$(kubectl get organizationmemberships -n organization-fieldsel-org -o json | jq '.items | length')" -eq 2
+          # Field-select by user narrows the list
+          test "$(kubectl get organizationmemberships -n organization-fieldsel-org \
+            --field-selector spec.userRef.name=1002 -o json | jq '.items | length')" -eq 1
+
+  - name: cleanup
+    finally:
+    - delete:
+        file: resources/membership-1001.yaml
+    - delete:
+        file: resources/membership-1002.yaml
+    - delete:
+        file: resources/user-1001.yaml
+    - delete:
+        file: resources/user-1002.yaml
+    - delete:
+        file: resources/org.yaml
+
+

--- a/test/resource-management/organizationmembership-fieldselector/kubeconfig-org-template
+++ b/test/resource-management/organizationmembership-fieldselector/kubeconfig-org-template
@@ -1,0 +1,20 @@
+apiVersion: v1
+clusters:
+- cluster:
+    insecure-skip-tls-verify: true
+    server: https://localhost:30443/apis/resourcemanager.miloapis.com/v1alpha1/organizations/fieldsel-org/control-plane
+  name: org-fieldsel-org
+contexts:
+- context:
+    cluster: org-fieldsel-org
+    user: user-1001
+  name: org-fieldsel-org
+current-context: org-fieldsel-org
+kind: Config
+preferences: {}
+users:
+- name: user-1001
+  user:
+    token: test-admin-token
+
+

--- a/test/resource-management/organizationmembership-fieldselector/resources/membership-1001.yaml
+++ b/test/resource-management/organizationmembership-fieldselector/resources/membership-1001.yaml
@@ -1,0 +1,12 @@
+apiVersion: resourcemanager.miloapis.com/v1alpha1
+kind: OrganizationMembership
+metadata:
+  name: m-1001
+  namespace: organization-fieldsel-org
+spec:
+  organizationRef:
+    name: fieldsel-org
+  userRef:
+    name: "1001"
+
+

--- a/test/resource-management/organizationmembership-fieldselector/resources/membership-1002.yaml
+++ b/test/resource-management/organizationmembership-fieldselector/resources/membership-1002.yaml
@@ -1,0 +1,12 @@
+apiVersion: resourcemanager.miloapis.com/v1alpha1
+kind: OrganizationMembership
+metadata:
+  name: m-1002
+  namespace: organization-fieldsel-org
+spec:
+  organizationRef:
+    name: fieldsel-org
+  userRef:
+    name: "1002"
+
+

--- a/test/resource-management/organizationmembership-fieldselector/resources/org.yaml
+++ b/test/resource-management/organizationmembership-fieldselector/resources/org.yaml
@@ -1,0 +1,8 @@
+apiVersion: resourcemanager.miloapis.com/v1alpha1
+kind: Organization
+metadata:
+  name: fieldsel-org
+spec:
+  type: Standard
+
+

--- a/test/resource-management/organizationmembership-fieldselector/resources/user-1001.yaml
+++ b/test/resource-management/organizationmembership-fieldselector/resources/user-1001.yaml
@@ -1,0 +1,10 @@
+apiVersion: iam.miloapis.com/v1alpha1
+kind: User
+metadata:
+  name: "1001"
+spec:
+  email: user1001@test.local
+  givenName: FieldSel
+  familyName: One
+
+

--- a/test/resource-management/organizationmembership-fieldselector/resources/user-1002.yaml
+++ b/test/resource-management/organizationmembership-fieldselector/resources/user-1002.yaml
@@ -1,0 +1,10 @@
+apiVersion: iam.miloapis.com/v1alpha1
+kind: User
+metadata:
+  name: "1002"
+spec:
+  email: user1002@test.local
+  givenName: FieldSel
+  familyName: Two
+
+


### PR DESCRIPTION
This pull request introduces two new sets of end-to-end tests to validate resource management and admission policies in a multi-organization environment. The changes add Chainsaw test suites, supporting resources, and configuration files for both validating admission policies on project creation and for testing field selectors on organization memberships. Additionally, there are minor updates to authentication token data and Go module dependencies.

**Admission Policy Tests**

* Added a Chainsaw test suite (`chainsaw-test.yaml`) for validating admission policies on `Project` resources, ensuring only projects with names starting with `vap-ok-` are allowed in each organization. This includes setup, validation, assertion, and cleanup steps.
* Introduced resource manifests for organizations, valid/invalid projects, and the admission policy itself (`policy.yaml`, `org-a.yaml`, `org-b.yaml`, `project-good-a.yaml`, `project-good-b.yaml`, `project-bad-a.yaml`, `project-bad-b.yaml`).
* Added assertion files to verify correct owner references after successful project creation. 

**OrganizationMembership Field Selector Tests**

* Added a Chainsaw test suite (`chainsaw-test.yaml`) for `OrganizationMembership` resources, verifying field selector behavior and correct filtering by user and organization references.
* Introduced supporting resource manifests for organization, users, and memberships used in the tests. 

**Infrastructure and Dependency Updates**

* Updated `tokens.csv` in the auth tokens secret to use usernames instead of numeric IDs for the `user` field.