### PR TITLE
fix: add scheme

### DIFF
--- a/cmd/milo/controller-manager/controllermanager.go
+++ b/cmd/milo/controller-manager/controllermanager.go
@@ -84,6 +84,7 @@ import (
 	infrastructurev1alpha1 "go.miloapis.com/milo/pkg/apis/infrastructure/v1alpha1"
 	notificationv1alpha1 "go.miloapis.com/milo/pkg/apis/notification/v1alpha1"
 	resourcemanagerv1alpha1 "go.miloapis.com/milo/pkg/apis/resourcemanager/v1alpha1"
+	apiregistrationv1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
 	controllerruntime "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/metrics/server"
@@ -126,6 +127,7 @@ func init() {
 	utilruntime.Must(infrastructurev1alpha1.AddToScheme(Scheme))
 	utilruntime.Must(iamv1alpha1.AddToScheme(Scheme))
 	utilruntime.Must(notificationv1alpha1.AddToScheme(Scheme))
+	utilruntime.Must(apiregistrationv1.AddToScheme(Scheme))
 }
 
 const (


### PR DESCRIPTION
This pull request adds support for the Kubernetes API Registration v1 API to the controller manager by updating the scheme registration. This ensures that custom resource controllers can interact with aggregated APIs as needed.

**Kubernetes API Registration Integration:**

* Added the import for `apiregistrationv1` from `k8s.io/kube-aggregator/pkg/apis/apiregistration/v1` in `controllermanager.go`.
* Registered `apiregistrationv1` with the controller manager's scheme in the `init()` function to enable handling of aggregated API resources.