### PR TITLE
feat: add validation package for quota resources

### DIFF
--- a/internal/quota/validation/cel.go
+++ b/internal/quota/validation/cel.go
@@ -1,0 +1,249 @@
+package validation
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/google/cel-go/cel"
+	"github.com/google/cel-go/common/types"
+	"github.com/google/cel-go/common/types/ref"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	quotav1alpha1 "go.miloapis.com/milo/pkg/apis/quota/v1alpha1"
+)
+
+// CELValidator provides validation for CEL expressions used in GrantCreationPolicy.
+type CELValidator struct {
+	env *cel.Env
+}
+
+// NewCELValidator creates a new CEL validator with the appropriate environment.
+func NewCELValidator() (*CELValidator, error) {
+	env, err := cel.NewEnv(
+		// Add the 'trigger' variable that contains the trigger resource
+		cel.Variable("trigger", cel.DynType),
+
+		// Add custom functions for Kubernetes operations
+		cel.Function("has",
+			cel.MemberOverload("has_field", []*cel.Type{cel.DynType, cel.StringType}, cel.BoolType,
+				cel.BinaryBinding(func(obj, field ref.Val) ref.Val {
+					if objMap, ok := obj.Value().(map[string]interface{}); ok {
+						fieldStr := field.Value().(string)
+						_, exists := getNestedField(objMap, fieldStr)
+						return types.Bool(exists)
+					}
+					return types.False
+				}),
+			),
+		),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create CEL environment: %w", err)
+	}
+
+	return &CELValidator{env: env}, nil
+}
+
+// ValidateConditions validates CEL expressions in trigger conditions.
+func (v *CELValidator) ValidateConditions(conditions []quotav1alpha1.ConditionExpression) error {
+	for i, condition := range conditions {
+		if err := v.validateExpression(condition.Expression, cel.BoolType); err != nil {
+			return fmt.Errorf("condition %d: %w", i, err)
+		}
+	}
+	return nil
+}
+
+// ValidateNameExpression validates a CEL expression that should return a string.
+func (v *CELValidator) ValidateNameExpression(expression string) error {
+	return v.validateExpression(expression, cel.StringType)
+}
+
+// validateExpression validates that a CEL expression is syntactically correct and returns the expected type.
+func (v *CELValidator) validateExpression(expression string, expectedType *cel.Type) error {
+	if strings.TrimSpace(expression) == "" {
+		return fmt.Errorf("expression cannot be empty")
+	}
+
+	// Parse the expression
+	ast, issues := v.env.Parse(expression)
+	if issues != nil && issues.Err() != nil {
+		return fmt.Errorf("parse error: %w", issues.Err())
+	}
+
+	// Type-check the expression
+	checked, issues := v.env.Check(ast)
+	if issues != nil && issues.Err() != nil {
+		return fmt.Errorf("type check error: %w", issues.Err())
+	}
+
+	// Verify the return type matches expectations
+	if !checked.OutputType().IsEquivalentType(expectedType) {
+		return fmt.Errorf("expression must return %s, got %s", expectedType, checked.OutputType())
+	}
+
+	// Additional security checks
+	if err := v.validateSecurity(expression); err != nil {
+		return fmt.Errorf("security validation failed: %w", err)
+	}
+
+	return nil
+}
+
+// validateSecurity performs basic security validation on CEL expressions.
+func (v *CELValidator) validateSecurity(expression string) error {
+	// Prevent potentially dangerous operations
+	forbidden := []string{
+		"system",
+		"exec",
+		"eval",
+		"import",
+		"file",
+		"network",
+		"subprocess",
+	}
+
+	lowerExpr := strings.ToLower(expression)
+	for _, term := range forbidden {
+		if strings.Contains(lowerExpr, term) {
+			return fmt.Errorf("expression contains forbidden term: %s", term)
+		}
+	}
+
+	// Limit expression length to prevent DoS
+	if len(expression) > 1024 {
+		return fmt.Errorf("expression exceeds maximum length of 1024 characters")
+	}
+
+	return nil
+}
+
+// EvaluateConditions evaluates all trigger conditions against a resource object.
+func (v *CELValidator) EvaluateConditions(conditions []quotav1alpha1.ConditionExpression, obj *unstructured.Unstructured) (bool, error) {
+	if len(conditions) == 0 {
+		return true, nil // No conditions means always match
+	}
+
+	// Convert unstructured object to a map for CEL evaluation
+	objData := obj.Object
+
+	for i, condition := range conditions {
+		result, err := v.evaluateCondition(condition.Expression, objData)
+		if err != nil {
+			return false, fmt.Errorf("condition %d evaluation failed: %w", i, err)
+		}
+
+		if !result {
+			return false, nil // At least one condition failed
+		}
+	}
+
+	return true, nil // All conditions passed
+}
+
+// EvaluateNameExpression evaluates a name expression against a resource object.
+func (v *CELValidator) EvaluateNameExpression(expression string, obj *unstructured.Unstructured) (string, error) {
+	objData := obj.Object
+
+	// Parse and compile the expression
+	ast, issues := v.env.Parse(expression)
+	if issues != nil && issues.Err() != nil {
+		return "", fmt.Errorf("parse error: %w", issues.Err())
+	}
+
+	checked, issues := v.env.Check(ast)
+	if issues != nil && issues.Err() != nil {
+		return "", fmt.Errorf("type check error: %w", issues.Err())
+	}
+
+	// Create program with optimizations
+	program, err := v.env.Program(checked,
+		cel.EvalOptions(cel.OptOptimize),
+	)
+	if err != nil {
+		return "", fmt.Errorf("program creation failed: %w", err)
+	}
+
+	// Evaluate with the resource object
+	vars := map[string]interface{}{
+		"trigger": objData,
+	}
+
+	result, _, err := program.Eval(vars)
+	if err != nil {
+		return "", fmt.Errorf("evaluation failed: %w", err)
+	}
+
+	// Convert result to string
+	if str, ok := result.Value().(string); ok {
+		return str, nil
+	}
+
+	return "", fmt.Errorf("expression did not return a string value")
+}
+
+// evaluateCondition evaluates a single condition expression.
+func (v *CELValidator) evaluateCondition(expression string, objData map[string]interface{}) (bool, error) {
+	// Parse and compile the expression
+	ast, issues := v.env.Parse(expression)
+	if issues != nil && issues.Err() != nil {
+		return false, fmt.Errorf("parse error: %w", issues.Err())
+	}
+
+	checked, issues := v.env.Check(ast)
+	if issues != nil && issues.Err() != nil {
+		return false, fmt.Errorf("type check error: %w", issues.Err())
+	}
+
+	// Create program with optimizations
+	program, err := v.env.Program(checked,
+		cel.EvalOptions(cel.OptOptimize),
+	)
+	if err != nil {
+		return false, fmt.Errorf("program creation failed: %w", err)
+	}
+
+	// Evaluate with the resource object
+	vars := map[string]interface{}{
+		"trigger": objData,
+	}
+
+	result, _, err := program.Eval(vars)
+	if err != nil {
+		return false, fmt.Errorf("evaluation failed: %w", err)
+	}
+
+	// Convert result to boolean
+	if b, ok := result.Value().(bool); ok {
+		return b, nil
+	}
+
+	return false, fmt.Errorf("expression did not return a boolean value")
+}
+
+// getNestedField retrieves a nested field from a map using dot notation.
+func getNestedField(obj map[string]interface{}, fieldPath string) (interface{}, bool) {
+	parts := strings.Split(fieldPath, ".")
+	current := obj
+
+	for i, part := range parts {
+		if current == nil {
+			return nil, false
+		}
+
+		if i == len(parts)-1 {
+			// Last part - return the value
+			value, exists := current[part]
+			return value, exists
+		}
+
+		// Intermediate part - must be a map
+		if next, ok := current[part].(map[string]interface{}); ok {
+			current = next
+		} else {
+			return nil, false
+		}
+	}
+
+	return current, true
+}

--- a/internal/quota/validation/claim_template.go
+++ b/internal/quota/validation/claim_template.go
@@ -1,0 +1,55 @@
+package validation
+
+import (
+	"fmt"
+	"strings"
+	"text/template"
+
+	quotav1alpha1 "go.miloapis.com/milo/pkg/apis/quota/v1alpha1"
+)
+
+// ClaimTemplateValidator provides validation for Go templates used in ClaimCreationPolicy metadata.
+type ClaimTemplateValidator struct{}
+
+// ValidateClaimTemplate validates the ResourceClaim template structure and template syntax.
+// It enforces name/generateName mutual exclusivity and parses templated fields for syntax errors.
+func (v *ClaimTemplateValidator) ValidateClaimTemplate(t quotav1alpha1.ResourceClaimTemplate) error {
+	// name vs generateName mutual exclusivity
+	nameSet := strings.TrimSpace(t.Metadata.Name) != ""
+	genSet := strings.TrimSpace(t.Metadata.GenerateName) != ""
+	if nameSet && genSet {
+		return fmt.Errorf("metadata.name and metadata.generateName are mutually exclusive")
+	}
+
+	// Validate templated fields: name, generateName, namespace
+	if err := parseTemplateIfNeeded(t.Metadata.Name); err != nil {
+		return fmt.Errorf("invalid metadata.name template: %w", err)
+	}
+	if err := parseTemplateIfNeeded(t.Metadata.GenerateName); err != nil {
+		return fmt.Errorf("invalid metadata.generateName template: %w", err)
+	}
+	if err := parseTemplateIfNeeded(t.Metadata.Namespace); err != nil {
+		return fmt.Errorf("invalid metadata.namespace template: %w", err)
+	}
+
+	// Validate annotations (values are templated)
+	for k, vStr := range t.Metadata.Annotations {
+		if err := parseTemplateIfNeeded(vStr); err != nil {
+			return fmt.Errorf("invalid annotation template for key %q: %w", k, err)
+		}
+	}
+
+	return nil
+}
+
+func parseTemplateIfNeeded(s string) error {
+	if strings.TrimSpace(s) == "" {
+		return nil
+	}
+	if !strings.Contains(s, "{{") {
+		return nil
+	}
+	_, err := template.New("tmpl").Parse(s)
+	return err
+}
+

--- a/internal/quota/validation/grant_template.go
+++ b/internal/quota/validation/grant_template.go
@@ -1,0 +1,396 @@
+package validation
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strings"
+	"text/template"
+
+	quotav1alpha1 "go.miloapis.com/milo/pkg/apis/quota/v1alpha1"
+	"k8s.io/apimachinery/pkg/util/validation"
+)
+
+// GrantTemplateValidator provides validation for Go templates used in GrantCreationPolicy.
+type GrantTemplateValidator struct {
+	// validVariables defines the allowed template variables
+	validVariables map[string]bool
+	// resourceTypeValidator validates resource types against ResourceRegistrations
+	resourceTypeValidator ResourceTypeValidator
+}
+
+// NewGrantTemplateValidator creates a new grant template validator.
+func NewGrantTemplateValidator(resourceTypeValidator ResourceTypeValidator) *GrantTemplateValidator {
+	return &GrantTemplateValidator{
+		validVariables: map[string]bool{
+			"trigger": true,
+		},
+		resourceTypeValidator: resourceTypeValidator,
+	}
+}
+
+// ValidateGrantTemplate validates the entire ResourceGrant template structure.
+func (v *GrantTemplateValidator) ValidateGrantTemplate(ctx context.Context, grantTemplate quotav1alpha1.ResourceGrantTemplate) error {
+	// Validate metadata template
+	if err := v.ValidateMetadataTemplate(grantTemplate.Metadata); err != nil {
+		return fmt.Errorf("metadata template validation failed: %w", err)
+	}
+
+	// Validate spec template (including resource type validation)
+	if err := v.ValidateSpecTemplate(ctx, grantTemplate.Spec); err != nil {
+		return fmt.Errorf("spec template validation failed: %w", err)
+	}
+
+	return nil
+}
+
+// ValidateMetadataTemplate validates metadata template fields.
+func (v *GrantTemplateValidator) ValidateMetadataTemplate(metadata quotav1alpha1.ObjectMetaTemplate) error {
+	// Validate name template
+	if err := v.ValidateNameTemplate(metadata.Name); err != nil {
+		return fmt.Errorf("name template validation failed: %w", err)
+	}
+
+	// Validate namespace if provided
+	if metadata.Namespace != "" {
+		// If namespace contains template variables, validate as template, otherwise validate as Kubernetes name
+		if v.containsTemplateVariables(metadata.Namespace) {
+			if err := v.ValidateTemplate(metadata.Namespace); err != nil {
+				return fmt.Errorf("namespace template validation failed: %w", err)
+			}
+		} else {
+			if err := v.validateKubernetesName(metadata.Namespace); err != nil {
+				return fmt.Errorf("namespace validation failed: %w", err)
+			}
+		}
+	}
+
+	// Validate labels (no template variables allowed in keys or values for labels)
+	for key, value := range metadata.Labels {
+		if err := v.validateLabelKey(key); err != nil {
+			return fmt.Errorf("label key '%s' validation failed: %w", key, err)
+		}
+		if err := v.validateLabelValue(value); err != nil {
+			return fmt.Errorf("label value '%s' validation failed: %w", value, err)
+		}
+	}
+
+	// Validate annotations (keys must be valid, values can contain template variables)
+	for key, value := range metadata.Annotations {
+		if err := v.validateAnnotationKey(key); err != nil {
+			return fmt.Errorf("annotation key '%s' validation failed: %w", key, err)
+		}
+		// Annotation values can contain template variables, so validate as template if needed
+		if v.containsTemplateVariables(value) {
+			if err := v.ValidateTemplate(value); err != nil {
+				return fmt.Errorf("annotation value template validation failed for key '%s': %w", key, err)
+			}
+		}
+	}
+
+	return nil
+}
+
+// ValidateSpecTemplate validates the spec template structure.
+func (v *GrantTemplateValidator) ValidateSpecTemplate(ctx context.Context, spec quotav1alpha1.ResourceGrantSpec) error {
+	// Validate consumer ref template
+	if err := v.ValidateConsumerRefTemplate(spec.ConsumerRef); err != nil {
+		return fmt.Errorf("consumer ref template validation failed: %w", err)
+	}
+
+	// Validate allowances
+	if len(spec.Allowances) == 0 {
+		return fmt.Errorf("at least one allowance must be specified")
+	}
+
+	// Validate each allowance (including resource type validation)
+	for i, allowance := range spec.Allowances {
+		if allowance.ResourceType == "" {
+			return fmt.Errorf("allowance %d: resource type cannot be empty", i)
+		}
+
+		// Validate resource type against ResourceRegistrations
+		if err := v.resourceTypeValidator.ValidateResourceType(ctx, allowance.ResourceType); err != nil {
+			return fmt.Errorf("allowance %d resource type validation failed: %w", i, err)
+		}
+
+		// Validate allowance template structure
+		if err := v.ValidateAllowanceTemplate(allowance); err != nil {
+			return fmt.Errorf("allowance %d validation failed: %w", i, err)
+		}
+	}
+
+	return nil
+}
+
+// ValidateConsumerRefTemplate validates the consumer reference template.
+func (v *GrantTemplateValidator) ValidateConsumerRefTemplate(consumerRef quotav1alpha1.ConsumerRef) error {
+	// Validate APIGroup template if provided
+	if consumerRef.APIGroup != "" {
+		if v.containsTemplateVariables(consumerRef.APIGroup) {
+			if err := v.ValidateTemplate(consumerRef.APIGroup); err != nil {
+				return fmt.Errorf("apiGroup template validation failed: %w", err)
+			}
+		} else {
+			if err := v.validateAPIGroup(consumerRef.APIGroup); err != nil {
+				return fmt.Errorf("apiGroup validation failed: %w", err)
+			}
+		}
+	}
+
+	// Validate Kind template
+	if v.containsTemplateVariables(consumerRef.Kind) {
+		if err := v.ValidateTemplate(consumerRef.Kind); err != nil {
+			return fmt.Errorf("kind template validation failed: %w", err)
+		}
+	} else {
+		if err := v.validateKind(consumerRef.Kind); err != nil {
+			return fmt.Errorf("kind validation failed: %w", err)
+		}
+	}
+
+	// Validate Name (for ConsumerRef, we allow templates that start with variables since they reference existing resources)
+	if err := v.ValidateConsumerRefNameTemplate(consumerRef.Name); err != nil {
+		return fmt.Errorf("name template validation failed: %w", err)
+	}
+
+	return nil
+}
+
+// ValidateAllowanceTemplate validates an allowance template.
+func (v *GrantTemplateValidator) ValidateAllowanceTemplate(allowance quotav1alpha1.Allowance) error {
+	// Validate resource type is not empty
+	if allowance.ResourceType == "" {
+		return fmt.Errorf("resource type cannot be empty")
+	}
+
+	// Note: Resource type registration validation is handled separately by the controller
+	// through validateResourceTypes() which checks against ResourceRegistrations
+
+	// Validate buckets
+	if len(allowance.Buckets) == 0 {
+		return fmt.Errorf("at least one bucket must be specified")
+	}
+
+	for i, bucket := range allowance.Buckets {
+		if err := v.ValidateBucketTemplate(bucket); err != nil {
+			return fmt.Errorf("bucket %d validation failed: %w", i, err)
+		}
+	}
+
+	return nil
+}
+
+// ValidateBucketTemplate validates a bucket template.
+func (v *GrantTemplateValidator) ValidateBucketTemplate(bucket quotav1alpha1.Bucket) error {
+	// Validate amount (must be non-negative)
+	if bucket.Amount < 0 {
+		return fmt.Errorf("amount cannot be negative: %d", bucket.Amount)
+	}
+
+	return nil
+}
+
+// ValidateNameTemplate validates a name template.
+func (v *GrantTemplateValidator) ValidateNameTemplate(nameTemplate string) error {
+	if nameTemplate == "" {
+		return fmt.Errorf("name template cannot be empty")
+	}
+
+	// If it contains template variables, validate as template
+	if v.containsTemplateVariables(nameTemplate) {
+		if err := v.ValidateTemplate(nameTemplate); err != nil {
+			return fmt.Errorf("template validation failed: %w", err)
+		}
+	} else {
+		// If it doesn't contain template variables, validate as Kubernetes name
+		if err := v.validateKubernetesName(nameTemplate); err != nil {
+			return fmt.Errorf("Kubernetes name validation failed: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// ValidateConsumerRefNameTemplate validates a consumer reference name template.
+// This is more permissive than regular name templates since consumer refs reference existing resources.
+func (v *GrantTemplateValidator) ValidateConsumerRefNameTemplate(nameTemplate string) error {
+	if nameTemplate == "" {
+		return fmt.Errorf("name template cannot be empty")
+	}
+
+	// If it contains template variables, validate as template
+	if v.containsTemplateVariables(nameTemplate) {
+		if err := v.ValidateTemplate(nameTemplate); err != nil {
+			return fmt.Errorf("template validation failed: %w", err)
+		}
+	} else {
+		// If it doesn't contain template variables, validate as Kubernetes name
+		if err := v.validateKubernetesName(nameTemplate); err != nil {
+			return fmt.Errorf("Kubernetes name validation failed: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// ValidateTemplate validates a Go template string.
+func (v *GrantTemplateValidator) ValidateTemplate(templateStr string) error {
+	if templateStr == "" {
+		return nil
+	}
+
+	// Parse the template to check for syntax errors
+	tmpl, err := template.New("validation").Parse(templateStr)
+	if err != nil {
+		return fmt.Errorf("template syntax error: %w", err)
+	}
+
+	// Extract and validate template variables
+	variables := v.extractTemplateVariables(templateStr)
+	for _, variable := range variables {
+		if !v.validVariables[variable] {
+			validVars := v.getValidVariablesList()
+			return fmt.Errorf("invalid template variable '%s', valid variables are: %v", variable, validVars)
+		}
+	}
+
+	// Execute template with dummy data to check for runtime errors
+	dummyData := map[string]interface{}{
+		"trigger": map[string]interface{}{
+			"metadata": map[string]interface{}{
+				"name":      "test-name",
+				"namespace": "test-namespace",
+			},
+			"spec": map[string]interface{}{},
+		},
+	}
+
+	var result strings.Builder
+	err = tmpl.Execute(&result, dummyData)
+	if err != nil {
+		return fmt.Errorf("template execution error: %w", err)
+	}
+
+	return nil
+}
+
+// containsTemplateVariables checks if a string contains Go template variables.
+func (v *GrantTemplateValidator) containsTemplateVariables(str string) bool {
+	return strings.Contains(str, "{{") && strings.Contains(str, "}}")
+}
+
+// extractTemplateVariables extracts template variables from a template string.
+func (v *GrantTemplateValidator) extractTemplateVariables(templateStr string) []string {
+	// Simple extraction - looks for {{.variableName}} patterns
+	re := regexp.MustCompile(`\{\{\s*\.(\w+)`)
+	matches := re.FindAllStringSubmatch(templateStr, -1)
+
+	var variables []string
+	seen := make(map[string]bool)
+	for _, match := range matches {
+		if len(match) > 1 {
+			variable := match[1]
+			if !seen[variable] {
+				variables = append(variables, variable)
+				seen[variable] = true
+			}
+		}
+	}
+
+	return variables
+}
+
+// getValidVariablesList returns a list of valid template variables.
+func (v *GrantTemplateValidator) getValidVariablesList() []string {
+	var variables []string
+	for variable := range v.validVariables {
+		variables = append(variables, variable)
+	}
+	return variables
+}
+
+// validateKubernetesName validates a Kubernetes name.
+func (v *GrantTemplateValidator) validateKubernetesName(name string) error {
+	if len(name) == 0 {
+		return fmt.Errorf("name cannot be empty")
+	}
+	if len(name) > 253 {
+		return fmt.Errorf("name cannot be longer than 253 characters")
+	}
+
+	// Kubernetes names must be lowercase alphanumeric with hyphens
+	re := regexp.MustCompile(`^[a-z0-9]([-a-z0-9]*[a-z0-9])?$`)
+	if !re.MatchString(name) {
+		return fmt.Errorf("name must consist of lowercase alphanumeric characters or '-', and must start and end with an alphanumeric character")
+	}
+
+	return nil
+}
+
+// validateLabelKey validates a label key using official Kubernetes validation.
+func (v *GrantTemplateValidator) validateLabelKey(key string) error {
+	if len(key) == 0 {
+		return fmt.Errorf("label key cannot be empty")
+	}
+
+	// Kubernetes metadata expects labels to support the prefix/name format (e.g.,
+	// "quota.miloapis.com/auto-created")
+	if errs := validation.IsQualifiedName(key); len(errs) > 0 {
+		return fmt.Errorf("label key must be a valid qualified name: %s", strings.Join(errs, "; "))
+	}
+
+	return nil
+}
+
+// validateLabelValue validates a Kubernetes label value using official Kubernetes validation.
+func (v *GrantTemplateValidator) validateLabelValue(value string) error {
+	// Use Kubernetes official validation for label values
+	if errs := validation.IsValidLabelValue(value); len(errs) > 0 {
+		return fmt.Errorf("label value must be valid: %s", strings.Join(errs, "; "))
+	}
+
+	return nil
+}
+
+// validateAnnotationKey validates a Kubernetes annotation key.
+func (v *GrantTemplateValidator) validateAnnotationKey(key string) error {
+	// Similar to label key validation but more permissive
+	return v.validateLabelKey(key)
+}
+
+// validateAPIGroup validates a Kubernetes API group.
+func (v *GrantTemplateValidator) validateAPIGroup(apiGroup string) error {
+	if len(apiGroup) == 0 {
+		// Empty API group is valid (core group)
+		return nil
+	}
+	if len(apiGroup) > 253 {
+		return fmt.Errorf("API group cannot be longer than 253 characters")
+	}
+
+	// API groups are DNS names
+	re := regexp.MustCompile(`^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$`)
+	if !re.MatchString(apiGroup) {
+		return fmt.Errorf("API group must be a valid DNS name")
+	}
+
+	return nil
+}
+
+// validateKind validates a Kubernetes Kind.
+func (v *GrantTemplateValidator) validateKind(kind string) error {
+	if len(kind) == 0 {
+		return fmt.Errorf("kind cannot be empty")
+	}
+	if len(kind) > 63 {
+		return fmt.Errorf("kind cannot be longer than 63 characters")
+	}
+
+	re := regexp.MustCompile(`^[A-Z][a-zA-Z0-9]*$`)
+	if !re.MatchString(kind) {
+		return fmt.Errorf("kind must start with uppercase letter and contain only alphanumeric characters")
+	}
+
+	return nil
+}

--- a/internal/quota/validation/grant_template_test.go
+++ b/internal/quota/validation/grant_template_test.go
@@ -1,0 +1,323 @@
+package validation
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	quotav1alpha1 "go.miloapis.com/milo/pkg/apis/quota/v1alpha1"
+)
+
+// MockResourceTypeValidator for testing
+type MockResourceTypeValidator struct {
+	validResourceTypes map[string]bool
+}
+
+func (m *MockResourceTypeValidator) ValidateResourceType(ctx context.Context, resourceType string) error {
+	if m.validResourceTypes[resourceType] {
+		return nil
+	}
+	return fmt.Errorf("resource type '%s' is not registered", resourceType)
+}
+
+func (m *MockResourceTypeValidator) IsClaimingResourceAllowed(ctx context.Context, resourceType string, consumerRef quotav1alpha1.ConsumerRef, claimingAPIGroup, claimingKind string) (bool, []string, error) {
+	// Simple mock implementation - allow all claiming resources for valid resource types
+	if m.validResourceTypes[resourceType] {
+		return true, []string{fmt.Sprintf("%s/%s", claimingAPIGroup, claimingKind)}, nil
+	}
+	return false, nil, fmt.Errorf("resource type '%s' is not registered", resourceType)
+}
+
+func (m *MockResourceTypeValidator) IsReady() bool {
+	// Mock is always ready for testing
+	return true
+}
+
+func TestValidateLabelKey(t *testing.T) {
+	validator := NewGrantTemplateValidator(&MockResourceTypeValidator{
+		validResourceTypes: map[string]bool{
+			"test.example.com/projects": true,
+		},
+	})
+
+	tests := []struct {
+		name        string
+		key         string
+		expectError bool
+		description string
+	}{
+		{
+			name:        "valid simple key",
+			key:         "environment",
+			expectError: false,
+			description: "Simple alphanumeric label key should be valid",
+		},
+		{
+			name:        "valid key with hyphens",
+			key:         "app-name",
+			expectError: false,
+			description: "Label key with hyphens should be valid",
+		},
+		{
+			name:        "valid key with dots",
+			key:         "app.name",
+			expectError: false,
+			description: "Label key with dots should be valid",
+		},
+		{
+			name:        "valid key with underscores",
+			key:         "app_name",
+			expectError: false,
+			description: "Label key with underscores should be valid",
+		},
+		{
+			name:        "valid prefixed key with slash",
+			key:         "quota.miloapis.com/auto-created",
+			expectError: false,
+			description: "Prefixed label key with forward slash should be valid (this was the bug)",
+		},
+		{
+			name:        "valid kubernetes.io prefix",
+			key:         "kubernetes.io/arch",
+			expectError: false,
+			description: "Kubernetes.io prefixed label should be valid",
+		},
+		{
+			name:        "valid app.kubernetes.io prefix",
+			key:         "app.kubernetes.io/name",
+			expectError: false,
+			description: "app.kubernetes.io prefixed label should be valid",
+		},
+		{
+			name:        "valid prefixed key with subdomain",
+			key:         "example.com/component",
+			expectError: false,
+			description: "Prefixed label with subdomain should be valid",
+		},
+		{
+			name:        "empty key",
+			key:         "",
+			expectError: true,
+			description: "Empty label key should be invalid",
+		},
+		{
+			name:        "key starting with hyphen",
+			key:         "-invalid",
+			expectError: true,
+			description: "Label key starting with hyphen should be invalid",
+		},
+		{
+			name:        "key ending with hyphen",
+			key:         "invalid-",
+			expectError: true,
+			description: "Label key ending with hyphen should be invalid",
+		},
+		{
+			name:        "key with invalid characters",
+			key:         "invalid@key",
+			expectError: true,
+			description: "Label key with @ symbol should be invalid",
+		},
+		{
+			name:        "key too long",
+			key:         "this-is-a-very-long-label-key-that-exceeds-the-maximum-length-allowed-by-kubernetes-and-should-fail-validation",
+			expectError: true,
+			description: "Label key longer than 63 characters should be invalid",
+		},
+		{
+			name:        "key with multiple slashes",
+			key:         "invalid/multiple/slashes",
+			expectError: true,
+			description: "Label key with multiple slashes should be invalid",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validator.validateLabelKey(tt.key)
+			if tt.expectError && err == nil {
+				t.Errorf("Expected error for key '%s', but got none. %s", tt.key, tt.description)
+			}
+			if !tt.expectError && err != nil {
+				t.Errorf("Unexpected error for key '%s': %v. %s", tt.key, err, tt.description)
+			}
+		})
+	}
+}
+
+func TestValidateLabelValue(t *testing.T) {
+	validator := NewGrantTemplateValidator(&MockResourceTypeValidator{
+		validResourceTypes: map[string]bool{
+			"test.example.com/projects": true,
+		},
+	})
+
+	tests := []struct {
+		name        string
+		value       string
+		expectError bool
+		description string
+	}{
+		{
+			name:        "valid simple value",
+			value:       "production",
+			expectError: false,
+			description: "Simple alphanumeric label value should be valid",
+		},
+		{
+			name:        "valid value with hyphens",
+			value:       "my-app",
+			expectError: false,
+			description: "Label value with hyphens should be valid",
+		},
+		{
+			name:        "valid value with dots",
+			value:       "1.0.0",
+			expectError: false,
+			description: "Label value with dots should be valid",
+		},
+		{
+			name:        "valid value with underscores",
+			value:       "my_app",
+			expectError: false,
+			description: "Label value with underscores should be valid",
+		},
+		{
+			name:        "valid empty value",
+			value:       "",
+			expectError: false,
+			description: "Empty label value should be valid",
+		},
+		{
+			name:        "valid numeric value",
+			value:       "123",
+			expectError: false,
+			description: "Numeric label value should be valid",
+		},
+		{
+			name:        "valid boolean-like value",
+			value:       "true",
+			expectError: false,
+			description: "Boolean-like label value should be valid",
+		},
+		{
+			name:        "value starting with hyphen",
+			value:       "-invalid",
+			expectError: true,
+			description: "Label value starting with hyphen should be invalid",
+		},
+		{
+			name:        "value ending with hyphen",
+			value:       "invalid-",
+			expectError: true,
+			description: "Label value ending with hyphen should be invalid",
+		},
+		{
+			name:        "value with invalid characters",
+			value:       "invalid@value",
+			expectError: true,
+			description: "Label value with @ symbol should be invalid",
+		},
+		{
+			name:        "value too long",
+			value:       "this-is-a-very-long-label-value-that-exceeds-the-maximum-length-allowed-by-kubernetes-and-should-fail",
+			expectError: true,
+			description: "Label value longer than 63 characters should be invalid",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validator.validateLabelValue(tt.value)
+			if tt.expectError && err == nil {
+				t.Errorf("Expected error for value '%s', but got none. %s", tt.value, tt.description)
+			}
+			if !tt.expectError && err != nil {
+				t.Errorf("Unexpected error for value '%s': %v. %s", tt.value, err, tt.description)
+			}
+		})
+	}
+}
+
+func TestValidateMetadataTemplateLabels(t *testing.T) {
+	validator := NewGrantTemplateValidator(&MockResourceTypeValidator{
+		validResourceTypes: map[string]bool{
+			"test.example.com/projects": true,
+		},
+	})
+
+	tests := []struct {
+		name        string
+		metadata    quotav1alpha1.ObjectMetaTemplate
+		expectError bool
+		description string
+	}{
+		{
+			name: "valid labels with prefixed keys",
+			metadata: quotav1alpha1.ObjectMetaTemplate{
+				Name:      "test-grant",
+				Namespace: "test-namespace",
+				Labels: map[string]string{
+					"quota.miloapis.com/auto-created": "true",
+					"quota.miloapis.com/policy":       "test-policy",
+					"app.kubernetes.io/name":          "milo",
+					"app.kubernetes.io/component":     "quota-system",
+					"environment":                     "production",
+					"version":                         "1.0.0",
+				},
+			},
+			expectError: false,
+			description: "All production-like labels should be valid",
+		},
+		{
+			name: "invalid label key",
+			metadata: quotav1alpha1.ObjectMetaTemplate{
+				Name:      "test-grant",
+				Namespace: "test-namespace",
+				Labels: map[string]string{
+					"invalid@key": "value",
+				},
+			},
+			expectError: true,
+			description: "Label with invalid key should fail validation",
+		},
+		{
+			name: "invalid label value",
+			metadata: quotav1alpha1.ObjectMetaTemplate{
+				Name:      "test-grant",
+				Namespace: "test-namespace",
+				Labels: map[string]string{
+					"valid-key": "invalid@value",
+				},
+			},
+			expectError: true,
+			description: "Label with invalid value should fail validation",
+		},
+		{
+			name: "valid annotations with templating",
+			metadata: quotav1alpha1.ObjectMetaTemplate{
+				Name:      "test-grant",
+				Namespace: "test-namespace",
+				Annotations: map[string]string{
+					"quota.miloapis.com/description":  "Auto-generated grant for {{.trigger.metadata.name}}",
+					"quota.miloapis.com/created-by":   "grant-creation-policy",
+					"quota.miloapis.com/organization": "{{.trigger.metadata.name}}",
+				},
+			},
+			expectError: false,
+			description: "Valid annotations with template variables should be valid",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validator.ValidateMetadataTemplate(tt.metadata)
+			if tt.expectError && err == nil {
+				t.Errorf("Expected error for metadata, but got none. %s", tt.description)
+			}
+			if !tt.expectError && err != nil {
+				t.Errorf("Unexpected error for metadata: %v. %s", err, tt.description)
+			}
+		})
+	}
+}

--- a/internal/quota/validation/resourceclaim.go
+++ b/internal/quota/validation/resourceclaim.go
@@ -1,0 +1,105 @@
+package validation
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"k8s.io/client-go/dynamic"
+
+	quotav1alpha1 "go.miloapis.com/milo/pkg/apis/quota/v1alpha1"
+)
+
+// ValidationEngine provides validation capabilities for quota resources.
+type ValidationEngine interface {
+	// ValidateResourceClaimAgainstRegistrations validates that a ResourceClaim's
+	// ResourceRef is allowed to claim each of the requested resource types.
+	ValidateResourceClaimAgainstRegistrations(ctx context.Context, claim *quotav1alpha1.ResourceClaim) error
+
+	// ValidateClaimingResourcesConfiguration validates that all ClaimingResources
+	// in a ResourceRegistration are valid and that there are no duplicates.
+	ValidateClaimingResourcesConfiguration(registration *quotav1alpha1.ResourceRegistration) error
+}
+
+// validationEngine implements ValidationEngine using dynamic client for resource access
+// and ResourceTypeValidator for fast cached resource type validation.
+type validationEngine struct {
+	dynamicClient         dynamic.Interface
+	resourceTypeValidator ResourceTypeValidator
+}
+
+// NewValidationEngine creates a new validation engine with dynamic client support and
+// a required ResourceTypeValidator for optimized resource type validation.
+func NewValidationEngine(dynamicClient dynamic.Interface, resourceTypeValidator ResourceTypeValidator) ValidationEngine {
+	return &validationEngine{
+		dynamicClient:         dynamicClient,
+		resourceTypeValidator: resourceTypeValidator,
+	}
+}
+
+// ValidateResourceClaimAgainstRegistrations validates that the ResourceClaim's
+// ResourceRef is allowed to claim each of the requested resource types.
+func (e *validationEngine) ValidateResourceClaimAgainstRegistrations(ctx context.Context, claim *quotav1alpha1.ResourceClaim) error {
+	// Get the resource type that's claiming (from ResourceRef)
+	claimingResource := claim.Spec.ResourceRef
+
+	// For each request in the claim, verify it's allowed
+	for _, request := range claim.Spec.Requests {
+		// Validate that the resource type is registered and active using the cached validator
+		if err := e.resourceTypeValidator.ValidateResourceType(ctx, request.ResourceType); err != nil {
+			return err // This provides user-friendly error messages about registration
+		}
+
+		// Check if the claiming resource is allowed using the cached validator
+		allowed, allowedList, err := e.resourceTypeValidator.IsClaimingResourceAllowed(ctx, request.ResourceType, claim.Spec.ConsumerRef, claimingResource.APIGroup, claimingResource.Kind)
+		if err != nil {
+			return fmt.Errorf("failed to check claiming resource permission for %s: %w", request.ResourceType, err)
+		}
+		if !allowed {
+			// Build helpful error message
+			claimingResourceStr := claimingResource.Kind
+			if claimingResource.APIGroup != "" {
+				claimingResourceStr = fmt.Sprintf("%s/%s", claimingResource.APIGroup, claimingResource.Kind)
+			}
+
+			if len(allowedList) == 0 {
+				return fmt.Errorf("resource type %s is not allowed to claim quota for %s. No ClaimingResources configured",
+					claimingResourceStr, request.ResourceType)
+			}
+
+			return fmt.Errorf("resource type %s is not allowed to claim quota for %s. Allowed claiming resources: [%s]",
+				claimingResourceStr, request.ResourceType, strings.Join(allowedList, ", "))
+		}
+	}
+
+	return nil
+}
+
+// ValidateClaimingResourcesConfiguration validates that all ClaimingResources
+// in a ResourceRegistration are valid and that there are no duplicates.
+func (e *validationEngine) ValidateClaimingResourcesConfiguration(registration *quotav1alpha1.ResourceRegistration) error {
+	if len(registration.Spec.ClaimingResources) == 0 {
+		// Empty is valid - will use defaults
+		return nil
+	}
+
+	// Check for duplicates
+	seen := make(map[string]bool)
+	for _, cr := range registration.Spec.ClaimingResources {
+		key := fmt.Sprintf("%s/%s", cr.APIGroup, cr.Kind)
+		if seen[key] {
+			return fmt.Errorf("duplicate ClaimingResource: %s", key)
+		}
+		seen[key] = true
+	}
+
+	// Validate that ClaimingResources don't reference invalid kinds
+	for _, cr := range registration.Spec.ClaimingResources {
+		if cr.Kind == "" {
+			return fmt.Errorf("ClaimingResource must have a Kind")
+		}
+		// Additional validation could be added here (e.g., checking if the Kind exists in the cluster)
+	}
+
+	return nil
+}

--- a/internal/quota/validation/resourcetype.go
+++ b/internal/quota/validation/resourcetype.go
@@ -1,0 +1,344 @@
+package validation
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/go-logr/logr"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/tools/cache"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	quotav1alpha1 "go.miloapis.com/milo/pkg/apis/quota/v1alpha1"
+)
+
+// claimingPermissions represents the claiming rules for a specific resource type
+type claimingPermissions struct {
+	resourceType      string
+	consumerTypeRef   quotav1alpha1.ConsumerTypeRef
+	claimingResources []quotav1alpha1.ClaimingResource
+	registrationName  string // For error messages
+}
+
+// ResourceTypeValidator provides an interface for validating resource types against ResourceRegistrations.
+// The validator uses a shared informer to cache claiming permissions for fast O(1) lookups.
+type ResourceTypeValidator interface {
+	// ValidateResourceType validates a single resource type against ResourceRegistrations.
+	// Returns an error if the resource type is not registered or not active.
+	// Returns nil if the resource type is valid and active.
+	ValidateResourceType(ctx context.Context, resourceType string) error
+
+	// IsClaimingResourceAllowed checks if the given resource type is allowed to claim quota for the specified resource type.
+	// This performs a cached lookup and validates claiming permissions without exposing the method on the API type.
+	// Returns allowed status and detailed error message information for user-friendly feedback.
+	IsClaimingResourceAllowed(ctx context.Context, resourceType string, consumerRef quotav1alpha1.ConsumerRef, claimingAPIGroup, claimingKind string) (bool, []string, error)
+}
+
+// resourceTypeValidator implements ResourceTypeValidator using a shared informer for caching.
+type resourceTypeValidator struct {
+	logger        logr.Logger
+	dynamicClient dynamic.Interface
+	informer      cache.SharedIndexInformer
+
+	// Cache for fast lookups
+	cacheMutex sync.RWMutex
+	cache      map[string]*claimingPermissions // resourceType -> claiming permissions
+}
+
+// NewResourceTypeValidator creates a new ResourceTypeValidator with async initialization.
+// This is the recommended approach as it prevents blocking during startup.
+// The validator will return immediately and sync in the background.
+func NewResourceTypeValidator(dynamicClient dynamic.Interface) ResourceTypeValidator {
+	logger := log.Log.WithName("resource-type-validator")
+	logger.Info("Creating ResourceTypeValidator with delayed start")
+
+	validator := &resourceTypeValidator{
+		logger:        logger,
+		dynamicClient: dynamicClient,
+		informer:      nil, // Will be initialized later
+		cache:         make(map[string]*claimingPermissions),
+	}
+
+	// Start initialization in background with infinite retry
+	go func() {
+		attempt := 0
+
+		logger.Info("Starting ResourceTypeValidator initialization with infinite retry")
+
+		for {
+			attempt++
+			logger.V(1).Info("Attempting to initialize ResourceTypeValidator informer", "attempt", attempt)
+
+			if err := validator.tryInitializeInformer(); err != nil {
+				logger.Error(err, "Failed to initialize ResourceTypeValidator informer, will retry", "attempt", attempt)
+
+				// Calculate exponential backoff delay with cap
+				delay := time.Duration(attempt) * 5 * time.Second
+				if delay > 30*time.Second {
+					delay = 30 * time.Second
+				}
+
+				logger.V(1).Info("Waiting before retry", "delay", delay, "attempt", attempt)
+				time.Sleep(delay)
+				continue
+			}
+
+			// Success! Stop retrying
+			logger.Info("ResourceTypeValidator cache synced successfully", "attempt", attempt)
+			break
+		}
+	}()
+
+	logger.Info("ResourceTypeValidator created, will initialize when API server is ready")
+	return validator
+}
+
+// tryInitializeInformer attempts to create and sync the informer, returning an error if it fails
+func (v *resourceTypeValidator) tryInitializeInformer() error {
+	// Create shared informer for ResourceRegistrations
+	gvr := schema.GroupVersionResource{
+		Group:    quotav1alpha1.GroupVersion.Group,
+		Version:  quotav1alpha1.GroupVersion.Version,
+		Resource: "resourceregistrations",
+	}
+
+	// Create ListWatch for the informer
+	lw := &cache.ListWatch{
+		ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
+			return v.dynamicClient.Resource(gvr).List(context.Background(), options)
+		},
+		WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+			return v.dynamicClient.Resource(gvr).Watch(context.Background(), options)
+		},
+	}
+
+	// Create shared informer with 10 minute resync period
+	informer := cache.NewSharedIndexInformer(
+		lw,
+		&unstructured.Unstructured{},
+		10*time.Minute,
+		cache.Indexers{
+			"resourceType": func(obj interface{}) ([]string, error) {
+				if unstrObj, ok := obj.(*unstructured.Unstructured); ok {
+					resourceType, found, err := unstructured.NestedString(unstrObj.Object, "spec", "resourceType")
+					if err != nil {
+						return nil, fmt.Errorf("failed to extract resource type: %w", err)
+					} else if !found {
+						return nil, fmt.Errorf("failed to extract resourceType from ResourceRegistration")
+					}
+					return []string{resourceType}, nil
+				}
+				return nil, fmt.Errorf("object is not an unstructured object")
+			},
+		},
+	)
+
+	// Add event handlers to maintain cache
+	if _, err := informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    v.onResourceRegistrationAdd,
+		UpdateFunc: v.onResourceRegistrationUpdate,
+		DeleteFunc: v.onResourceRegistrationDelete,
+	}); err != nil {
+		return fmt.Errorf("failed to add event handler: %w", err)
+	}
+
+	// Set the informer (this makes the validator functional)
+	v.cacheMutex.Lock()
+	v.informer = informer
+	v.cacheMutex.Unlock()
+
+	// Start the informer
+	informerStopCh := make(chan struct{})
+	go informer.Run(informerStopCh)
+
+	// Wait for sync with timeout
+	syncCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	syncDone := make(chan bool, 1)
+	go func() {
+		syncDone <- cache.WaitForCacheSync(informerStopCh, informer.HasSynced)
+	}()
+
+	select {
+	case <-syncCtx.Done():
+		close(informerStopCh)
+		return fmt.Errorf("timeout waiting for cache sync")
+	case synced := <-syncDone:
+		if !synced {
+			close(informerStopCh)
+			return fmt.Errorf("failed to sync cache")
+		}
+	}
+
+	// Success - informer is running and synced
+	return nil
+}
+
+// ValidateResourceType validates using the cached data.
+// The cache only contains active ResourceRegistrations, so this is a simple lookup.
+// Returns an error if the validator is not ready or if the resource type is not registered.
+func (v *resourceTypeValidator) ValidateResourceType(ctx context.Context, resourceType string) error {
+	v.cacheMutex.RLock()
+	defer v.cacheMutex.RUnlock()
+
+	_, exists := v.cache[resourceType]
+	if !exists {
+		//lint:ignore ST1005 "Error message intentionally capitalized for user-facing display"
+		return fmt.Errorf("Resource type '%s' is not available for quota management. Enable quota tracking for this resource type by registering it with the quota system", resourceType)
+	}
+
+	return nil
+}
+
+// IsClaimingResourceAllowed checks if the given resource type is allowed to claim quota for the specified resource type.
+func (v *resourceTypeValidator) IsClaimingResourceAllowed(ctx context.Context, resourceType string, consumerRef quotav1alpha1.ConsumerRef, claimingAPIGroup, claimingKind string) (bool, []string, error) {
+	v.cacheMutex.RLock()
+	defer v.cacheMutex.RUnlock()
+
+	permissions, exists := v.cache[resourceType]
+	if !exists {
+		return false, nil, fmt.Errorf("no ResourceRegistration found for resource type %s", resourceType)
+	}
+
+	// Verify this registration is for the correct consumer type
+	if permissions.consumerTypeRef.APIGroup != consumerRef.APIGroup ||
+		permissions.consumerTypeRef.Kind != consumerRef.Kind {
+		return false, nil, fmt.Errorf("consumer type mismatch for resource type %s: expected %s/%s, got %s/%s",
+			resourceType,
+			consumerRef.APIGroup, consumerRef.Kind,
+			permissions.consumerTypeRef.APIGroup, permissions.consumerTypeRef.Kind)
+	}
+
+	// Check claiming permissions
+	if len(permissions.claimingResources) == 0 {
+		// When not specified, deny by default for security
+		return false, nil, nil // No allowed resources configured
+	}
+
+	// Build allowed list for error messages
+	var allowedList []string
+	for _, allowedResource := range permissions.claimingResources {
+		if allowedResource.APIGroup == "" {
+			allowedList = append(allowedList, fmt.Sprintf("core/%s", allowedResource.Kind))
+		} else {
+			allowedList = append(allowedList, fmt.Sprintf("%s/%s", allowedResource.APIGroup, allowedResource.Kind))
+		}
+
+		// Check if this claiming resource is allowed
+		if allowedResource.APIGroup == claimingAPIGroup &&
+			strings.EqualFold(allowedResource.Kind, claimingKind) {
+			return true, allowedList, nil // Match found
+		}
+	}
+
+	return false, allowedList, nil // Not allowed
+}
+
+// Event handlers for cache maintenance
+func (v *resourceTypeValidator) onResourceRegistrationAdd(obj interface{}) {
+	reg := v.convertToResourceRegistration(obj)
+	if reg == nil {
+		v.logger.Error(nil, "Received invalid object in Add handler")
+		return
+	}
+
+	v.updateCacheForRegistration(reg)
+}
+
+func (v *resourceTypeValidator) onResourceRegistrationUpdate(oldObj, newObj interface{}) {
+	reg := v.convertToResourceRegistration(newObj)
+	if reg == nil {
+		v.logger.Error(nil, "Received invalid object in Update handler")
+		return
+	}
+
+	v.updateCacheForRegistration(reg)
+}
+
+func (v *resourceTypeValidator) onResourceRegistrationDelete(obj interface{}) {
+	reg := v.convertToResourceRegistration(obj)
+	if reg == nil {
+		// Handle DeletedFinalStateUnknown
+		if tombstone, ok := obj.(cache.DeletedFinalStateUnknown); ok {
+			reg = v.convertToResourceRegistration(tombstone.Obj)
+			if reg == nil {
+				v.logger.Error(nil, "Received invalid object in Delete handler tombstone")
+				return
+			}
+		} else {
+			v.logger.Error(nil, "Received invalid object in Delete handler")
+			return
+		}
+	}
+
+	v.cacheMutex.Lock()
+	delete(v.cache, reg.Spec.ResourceType)
+	v.cacheMutex.Unlock()
+
+	v.logger.V(1).Info("Removed ResourceRegistration from cache", "resourceType", reg.Spec.ResourceType)
+}
+
+// convertToResourceRegistration converts an unstructured object to a ResourceRegistration
+func (v *resourceTypeValidator) convertToResourceRegistration(obj interface{}) *quotav1alpha1.ResourceRegistration {
+	unstrObj, ok := obj.(*unstructured.Unstructured)
+	if !ok {
+		return nil
+	}
+
+	var reg quotav1alpha1.ResourceRegistration
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(unstrObj.Object, &reg); err != nil {
+		v.logger.Error(err, "Failed to convert unstructured object to ResourceRegistration")
+		return nil
+	}
+
+	return &reg
+}
+
+// updateCacheForRegistration updates the cache based on ResourceRegistration status.
+// Only active ResourceRegistrations are kept in the cache for fast validation.
+func (v *resourceTypeValidator) updateCacheForRegistration(reg *quotav1alpha1.ResourceRegistration) {
+	resourceType := reg.Spec.ResourceType
+
+	// Check if the ResourceRegistration is active
+	activeCondition := apimeta.FindStatusCondition(reg.Status.Conditions, quotav1alpha1.ResourceRegistrationActive)
+	isActive := activeCondition != nil && activeCondition.Status == metav1.ConditionTrue
+
+	v.cacheMutex.Lock()
+	defer v.cacheMutex.Unlock()
+
+	if isActive {
+		// Create claiming permissions from registration
+		permissions := &claimingPermissions{
+			resourceType:      resourceType,
+			consumerTypeRef:   reg.Spec.ConsumerTypeRef,
+			claimingResources: make([]quotav1alpha1.ClaimingResource, len(reg.Spec.ClaimingResources)),
+			registrationName:  reg.Name,
+		}
+		copy(permissions.claimingResources, reg.Spec.ClaimingResources)
+
+		// Add/update active registration in cache
+		v.cache[resourceType] = permissions
+		v.logger.V(1).Info("Updated active ResourceRegistration in cache",
+			"resourceType", resourceType,
+			"consumerType", fmt.Sprintf("%s/%s", reg.Spec.ConsumerTypeRef.APIGroup, reg.Spec.ConsumerTypeRef.Kind))
+	} else {
+		// Remove inactive registration from cache
+		if _, exists := v.cache[resourceType]; exists {
+			delete(v.cache, resourceType)
+			v.logger.V(1).Info("Removed inactive ResourceRegistration from cache",
+				"resourceType", resourceType,
+				"consumerType", fmt.Sprintf("%s/%s", reg.Spec.ConsumerTypeRef.APIGroup, reg.Spec.ConsumerTypeRef.Kind),
+				"reason", "not active")
+		}
+	}
+}


### PR DESCRIPTION
Introduces a new validation package that can be used to validate quota API resources. This includes a new resource type validator that uses an informer to maintain a cache of valid resource type configurations that can be used in resource claims.