### PR TITLE
feat: add notification group to audit policy configuration

### DIFF
--- a/config/components/apiserver-audit-logging/audit-policy-configmap.yaml
+++ b/config/components/apiserver-audit-logging/audit-policy-configmap.yaml
@@ -149,6 +149,7 @@ data:
         - group: "iam.miloapis.com"
         - group: "infrastructure.miloapis.com"
         - group: "quota.miloapis.com"
+        - group: "notification.miloapis.com"
 
       # Log core Kubernetes API resources at RequestResponse level
       - level: RequestResponse


### PR DESCRIPTION
This update introduces a new rule in the audit policy configuration to include the "notification.miloapis.com" group, enhancing the auditing capabilities for notifications within the system.

Closes https://github.com/datum-cloud/enhancements/issues/306