### PR TITLE
feat: 429 retries

### DIFF
--- a/config/ingress/gateway-api/httproute.yaml
+++ b/config/ingress/gateway-api/httproute.yaml
@@ -8,27 +8,15 @@ spec:
     namespace: envoy-gateway-system
 
   rules:
-  # 1) Retry on 429s so that project storage initialization has time to complete
   - matches:
     - path:
         type: PathPrefix
         value: /
-      method: GET
     backendRefs:
     - name: milo-apiserver
       port: 6443
       kind: Service
-    retry:
+    retry: # Retry on 429s so that project storage initialization has time to complete
       codes: [429]
       attempts: 5
       backoff: 300ms
-
-  # 2) everything else (no retries)
-  - matches:
-    - path:
-        type: PathPrefix
-        value: /
-    backendRefs:
-    - name: milo-apiserver
-      port: 6443
-      kind: Service


### PR DESCRIPTION
This pull request updates the HTTP routing configuration to introduce request retries for any requests, improving resilience for specific API calls. 

Routing and retry configuration:

* Added a new rule to `config/ingress/gateway-api/httproute.yaml` that matches any requests to any path and routes them to the `milo-apiserver` service on port 6443, with retry logic for HTTP 429 responses (up to 5 attempts, 300ms backoff).