### PR TITLE
Add new organization and  project roles

### DIFF
--- a/config/roles/iam-viewer.yaml
+++ b/config/roles/iam-viewer.yaml
@@ -1,7 +1,7 @@
 apiVersion: iam.miloapis.com/v1alpha1
 kind: Role
 metadata:
-  name: iam-reader
+  name: iam-viewer
 spec:
   launchStage: Beta
   includedPermissions:

--- a/config/roles/organization-admin.yaml
+++ b/config/roles/organization-admin.yaml
@@ -1,0 +1,17 @@
+apiVersion: iam.miloapis.com/v1alpha1
+kind: Role
+metadata:
+  name: resourcemanager.miloapis.com/organization-admin
+  annotations:
+    kubernetes.io/display-name: Organization Admin
+    kubernetes.io/description: "Full access to all organization and organization membership resources"
+spec:
+  launchStage: Beta
+  inheritedRoles:
+    - name: organizationmembership-admin
+    - name: organization-viewer
+  includedPermissions:
+    - resourcemanager.miloapis.com/organizations.create
+    - resourcemanager.miloapis.com/organizations.update
+    - resourcemanager.miloapis.com/organizations.patch
+    - resourcemanager.miloapis.com/organizations.delete

--- a/config/roles/organization-viewer.yaml
+++ b/config/roles/organization-viewer.yaml
@@ -1,0 +1,15 @@
+apiVersion: iam.miloapis.com/v1alpha1
+kind: Role
+metadata:
+  name: resourcemanager.miloapis.com/organization-viewer
+  annotations:
+    kubernetes.io/display-name: Organization Viewer
+    kubernetes.io/description: "View access to all organization and organization membership resources"
+spec:
+  launchStage: Beta
+  inheritedRoles:
+    - name: organizationmembership-reader
+  includedPermissions:
+    - resourcemanager.miloapis.com/organizations.get
+    - resourcemanager.miloapis.com/organizations.list
+    - resourcemanager.miloapis.com/organizations.watch

--- a/config/roles/project-admin.yaml
+++ b/config/roles/project-admin.yaml
@@ -1,0 +1,16 @@
+apiVersion: iam.miloapis.com/v1alpha1
+kind: Role
+metadata:
+  name: resourcemanager.miloapis.com/project-admin
+  annotations:
+    kubernetes.io/display-name: Project Admin
+    kubernetes.io/description: "Full access to all project resources"
+spec:
+  launchStage: Beta
+  inheritedRoles:
+    - name: project-viewer
+  includedPermissions:
+    - resourcemanager.miloapis.com/projects.create
+    - resourcemanager.miloapis.com/projects.update
+    - resourcemanager.miloapis.com/projects.patch
+    - resourcemanager.miloapis.com/projects.delete

--- a/config/roles/project-viewer.yaml
+++ b/config/roles/project-viewer.yaml
@@ -1,0 +1,13 @@
+apiVersion: iam.miloapis.com/v1alpha1
+kind: Role
+metadata:
+  name: resourcemanager.miloapis.com/project-viewer
+  annotations:
+    kubernetes.io/display-name: Project Viewer
+    kubernetes.io/description: "View access to all project resources"
+spec:
+  launchStage: Beta
+  includedPermissions:
+    - resourcemanager.miloapis.com/projects.get
+    - resourcemanager.miloapis.com/projects.list
+    - resourcemanager.miloapis.com/projects.watch


### PR DESCRIPTION
This PR added the next roles:

1. **Organization Admin**: Full access to all organization and organization membership resources.
2. **Organization Viewer**: View access to all organization and organization membership resources.
3. **Project Admin**: Full access to all project resources.
4. **Project Viewer**: View access to all project resources.

Each role includes specific permissions and inherited roles to facilitate resource management.

Related to https://github.com/datum-cloud/enhancements/issues/365