### PR TITLE
Add EmailBroadcast ProtectedResource manifest

### DIFF
--- a/config/protected-resources/notification/emailbroadcast.yaml
+++ b/config/protected-resources/notification/emailbroadcast.yaml
@@ -1,0 +1,18 @@
+apiVersion: iam.miloapis.com/v1alpha1
+kind: ProtectedResource
+metadata:
+  name: notification.miloapis.com-emailbroadcast
+spec:
+  serviceRef:
+    name: "notification.miloapis.com"
+  kind: EmailBroadcast
+  plural: emailbroadcasts
+  singular: emailbroadcast
+  permissions:
+    - list
+    - get
+    - create
+    - update
+    - delete
+    - patch
+    - watch


### PR DESCRIPTION
This commit introduces a new ProtectedResource manifest for EmailBroadcast, defining its permissions and service reference. The manifest allows for the management of email broadcast resources within the IAM framework, enabling operations such as list, get, create, update, delete, patch, and watch.