### PR TITLE
Add selectable fields for GroupMembership CRD

### DIFF
--- a/config/crd/bases/iam/iam.miloapis.com_groupmemberships.yaml
+++ b/config/crd/bases/iam/iam.miloapis.com_groupmemberships.yaml
@@ -145,6 +145,9 @@ spec:
                 type: array
             type: object
         type: object
+    selectableFields:
+    - jsonPath: .spec.groupRef.name
+    - jsonPath: .spec.userRef.name
     served: true
     storage: true
     subresources:

--- a/pkg/apis/iam/v1alpha1/groupmembership_types.go
+++ b/pkg/apis/iam/v1alpha1/groupmembership_types.go
@@ -52,7 +52,8 @@ type GroupMembershipStatus struct {
 // +kubebuilder:printcolumn:name="Group",type="string",JSONPath=".spec.groupRef.name"
 // +kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.conditions[?(@.type=='Ready')].status"
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
-
+// +kubebuilder:selectablefield:JSONPath=".spec.groupRef.name"
+// +kubebuilder:selectablefield:JSONPath=".spec.userRef.name"
 // GroupMembership is the Schema for the groupmemberships API
 type GroupMembership struct {
 	metav1.TypeMeta   `json:",inline"`


### PR DESCRIPTION
This commit introduces selectable fields for the GroupMembership Custom Resource Definition (CRD) by adding JSONPath references for `groupRef.name` and `userRef.name`. This enhancement allows for improved querying capabilities within the IAM framework.