### PR TITLE
feat: remove CEL validations on resource ref

### DIFF
--- a/config/crd/bases/quota/quota.miloapis.com_claimcreationpolicies.yaml
+++ b/config/crd/bases/quota/quota.miloapis.com_claimcreationpolicies.yaml
@@ -413,6 +413,7 @@ spec:
                               - resourceType
                               type: object
                             maxItems: 20
+                            minItems: 1
                             type: array
                           resourceRef:
                             description: |-
@@ -481,6 +482,10 @@ spec:
                     - metadata
                     - spec
                     type: object
+                    x-kubernetes-validations:
+                    - message: resourceRef field is automatically populated and cannot
+                        be set in template
+                      rule: '!has(self.spec.resourceRef)'
                 required:
                 - resourceClaimTemplate
                 type: object

--- a/config/crd/bases/quota/quota.miloapis.com_resourceclaims.yaml
+++ b/config/crd/bases/quota/quota.miloapis.com_resourceclaims.yaml
@@ -259,6 +259,7 @@ spec:
                   - resourceType
                   type: object
                 maxItems: 20
+                minItems: 1
                 type: array
               resourceRef:
                 description: |-
@@ -361,6 +362,7 @@ spec:
                         Set to the requested amount when Status=Granted, 0 when Status=Denied or
                         Pending.
                       format: int64
+                      minimum: 0
                       type: integer
                     allocatingBucket:
                       description: |-
@@ -399,6 +401,7 @@ spec:
                         ResourceType identifies which resource request this allocation status
                         describes. Must exactly match one of the resourceType values in
                         spec.requests.
+                      minLength: 1
                       type: string
                     status:
                       description: |-

--- a/config/crd/bases/quota/quota.miloapis.com_resourceregistrations.yaml
+++ b/config/crd/bases/quota/quota.miloapis.com_resourceregistrations.yaml
@@ -111,6 +111,7 @@ spec:
                   - "byte" (for storage or memory)
                   - "user" (for Entity type tracking Users)
                 maxLength: 50
+                minLength: 1
                 type: string
               claimingResources:
                 description: |-
@@ -206,6 +207,7 @@ spec:
                   - "Projects created within Organizations"
                   - "CPU millicores allocated to workloads"
                   - "Storage bytes claimed by volume requests"
+                maxLength: 500
                 minLength: 1
                 type: string
               displayUnit:
@@ -219,6 +221,7 @@ spec:
                   - "GiB" (for displaying memory/storage instead of bytes)
                   - "TB" (for large storage volumes)
                 maxLength: 50
+                minLength: 1
                 type: string
               resourceType:
                 description: |-

--- a/docs/api/quota.md
+++ b/docs/api/quota.md
@@ -792,6 +792,8 @@ Target defines how and where **ResourceClaims** should be created.
         <td>
           ResourceClaimTemplate defines how to create **ResourceClaims**.
 String fields support CEL expressions for dynamic content.<br/>
+          <br/>
+            <i>Validations</i>:<li>!has(self.spec.resourceRef): resourceRef field is automatically populated and cannot be set in template</li>
         </td>
         <td>true</td>
       </tr></tbody>
@@ -2980,6 +2982,7 @@ Set to the requested amount when Status=Granted, 0 when Status=Denied or
 Pending.<br/>
           <br/>
             <i>Format</i>: int64<br/>
+            <i>Minimum</i>: 0<br/>
         </td>
         <td>false</td>
       </tr><tr>

--- a/pkg/apis/quota/v1alpha1/claimcreationpolicy_types.go
+++ b/pkg/apis/quota/v1alpha1/claimcreationpolicy_types.go
@@ -62,7 +62,8 @@ type ClaimTargetSpec struct {
 }
 
 // ResourceClaimTemplate defines how to create **ResourceClaims** using actual **ResourceClaim** structure.
-// The resourceRef field is automatically populated by the admission controller and should not be included in templates.
+//
+// +kubebuilder:validation:XValidation:rule="!has(self.spec.resourceRef)",message="resourceRef field is automatically populated and cannot be set in template"
 type ResourceClaimTemplate struct {
 	// Metadata for the created **ResourceClaim**.
 	// String fields support CEL expressions.

--- a/pkg/apis/quota/v1alpha1/resourceclaim_types.go
+++ b/pkg/apis/quota/v1alpha1/resourceclaim_types.go
@@ -67,7 +67,8 @@ type ResourceClaimSpec struct {
 	// The system processes all requests as a single atomic operation: either all
 	// requests are granted or all are denied.
 	//
-	// +kubebuilder:validation:Required +kubebuilder:validation:MinItems=1
+	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:MinItems=1
 	// +kubebuilder:validation:MaxItems=20
 	Requests []ResourceRequest `json:"requests"`
 
@@ -84,7 +85,6 @@ type ResourceClaimSpec struct {
 	//   - Project resource triggering Project quota claim
 	//   - User resource triggering User quota claim
 	//   - Organization resource triggering storage quota claim
-	//
 	ResourceRef UnversionedObjectReference `json:"resourceRef,omitempty"`
 }
 
@@ -96,7 +96,8 @@ type ResourceClaimAllocationStatus struct {
 	// describes. Must exactly match one of the resourceType values in
 	// spec.requests.
 	//
-	// +kubebuilder:validation:Required +kubebuilder:validation:MinLength=1
+	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:MinLength=1
 	ResourceType string `json:"resourceType"`
 
 	// Status indicates the allocation result for this specific resource request.
@@ -138,7 +139,8 @@ type ResourceClaimAllocationStatus struct {
 	// Set to the requested amount when Status=Granted, 0 when Status=Denied or
 	// Pending.
 	//
-	// +kubebuilder:validation:Optional +kubebuilder:validation:Minimum=0
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:validation:Minimum=0
 	AllocatedAmount int64 `json:"allocatedAmount,omitempty"`
 
 	// AllocatingBucket identifies the AllowanceBucket that provided the quota for

--- a/pkg/apis/quota/v1alpha1/resourceregistration_types.go
+++ b/pkg/apis/quota/v1alpha1/resourceregistration_types.go
@@ -90,7 +90,8 @@ type ResourceRegistrationSpec struct {
 	// - "CPU millicores allocated to workloads"
 	// - "Storage bytes claimed by volume requests"
 	//
-	// +kubebuilder:validation:Optional +kubebuilder:validation:MaxLength=500
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:validation:MaxLength=500
 	// +kubebuilder:validation:MinLength=1
 	Description string `json:"description,omitempty"`
 
@@ -104,7 +105,8 @@ type ResourceRegistrationSpec struct {
 	// - "byte" (for storage or memory)
 	// - "user" (for Entity type tracking Users)
 	//
-	// +kubebuilder:validation:Required +kubebuilder:validation:MinLength=1
+	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=50
 	BaseUnit string `json:"baseUnit"`
 
@@ -117,7 +119,8 @@ type ResourceRegistrationSpec struct {
 	// - "GiB" (for displaying memory/storage instead of bytes)
 	// - "TB" (for large storage volumes)
 	//
-	// +kubebuilder:validation:Required +kubebuilder:validation:MinLength=1
+	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=50
 	DisplayUnit string `json:"displayUnit"`
 


### PR DESCRIPTION
The resource ref is also used by the claim creation policy type leading to conflicts between validation the claim creation policy was doing and the resource claim type was doing. This validation is being moved to the admission plugin where additional resource claim validation is being performed. See https://github.com/datum-cloud/milo/pull/310/commits/d368cc2150c25ff17153a2a6b29fa63abc403806 for the admission plugin validation. 

This builds on changes in #283 