### PR TITLE
Enhance Contact validation webhook to avoid duplicates

### DIFF
--- a/internal/webhooks/notification/v1alpha1/contact_webhook_test.go
+++ b/internal/webhooks/notification/v1alpha1/contact_webhook_test.go
@@ -376,3 +376,56 @@ func TestContactValidator_ValidateCreate(t *testing.T) {
 		})
 	}
 }
+
+func TestContactValidator_ValidateUpdate_Duplicate(t *testing.T) {
+	// Seed two contacts under same subject
+	contactA := &notificationv1alpha1.Contact{
+		ObjectMeta: metav1.ObjectMeta{Name: "contact-a"},
+		Spec: notificationv1alpha1.ContactSpec{
+			GivenName:  "A",
+			FamilyName: "User",
+			Email:      "a@example.com",
+			SubjectRef: &notificationv1alpha1.SubjectReference{
+				APIGroup: "iam.miloapis.com",
+				Kind:     "User",
+				Name:     "test-user",
+			},
+		},
+	}
+
+	contactBOriginal := &notificationv1alpha1.Contact{
+		ObjectMeta: metav1.ObjectMeta{Name: "contact-b"},
+		Spec: notificationv1alpha1.ContactSpec{
+			GivenName:  "B",
+			FamilyName: "User",
+			Email:      "b@example.com",
+			SubjectRef: &notificationv1alpha1.SubjectReference{
+				APIGroup: "iam.miloapis.com",
+				Kind:     "User",
+				Name:     "test-user",
+			},
+		},
+	}
+
+	// New version of contactB with duplicate email
+	contactBUpdated := contactBOriginal.DeepCopy()
+	contactBUpdated.Spec.Email = "a@example.com"
+
+	// User resource so validation passes user existence
+	user := &iamv1alpha1.User{ObjectMeta: metav1.ObjectMeta{Name: "test-user"}, Spec: iamv1alpha1.UserSpec{Email: "user@example.com"}}
+
+	// Build fake client with index
+	builder := fake.NewClientBuilder().WithScheme(runtimeScheme).WithObjects(user, contactA, contactBOriginal)
+	builder = builder.WithIndex(&notificationv1alpha1.Contact{}, contactSpecKey, func(obj client.Object) []string {
+		c := obj.(*notificationv1alpha1.Contact)
+		return []string{buildContactSpecKey(*c)}
+	})
+	fakeClient := builder.Build()
+
+	validator := &ContactValidator{Client: fakeClient}
+
+	_, err := validator.ValidateUpdate(context.Background(), contactBOriginal, contactBUpdated)
+
+	assert.Error(t, err, "expected duplicate validation error on update")
+	assert.Contains(t, strings.ToLower(err.Error()), "already has this subject and email")
+}


### PR DESCRIPTION
This PR adds functionality to validate the creation of contacts by checking for duplicates based on both subject reference and email.  This prevents duplicates for Contacts that lives in the same `contact.namespace`. 

It introduces a composite index for contact specifications, allowing for efficient querying of existing contacts.

The changes include new test cases to ensure the validation logic works as expected.