### PR TITLE
refactor: remove Kubernetes native ResourceQuota system

### DIFF
--- a/cmd/milo/apiserver/config.go
+++ b/cmd/milo/apiserver/config.go
@@ -159,6 +159,7 @@ func NewConfig(opts options.CompletedOptions) (*Config, error) {
 
 	apiResourceConfigSource := controlplane.DefaultAPIResourceConfigSource()
 	apiResourceConfigSource.DisableResources(corev1.SchemeGroupVersion.WithResource("serviceaccounts"))
+	apiResourceConfigSource.DisableResources(corev1.SchemeGroupVersion.WithResource("resourcequotas"))
 	// Enable identity group/version served by virtual storage
 	apiResourceConfigSource.EnableVersions(identityopenapi.SchemeGroupVersion)
 

--- a/cmd/milo/controller-manager/controllermanager.go
+++ b/cmd/milo/controller-manager/controllermanager.go
@@ -216,7 +216,6 @@ func NewCommand() *cobra.Command {
 	// s.CSRSigningController.AddFlags(fss.FlagSet(names.CertificateSigningRequestSigningController))
 	s.GarbageCollectorController.AddFlags(namedFlagSets.FlagSet(names.GarbageCollectorController))
 	s.NamespaceController.AddFlags(namedFlagSets.FlagSet(names.NamespaceController))
-	s.ResourceQuotaController.AddFlags(namedFlagSets.FlagSet(names.ResourceQuotaController))
 	s.ValidatingAdmissionPolicyStatusController.AddFlags(namedFlagSets.FlagSet(names.ValidatingAdmissionPolicyStatusController))
 	s.Metrics.AddFlags(namedFlagSets.FlagSet("metrics"))
 	logsapi.AddFlags(s.Logs, namedFlagSets.FlagSet("logs"))
@@ -824,7 +823,6 @@ func NewControllerDescriptors() map[string]*ControllerDescriptor {
 
 	register(newNamespaceControllerDescriptor())
 	register(newGarbageCollectorControllerDescriptor())
-	register(newResourceQuotaControllerDescriptor())
 	// register(newCertificateSigningRequestSigningControllerDescriptor())
 	// register(newCertificateSigningRequestApprovingControllerDescriptor())
 	// register(newCertificateSigningRequestCleanerControllerDescriptor())


### PR DESCRIPTION
### Summary

Remove the native Kubernetes ResourceQuota controller and API in favor of Milo's custom quota system. 

Changes:
- Remove `ResourceQuota` controller implementation and registration
- Disable `/api/v1/resourcequotas` API endpoint
- Remove controller flags and unused imports

Refer to #322 for more information on the new quota system available with Milo. 

### Stacked Pull Requests

- **Previous**: #316 

---

Closes https://github.com/datum-cloud/milo/issues/166