### PR TITLE
Change inherited role from 'iam-reader' to 'iam-viewer'

### DIFF
--- a/config/roles/iam-editor.yaml
+++ b/config/roles/iam-editor.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   launchStage: Beta
   inheritedRoles:
-    - name: iam-reader
+    - name: iam-viewer
   includedPermissions:
     - iam.miloapis.com/groups.create
     - iam.miloapis.com/groups.update


### PR DESCRIPTION
This PR fix a wrong reference name, as the `iam-reader` role has been updated to `iam-viewer`