### PR TITLE
feat: Add selectable fields for ContactGroupMembership CRD

### DIFF
--- a/config/crd/bases/notification/notification.miloapis.com_contactgroupmemberships.yaml
+++ b/config/crd/bases/notification/notification.miloapis.com_contactgroupmemberships.yaml
@@ -165,6 +165,9 @@ spec:
                 type: string
             type: object
         type: object
+    selectableFields:
+    - jsonPath: .spec.contactRef.name
+    - jsonPath: .spec.contactGroupRef.name
     served: true
     storage: true
     subresources:

--- a/pkg/apis/notification/v1alpha1/contactgroupmembership.go
+++ b/pkg/apis/notification/v1alpha1/contactgroupmembership.go
@@ -49,6 +49,8 @@ const (
 // +kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.conditions[?(@.type=='Ready')].status"
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 // +kubebuilder:resource:scope=Namespaced
+// +kubebuilder:selectablefield:JSONPath=".spec.contactRef.name"
+// +kubebuilder:selectablefield:JSONPath=".spec.contactGroupRef.name"
 type ContactGroupMembership struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`


### PR DESCRIPTION
This PR adds new field selectors to the `ContactGroupMembership` CRD in order to allow filter capabilities by `spec.contactRef.name` and `spec.contactGroupRef.name`.

Request by front team.