### PR TITLE
feat: skip API state validation with dry-run requests

### DIFF
--- a/internal/quota/admission/plugin.go
+++ b/internal/quota/admission/plugin.go
@@ -1001,17 +1001,19 @@ func (p *ResourceQuotaEnforcementPlugin) validateClaimCreationPolicy(ctx context
 	span.SetAttributes(
 		attribute.String("policy.name", policy.Name),
 		attribute.String("policy.namespace", policy.Namespace),
+		attribute.Bool("dry_run", attrs.IsDryRun()),
 	)
 
-	// Validate the ClaimCreationPolicy
-	if validationErrs := p.claimCreationPolicyValidator.Validate(ctx, policy); len(validationErrs) > 0 {
+	validationOpts := validation.ValidationOptions{DryRun: attrs.IsDryRun()}
+	if validationErrs := p.claimCreationPolicyValidator.Validate(ctx, policy, validationOpts); len(validationErrs) > 0 {
 		span.SetAttributes(attribute.String("validation.status", "failed"))
 		span.SetStatus(codes.Error, "ClaimCreationPolicy validation failed")
 
 		p.logger.Info("ClaimCreationPolicy validation failed",
 			"name", policy.Name,
 			"namespace", policy.Namespace,
-			"errors", validationErrs)
+			"errors", validationErrs,
+			"dryRun", attrs.IsDryRun())
 
 		return admission.NewForbidden(attrs, errors.NewInvalid(
 			quotav1alpha1.GroupVersion.WithKind("ClaimCreationPolicy").GroupKind(),
@@ -1061,17 +1063,19 @@ func (p *ResourceQuotaEnforcementPlugin) validateGrantCreationPolicy(ctx context
 	span.SetAttributes(
 		attribute.String("policy.name", policy.Name),
 		attribute.String("policy.namespace", policy.Namespace),
+		attribute.Bool("dry_run", attrs.IsDryRun()),
 	)
 
-	// Validate the GrantCreationPolicy
-	if validationErrs := p.grantCreationPolicyValidator.Validate(ctx, policy); len(validationErrs) > 0 {
+	validationOpts := validation.ValidationOptions{DryRun: attrs.IsDryRun()}
+	if validationErrs := p.grantCreationPolicyValidator.Validate(ctx, policy, validationOpts); len(validationErrs) > 0 {
 		span.SetAttributes(attribute.String("validation.status", "failed"))
 		span.SetStatus(codes.Error, "GrantCreationPolicy validation failed")
 
 		p.logger.Info("GrantCreationPolicy validation failed",
 			"name", policy.Name,
 			"namespace", policy.Namespace,
-			"errors", validationErrs)
+			"errors", validationErrs,
+			"dryRun", attrs.IsDryRun())
 
 		return admission.NewForbidden(attrs, errors.NewInvalid(
 			quotav1alpha1.GroupVersion.WithKind("GrantCreationPolicy").GroupKind(),
@@ -1122,17 +1126,19 @@ func (p *ResourceQuotaEnforcementPlugin) validateResourceGrant(ctx context.Conte
 		attribute.String("grant.name", grant.Name),
 		attribute.String("grant.namespace", grant.Namespace),
 		attribute.Int("grant.allowances_count", len(grant.Spec.Allowances)),
+		attribute.Bool("dry_run", attrs.IsDryRun()),
 	)
 
-	// Validate the ResourceGrant
-	if validationErrs := p.resourceGrantValidator.Validate(ctx, grant); len(validationErrs) > 0 {
+	validationOpts := validation.ValidationOptions{DryRun: attrs.IsDryRun()}
+	if validationErrs := p.resourceGrantValidator.Validate(ctx, grant, validationOpts); len(validationErrs) > 0 {
 		span.SetAttributes(attribute.String("validation.status", "failed"))
 		span.SetStatus(codes.Error, "ResourceGrant validation failed")
 
 		p.logger.Info("ResourceGrant validation failed",
 			"name", grant.Name,
 			"namespace", grant.Namespace,
-			"errors", validationErrs)
+			"errors", validationErrs,
+			"dryRun", attrs.IsDryRun())
 
 		return admission.NewForbidden(attrs, errors.NewInvalid(
 			quotav1alpha1.GroupVersion.WithKind("ResourceGrant").GroupKind(),

--- a/internal/quota/controllers/core/grant.go
+++ b/internal/quota/controllers/core/grant.go
@@ -75,8 +75,7 @@ func (r *ResourceGrantController) updateResourceGrantStatus(ctx context.Context,
 	// Always update the observed generation in the status to match the current generation of the spec.
 	grant.Status.ObservedGeneration = grant.Generation
 
-	// Validate the ResourceGrant
-	if validationErrs := r.GrantValidator.Validate(ctx, grant); len(validationErrs) > 0 {
+	if validationErrs := r.GrantValidator.Validate(ctx, grant, validation.DefaultValidationOptions()); len(validationErrs) > 0 {
 		logger.Info("ResourceGrant validation failed", "errors", validationErrs.ToAggregate())
 		return r.setValidationFailedCondition(ctx, clusterClient, grant, validationErrs.ToAggregate())
 	}

--- a/internal/quota/controllers/policy/claim_creation.go
+++ b/internal/quota/controllers/policy/claim_creation.go
@@ -74,8 +74,7 @@ func (r *ClaimCreationPolicyReconciler) Reconcile(ctx context.Context, req mcrec
 	// Store original status to detect changes
 	originalStatus := policy.Status.DeepCopy()
 
-	// Validate the policy
-	validationErrs := r.PolicyValidator.Validate(ctx, &policy)
+	validationErrs := r.PolicyValidator.Validate(ctx, &policy, validation.DefaultValidationOptions())
 
 	// Update policy status based on validation results
 	r.updatePolicyStatus(&policy, validationErrs)

--- a/internal/quota/controllers/policy/grant_creation.go
+++ b/internal/quota/controllers/policy/grant_creation.go
@@ -72,8 +72,7 @@ func (r *GrantCreationPolicyReconciler) Reconcile(ctx context.Context, req mcrec
 	// Store original status to detect changes
 	originalStatus := policy.Status.DeepCopy()
 
-	// Validate the policy
-	validationErrs := r.PolicyValidator.Validate(ctx, &policy)
+	validationErrs := r.PolicyValidator.Validate(ctx, &policy, validation.DefaultValidationOptions())
 
 	// Update policy status based on validation results
 	r.updatePolicyStatus(&policy, validationErrs)

--- a/internal/quota/validation/claim_creation_policy.go
+++ b/internal/quota/validation/claim_creation_policy.go
@@ -20,8 +20,8 @@ func NewClaimCreationPolicyValidator(resourceTypeValidator ResourceTypeValidator
 	}
 }
 
-// Validate performs complete validation of a ClaimCreationPolicy.
-func (v *ClaimCreationPolicyValidator) Validate(ctx context.Context, policy *quotav1alpha1.ClaimCreationPolicy) field.ErrorList {
+// Validate validates a ClaimCreationPolicy.
+func (v *ClaimCreationPolicyValidator) Validate(ctx context.Context, policy *quotav1alpha1.ClaimCreationPolicy, opts ValidationOptions) field.ErrorList {
 	var allErrs field.ErrorList
 
 	templatePath := field.NewPath("spec", "target", "resourceClaimTemplate")
@@ -36,8 +36,11 @@ func (v *ClaimCreationPolicyValidator) Validate(ctx context.Context, policy *quo
 		}
 	}
 
-	if errs := v.validateResourceTypes(ctx, policy); len(errs) > 0 {
-		allErrs = append(allErrs, errs...)
+	// Skip resource type validation during dry-run because it queries API server state
+	if !opts.DryRun {
+		if errs := v.validateResourceTypes(ctx, policy); len(errs) > 0 {
+			allErrs = append(allErrs, errs...)
+		}
 	}
 
 	return allErrs

--- a/internal/quota/validation/grant_creation_policy.go
+++ b/internal/quota/validation/grant_creation_policy.go
@@ -24,9 +24,9 @@ func NewGrantCreationPolicyValidator(
 	}
 }
 
-// Validate performs complete validation of a GrantCreationPolicy including CEL expressions,
+// Validate validates a GrantCreationPolicy including CEL expressions,
 // parent context configuration, and grant template structure.
-func (v *GrantCreationPolicyValidator) Validate(ctx context.Context, policy *quotav1alpha1.GrantCreationPolicy) field.ErrorList {
+func (v *GrantCreationPolicyValidator) Validate(ctx context.Context, policy *quotav1alpha1.GrantCreationPolicy, opts ValidationOptions) field.ErrorList {
 	var allErrs field.ErrorList
 
 	if err := v.CELValidator.ValidateConstraints(policy.Spec.Trigger.Constraints); err != nil {
@@ -48,7 +48,7 @@ func (v *GrantCreationPolicyValidator) Validate(ctx context.Context, policy *quo
 	}
 
 	templatePath := field.NewPath("spec", "target", "resourceGrantTemplate")
-	if errs := v.TemplateValidator.ValidateGrantTemplate(ctx, policy.Spec.Target.ResourceGrantTemplate); len(errs) > 0 {
+	if errs := v.TemplateValidator.ValidateGrantTemplate(ctx, policy.Spec.Target.ResourceGrantTemplate, opts); len(errs) > 0 {
 		for _, err := range errs {
 			allErrs = append(allErrs, &field.Error{
 				Type:     err.Type,

--- a/internal/quota/validation/grant_template_test.go
+++ b/internal/quota/validation/grant_template_test.go
@@ -500,7 +500,7 @@ func TestGrantTemplateValidator_ValidateGrantTemplate(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			errs := validator.ValidateGrantTemplate(context.Background(), tt.template)
+			errs := validator.ValidateGrantTemplate(context.Background(), tt.template, DefaultValidationOptions())
 			if tt.expectError && len(errs) == 0 {
 				t.Errorf("Expected error for template, but got none. %s", tt.description)
 			}

--- a/internal/quota/validation/options.go
+++ b/internal/quota/validation/options.go
@@ -1,0 +1,42 @@
+package validation
+
+// ValidationOptions configures validation behavior.
+type ValidationOptions struct {
+	// DryRun, when true, skips validations that query API server state.
+	// Set DryRun to true when validating resources during dry-run operations,
+	// such as GitOps workflows where multiple resources are applied together
+	// and may not exist yet in the API server.
+	//
+	// When DryRun is true, validators perform:
+	// - Syntax validation (CEL expressions, template syntax)
+	// - Structural validation (required fields, mutual exclusivity)
+	// - Static schema validation
+	//
+	// When DryRun is true, validators skip:
+	// - Resource type existence checks against ResourceRegistrations
+	// - Cross-resource reference validation
+	// - Any validation requiring API server queries
+	//
+	// Use DryRun=true for:
+	// - Flux/ArgoCD server-side apply with --dry-run
+	// - kubectl apply --dry-run=server
+	// - Admission webhooks handling dry-run requests
+	DryRun bool
+}
+
+// DefaultValidationOptions returns options for full validation.
+// Controllers use DefaultValidationOptions to perform complete validation,
+// including API state checks.
+func DefaultValidationOptions() ValidationOptions {
+	return ValidationOptions{
+		DryRun: false,
+	}
+}
+
+// DryRunValidationOptions returns options for dry-run validation.
+// Admission webhooks use DryRunValidationOptions when handling dry-run requests.
+func DryRunValidationOptions() ValidationOptions {
+	return ValidationOptions{
+		DryRun: true,
+	}
+}

--- a/internal/quota/validation/resource_grant.go
+++ b/internal/quota/validation/resource_grant.go
@@ -20,22 +20,26 @@ func NewResourceGrantValidator(resourceTypeValidator ResourceTypeValidator) *Res
 }
 
 // Validate validates that all resource types in the grant's allowances correspond
-// to active ResourceRegistrations. Deduplicates resource types to avoid redundant validation.
-func (v *ResourceGrantValidator) Validate(ctx context.Context, grant *quotav1alpha1.ResourceGrant) field.ErrorList {
+// to active ResourceRegistrations. This method deduplicates resource types to avoid
+// redundant validation calls.
+func (v *ResourceGrantValidator) Validate(ctx context.Context, grant *quotav1alpha1.ResourceGrant, opts ValidationOptions) field.ErrorList {
 	var allErrs field.ErrorList
 	allowancesPath := field.NewPath("spec", "allowances")
 	seen := make(map[string]bool)
 
-	for i, allowance := range grant.Spec.Allowances {
-		resourceType := allowance.ResourceType
-		if !seen[resourceType] {
-			seen[resourceType] = true
-			if err := v.ResourceTypeValidator.ValidateResourceType(ctx, resourceType); err != nil {
-				allErrs = append(allErrs, field.Invalid(
-					allowancesPath.Index(i).Child("resourceType"),
-					resourceType,
-					err.Error(),
-				))
+	// Skip resource type validation during dry-run because it queries API server state
+	if !opts.DryRun {
+		for i, allowance := range grant.Spec.Allowances {
+			resourceType := allowance.ResourceType
+			if !seen[resourceType] {
+				seen[resourceType] = true
+				if err := v.ResourceTypeValidator.ValidateResourceType(ctx, resourceType); err != nil {
+					allErrs = append(allErrs, field.Invalid(
+						allowancesPath.Index(i).Child("resourceType"),
+						resourceType,
+						err.Error(),
+					))
+				}
 			}
 		}
 	}


### PR DESCRIPTION
### Summary

This PR modifies the validation the quota system performs on its resources to prevent validating resources based on API state when a dry-run request is being performed. This helps enable GitOps workflows where ClaimCreationPolicies and ResourceRegistrations are applied together in the same Flux kustomization.

### Problem

Flux performs server-side dry-run operations to validate resources before applying them. When a ClaimCreationPolicy references a ResourceRegistration that doesn't exist yet (because they're being applied together), validation fails because the validator queries the API server for the ResourceRegistration.

This prevents using a single Flux kustomization to deploy both a ResourceRegistration and policies that depend on it.

### Solution

Introduce `ValidationOptions` struct with a `DryRun` field. When `DryRun=true`, validators skip checks that rely on API state while still performing syntax and structural validation.
