### PR TITLE
chore: only validate with API state in controllers

### DIFF
--- a/internal/quota/admission/plugin.go
+++ b/internal/quota/admission/plugin.go
@@ -1001,19 +1001,16 @@ func (p *ResourceQuotaEnforcementPlugin) validateClaimCreationPolicy(ctx context
 	span.SetAttributes(
 		attribute.String("policy.name", policy.Name),
 		attribute.String("policy.namespace", policy.Namespace),
-		attribute.Bool("dry_run", attrs.IsDryRun()),
 	)
 
-	validationOpts := validation.ValidationOptions{DryRun: attrs.IsDryRun()}
-	if validationErrs := p.claimCreationPolicyValidator.Validate(ctx, policy, validationOpts); len(validationErrs) > 0 {
+	if validationErrs := p.claimCreationPolicyValidator.Validate(ctx, policy, validation.AdmissionValidationOptions()); len(validationErrs) > 0 {
 		span.SetAttributes(attribute.String("validation.status", "failed"))
 		span.SetStatus(codes.Error, "ClaimCreationPolicy validation failed")
 
 		p.logger.Info("ClaimCreationPolicy validation failed",
 			"name", policy.Name,
 			"namespace", policy.Namespace,
-			"errors", validationErrs,
-			"dryRun", attrs.IsDryRun())
+			"errors", validationErrs)
 
 		return admission.NewForbidden(attrs, errors.NewInvalid(
 			quotav1alpha1.GroupVersion.WithKind("ClaimCreationPolicy").GroupKind(),
@@ -1063,19 +1060,16 @@ func (p *ResourceQuotaEnforcementPlugin) validateGrantCreationPolicy(ctx context
 	span.SetAttributes(
 		attribute.String("policy.name", policy.Name),
 		attribute.String("policy.namespace", policy.Namespace),
-		attribute.Bool("dry_run", attrs.IsDryRun()),
 	)
 
-	validationOpts := validation.ValidationOptions{DryRun: attrs.IsDryRun()}
-	if validationErrs := p.grantCreationPolicyValidator.Validate(ctx, policy, validationOpts); len(validationErrs) > 0 {
+	if validationErrs := p.grantCreationPolicyValidator.Validate(ctx, policy, validation.AdmissionValidationOptions()); len(validationErrs) > 0 {
 		span.SetAttributes(attribute.String("validation.status", "failed"))
 		span.SetStatus(codes.Error, "GrantCreationPolicy validation failed")
 
 		p.logger.Info("GrantCreationPolicy validation failed",
 			"name", policy.Name,
 			"namespace", policy.Namespace,
-			"errors", validationErrs,
-			"dryRun", attrs.IsDryRun())
+			"errors", validationErrs)
 
 		return admission.NewForbidden(attrs, errors.NewInvalid(
 			quotav1alpha1.GroupVersion.WithKind("GrantCreationPolicy").GroupKind(),
@@ -1126,19 +1120,16 @@ func (p *ResourceQuotaEnforcementPlugin) validateResourceGrant(ctx context.Conte
 		attribute.String("grant.name", grant.Name),
 		attribute.String("grant.namespace", grant.Namespace),
 		attribute.Int("grant.allowances_count", len(grant.Spec.Allowances)),
-		attribute.Bool("dry_run", attrs.IsDryRun()),
 	)
 
-	validationOpts := validation.ValidationOptions{DryRun: attrs.IsDryRun()}
-	if validationErrs := p.resourceGrantValidator.Validate(ctx, grant, validationOpts); len(validationErrs) > 0 {
+	if validationErrs := p.resourceGrantValidator.Validate(ctx, grant, validation.AdmissionValidationOptions()); len(validationErrs) > 0 {
 		span.SetAttributes(attribute.String("validation.status", "failed"))
 		span.SetStatus(codes.Error, "ResourceGrant validation failed")
 
 		p.logger.Info("ResourceGrant validation failed",
 			"name", grant.Name,
 			"namespace", grant.Namespace,
-			"errors", validationErrs,
-			"dryRun", attrs.IsDryRun())
+			"errors", validationErrs)
 
 		return admission.NewForbidden(attrs, errors.NewInvalid(
 			quotav1alpha1.GroupVersion.WithKind("ResourceGrant").GroupKind(),

--- a/internal/quota/controllers/core/grant.go
+++ b/internal/quota/controllers/core/grant.go
@@ -75,7 +75,7 @@ func (r *ResourceGrantController) updateResourceGrantStatus(ctx context.Context,
 	// Always update the observed generation in the status to match the current generation of the spec.
 	grant.Status.ObservedGeneration = grant.Generation
 
-	if validationErrs := r.GrantValidator.Validate(ctx, grant, validation.DefaultValidationOptions()); len(validationErrs) > 0 {
+	if validationErrs := r.GrantValidator.Validate(ctx, grant, validation.ControllerValidationOptions()); len(validationErrs) > 0 {
 		logger.Info("ResourceGrant validation failed", "errors", validationErrs.ToAggregate())
 		return r.setValidationFailedCondition(ctx, clusterClient, grant, validationErrs.ToAggregate())
 	}

--- a/internal/quota/controllers/policy/claim_creation.go
+++ b/internal/quota/controllers/policy/claim_creation.go
@@ -74,7 +74,7 @@ func (r *ClaimCreationPolicyReconciler) Reconcile(ctx context.Context, req mcrec
 	// Store original status to detect changes
 	originalStatus := policy.Status.DeepCopy()
 
-	validationErrs := r.PolicyValidator.Validate(ctx, &policy, validation.DefaultValidationOptions())
+	validationErrs := r.PolicyValidator.Validate(ctx, &policy, validation.ControllerValidationOptions())
 
 	// Update policy status based on validation results
 	r.updatePolicyStatus(&policy, validationErrs)

--- a/internal/quota/controllers/policy/grant_creation.go
+++ b/internal/quota/controllers/policy/grant_creation.go
@@ -72,7 +72,7 @@ func (r *GrantCreationPolicyReconciler) Reconcile(ctx context.Context, req mcrec
 	// Store original status to detect changes
 	originalStatus := policy.Status.DeepCopy()
 
-	validationErrs := r.PolicyValidator.Validate(ctx, &policy, validation.DefaultValidationOptions())
+	validationErrs := r.PolicyValidator.Validate(ctx, &policy, validation.ControllerValidationOptions())
 
 	// Update policy status based on validation results
 	r.updatePolicyStatus(&policy, validationErrs)

--- a/internal/quota/validation/claim_creation_policy.go
+++ b/internal/quota/validation/claim_creation_policy.go
@@ -36,8 +36,8 @@ func (v *ClaimCreationPolicyValidator) Validate(ctx context.Context, policy *quo
 		}
 	}
 
-	// Skip resource type validation during dry-run because it queries API server state
-	if !opts.DryRun {
+	// Skip resource type validation when configured because it queries API server state
+	if !opts.SkipAPIStateValidation {
 		if errs := v.validateResourceTypes(ctx, policy); len(errs) > 0 {
 			allErrs = append(allErrs, errs...)
 		}

--- a/internal/quota/validation/grant_template.go
+++ b/internal/quota/validation/grant_template.go
@@ -87,8 +87,8 @@ func (v *GrantTemplateValidator) ValidateSpecTemplate(ctx context.Context, spec 
 		allErrs = append(allErrs, errs...)
 	}
 
-	// Skip resource type validation during dry-run because it queries API server state
-	if !opts.DryRun {
+	// Skip resource type validation when configured because it queries API server state
+	if !opts.SkipAPIStateValidation {
 		for i, allowance := range spec.Allowances {
 			ifldPath := fldPath.Child("allowances").Index(i)
 

--- a/internal/quota/validation/grant_template_test.go
+++ b/internal/quota/validation/grant_template_test.go
@@ -500,7 +500,7 @@ func TestGrantTemplateValidator_ValidateGrantTemplate(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			errs := validator.ValidateGrantTemplate(context.Background(), tt.template, DefaultValidationOptions())
+			errs := validator.ValidateGrantTemplate(context.Background(), tt.template, ControllerValidationOptions())
 			if tt.expectError && len(errs) == 0 {
 				t.Errorf("Expected error for template, but got none. %s", tt.description)
 			}

--- a/internal/quota/validation/options.go
+++ b/internal/quota/validation/options.go
@@ -2,41 +2,36 @@ package validation
 
 // ValidationOptions configures validation behavior.
 type ValidationOptions struct {
-	// DryRun, when true, skips validations that query API server state.
-	// Set DryRun to true when validating resources during dry-run operations,
-	// such as GitOps workflows where multiple resources are applied together
-	// and may not exist yet in the API server.
+	// SkipAPIStateValidation, when true, skips validations that query API server state.
 	//
-	// When DryRun is true, validators perform:
+	// When SkipAPIStateValidation is true, validators perform:
 	// - Syntax validation (CEL expressions, template syntax)
 	// - Structural validation (required fields, mutual exclusivity)
 	// - Static schema validation
 	//
-	// When DryRun is true, validators skip:
+	// When SkipAPIStateValidation is true, validators skip:
 	// - Resource type existence checks against ResourceRegistrations
 	// - Cross-resource reference validation
 	// - Any validation requiring API server queries
 	//
-	// Use DryRun=true for:
-	// - Flux/ArgoCD server-side apply with --dry-run
-	// - kubectl apply --dry-run=server
-	// - Admission webhooks handling dry-run requests
-	DryRun bool
+	// Admission webhooks always skip API state validation because they validate
+	// incoming requests without querying API state. Controllers perform full
+	// validation including API state checks.
+	SkipAPIStateValidation bool
 }
 
-// DefaultValidationOptions returns options for full validation.
-// Controllers use DefaultValidationOptions to perform complete validation,
-// including API state checks.
-func DefaultValidationOptions() ValidationOptions {
+// AdmissionValidationOptions returns options for admission webhook validation.
+// Admission webhooks validate request syntax and structure without querying API state.
+func AdmissionValidationOptions() ValidationOptions {
 	return ValidationOptions{
-		DryRun: false,
+		SkipAPIStateValidation: true,
 	}
 }
 
-// DryRunValidationOptions returns options for dry-run validation.
-// Admission webhooks use DryRunValidationOptions when handling dry-run requests.
-func DryRunValidationOptions() ValidationOptions {
+// ControllerValidationOptions returns options for controller validation.
+// Controllers perform full validation including API state checks.
+func ControllerValidationOptions() ValidationOptions {
 	return ValidationOptions{
-		DryRun: true,
+		SkipAPIStateValidation: false,
 	}
 }

--- a/internal/quota/validation/resource_grant.go
+++ b/internal/quota/validation/resource_grant.go
@@ -27,8 +27,8 @@ func (v *ResourceGrantValidator) Validate(ctx context.Context, grant *quotav1alp
 	allowancesPath := field.NewPath("spec", "allowances")
 	seen := make(map[string]bool)
 
-	// Skip resource type validation during dry-run because it queries API server state
-	if !opts.DryRun {
+	// Skip resource type validation when configured because it queries API server state
+	if !opts.SkipAPIStateValidation {
 		for i, allowance := range grant.Spec.Allowances {
 			resourceType := allowance.ResourceType
 			if !seen[resourceType] {


### PR DESCRIPTION
### Summary

This is a follow-up to #359 to only perform validation against API state in controllers allowing resources to be registered with the system and be activated once resources have been registered. This is a common practice in Kubernetes where the system is eventually consistent as resources are created. 

