### PR TITLE
bugfix: update quota tests for async validation

### DIFF
--- a/test/quota/enforcement-edge-cases/README.md
+++ b/test/quota/enforcement-edge-cases/README.md
@@ -18,7 +18,7 @@ This test verifies:
 | 3 | [setup-quota-enforcement-organization](#step-setup-quota-enforcement-organization) | 0 | 2 | 0 | 0 | 0 |
 | 4 | [create-limited-resource-grant](#step-create-limited-resource-grant) | 0 | 2 | 0 | 0 | 0 |
 | 5 | [test-boundary-conditions](#step-test-boundary-conditions) | 0 | 2 | 0 | 0 | 0 |
-| 6 | [test-policy-validation](#step-test-policy-validation) | 0 | 1 | 0 | 0 | 0 |
+| 6 | [test-policy-validation](#step-test-policy-validation) | 0 | 3 | 0 | 0 | 0 |
 
 ### Step: `setup-base-infrastructure`
 
@@ -84,14 +84,17 @@ Zero and negative amounts should be prevented by API validation.
 ### Step: `test-policy-validation`
 
 Test that ClaimCreationPolicy validation catches invalid configurations.
-Policies referencing non-existent resources should be rejected at admission time.
+Policies referencing non-existent resources are allowed at admission time
+but marked as not Ready by the controller with validation errors.
 
 
 #### Try
 
 | # | Operation | Bindings | Outputs | Description |
 |:-:|---|:-:|:-:|---|
-| 1 | `create` | 0 | 0 | Attempt to create policy with missing resource reference (should fail) |
+| 1 | `apply` | 0 | 0 | Create policy with missing resource reference (allowed at admission) |
+| 2 | `assert` | 0 | 0 | Wait for policy to be processed and marked invalid |
+| 3 | `assert` | 0 | 0 | Verify policy is not Ready due to validation failure |
 
 ---
 

--- a/test/quota/enforcement-edge-cases/chainsaw-test.yaml
+++ b/test/quota/enforcement-edge-cases/chainsaw-test.yaml
@@ -123,12 +123,24 @@ spec:
     - name: test-policy-validation
       description: |
         Test that ClaimCreationPolicy validation catches invalid configurations.
-        Policies referencing non-existent resources should be rejected at admission time.
+        Policies referencing non-existent resources are allowed at admission time
+        but marked as not Ready by the controller with validation errors.
       try:
-        - description: Attempt to create policy with missing resource reference (should fail)
-          create:
+        - description: Create policy with missing resource reference (allowed at admission)
+          apply:
             file: test-data/invalid-policy-missing-resource.yaml
-            expect:
-              - check:
-                  ($error != null): true
+        - description: Wait for policy to be processed and marked invalid
+          assert:
+            file: test-data/invalid-policy-missing-resource.yaml
+        - description: Verify policy is not Ready due to validation failure
+          assert:
+            resource:
+              apiVersion: quota.miloapis.com/v1alpha1
+              kind: ClaimCreationPolicy
+              metadata:
+                name: test-invalid-missing-resource-policy
+              status:
+                (conditions[?type == 'Ready']):
+                - status: "False"
+                  reason: "ValidationFailed"
 


### PR DESCRIPTION
Resource type validation in claim / grant policies is now handled by the controllers instead of the admission plugin so resources dont need to be created in a specific order. This PR updates the end to end tests accordingly. 

See #360 for details. 