### PR TITLE
feat: add email address to inviter user in user invitation

### DIFF
--- a/config/crd/bases/iam/iam.miloapis.com_userinvitations.yaml
+++ b/config/crd/bases/iam/iam.miloapis.com_userinvitations.yaml
@@ -220,6 +220,10 @@ spec:
                     description: DisplayName is the display name of the user who invited
                       the user in the invitation.
                     type: string
+                  emailAddress:
+                    description: EmailAddress is the email address of the user who
+                      invited the user in the invitation.
+                    type: string
                 type: object
               organization:
                 description: Organization contains information about the organization

--- a/docs/api/iam.md
+++ b/docs/api/iam.md
@@ -2473,6 +2473,13 @@ InviterUser contains information about the user who invited the user in the invi
           DisplayName is the display name of the user who invited the user in the invitation.<br/>
         </td>
         <td>false</td>
+      </tr><tr>
+        <td><b>emailAddress</b></td>
+        <td>string</td>
+        <td>
+          EmailAddress is the email address of the user who invited the user in the invitation.<br/>
+        </td>
+        <td>false</td>
       </tr></tbody>
 </table>
 

--- a/internal/controllers/iam/userinvitation_controller_test.go
+++ b/internal/controllers/iam/userinvitation_controller_test.go
@@ -662,6 +662,10 @@ func TestUserInvitationController_Reconcile_StateTransitionCreatesBindings(t *te
 	if afterFirst.Status.InviterUser.DisplayName != "John Doe" {
 		t.Fatalf("expected inviter user display name to be John Doe, got %s", afterFirst.Status.InviterUser.DisplayName)
 	}
+	// Verify inviter user email address is set
+	if afterFirst.Status.InviterUser.EmailAddress != "inviter@example.com" {
+		t.Fatalf("expected inviter user email address to be inviter@example.com, got %s", afterFirst.Status.InviterUser.EmailAddress)
+	}
 
 	// Ensure organization role PolicyBinding does NOT exist yet
 	orgRoleRef := ui.Spec.Roles[0]

--- a/pkg/apis/iam/v1alpha1/userinvitation_types.go
+++ b/pkg/apis/iam/v1alpha1/userinvitation_types.go
@@ -120,6 +120,10 @@ type UserInvitationUserStatus struct {
 	// DisplayName is the display name of the user who invited the user in the invitation.
 	// +kubebuilder:validation:Optional
 	DisplayName string `json:"displayName,omitempty"`
+
+	// EmailAddress is the email address of the user who invited the user in the invitation.
+	// +kubebuilder:validation:Optional
+	EmailAddress string `json:"emailAddress,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object


### PR DESCRIPTION
This PR was created as a request to provide more information about the user who created an User Invitation.
https://github.com/datum-cloud/enhancements/issues/282#issuecomment-3444277231

This commit enhances the UserInvitation resource by adding an optional email address field for the user who invited another user. The changes include updates to the CRD, API documentation, controller logic, and associated tests to ensure the new field is correctly handled and validated.