### PR TITLE
Add IAM roles for user invitation management

### DIFF
--- a/config/roles/iam.miloapis.com-acceptinvitation.yaml
+++ b/config/roles/iam.miloapis.com-acceptinvitation.yaml
@@ -1,0 +1,9 @@
+apiVersion: iam.miloapis.com/v1alpha1
+kind: Role
+metadata:
+  name: iam.miloapis.com-acceptinvitation
+spec:
+  launchStage: Beta
+  includedPermissions:
+  - iam.miloapis.com/userinvitations.update
+  - iam.miloapis.com/userinvitations.patch

--- a/config/roles/iam.miloapis.com-getinvitation.yaml
+++ b/config/roles/iam.miloapis.com-getinvitation.yaml
@@ -1,0 +1,10 @@
+apiVersion: iam.miloapis.com/v1alpha1
+kind: Role
+metadata:
+  name: iam.miloapis.com-getinvitation
+spec:
+  launchStage: Beta
+  includedPermissions:
+  - iam.miloapis.com/userinvitations.get
+  - iam.miloapis.com/userinvitations.list
+  - iam.miloapis.com/userinvitations.watch

--- a/config/roles/kustomization.yaml
+++ b/config/roles/kustomization.yaml
@@ -50,3 +50,5 @@ resources:
   - organization-admin.yaml
   - project-viewer.yaml
   - project-admin.yaml
+  - iam.miloapis.com-getinvitation.yaml
+  - iam.miloapis.com-acceptinvitation.yaml


### PR DESCRIPTION
This PR was created because of the error reported here https://github.com/datum-cloud/enhancements/issues/282#issuecomment-3444328264

In which users where not able to get their user invitations.

The error was caused by the absence of the IAM roles into the `iam-system`.

Please see the next reconciliation errors as a reference:

```
  - lastTransitionTime: "2025-10-24T18:08:09Z"
    message: 'role ''iam.miloapis.com-getinvitation'' not found: Role.iam.miloapis.com
      "iam.miloapis.com-getinvitation" not found'
    reason: RoleNotFoundForBinding
    status: "False"
    type: RoleValid
  - lastTransitionTime: "2025-10-24T18:08:09Z"
    message: 'Failed to create authorization binding: role ''iam.miloapis.com-getinvitation''
      not found: Role.iam.miloapis.com "iam.miloapis.com-getinvitation" not found'
    reason: RoleNotFoundForBinding
    status: "False"
    type: Ready
  observedGeneration: 1
```

This commit introduces two new IAM roles: `iam.miloapis.com-acceptinvitation` and `iam.miloapis.com-getinvitation`. The `acceptinvitation` role includes permissions for updating and patching user invitations, while the `getinvitation` role allows for retrieving and listing user invitations. These roles are added to the kustomization file for deployment.