### PR TITLE
Add annotations to IAM roles for better clarity

### DIFF
--- a/config/roles/iam-admin.yaml
+++ b/config/roles/iam-admin.yaml
@@ -2,6 +2,9 @@ apiVersion: iam.miloapis.com/v1alpha1
 kind: Role
 metadata:
   name: iam-admin
+  annotations:
+    kubernetes.io/display-name: IAM Admin
+    kubernetes.io/description: "Full access to all IAM resources"
 spec:
   launchStage: Beta
   inheritedRoles:

--- a/config/roles/iam-editor.yaml
+++ b/config/roles/iam-editor.yaml
@@ -2,6 +2,9 @@ apiVersion: iam.miloapis.com/v1alpha1
 kind: Role
 metadata:
   name: iam-editor
+  annotations:
+    kubernetes.io/display-name: IAM Editor
+    kubernetes.io/description: "Edit IAM resources"
 spec:
   launchStage: Beta
   inheritedRoles:

--- a/config/roles/iam-viewer.yaml
+++ b/config/roles/iam-viewer.yaml
@@ -2,6 +2,9 @@ apiVersion: iam.miloapis.com/v1alpha1
 kind: Role
 metadata:
   name: iam-viewer
+  annotations:
+    kubernetes.io/display-name: IAM Viewer
+    kubernetes.io/description: "View IAM resources"
 spec:
   launchStage: Beta
   includedPermissions:

--- a/config/roles/organizationmembership-admin.yaml
+++ b/config/roles/organizationmembership-admin.yaml
@@ -2,6 +2,9 @@ apiVersion: iam.miloapis.com/v1alpha1
 kind: Role
 metadata:
   name: organizationmembership-admin
+  annotations:
+    kubernetes.io/display-name: Organization Membership Admin
+    kubernetes.io/description: "Full access to all organization membership resources"
 spec:
   launchStage: Beta
   inheritedRoles:

--- a/config/roles/organizationmembership-editor.yaml
+++ b/config/roles/organizationmembership-editor.yaml
@@ -2,6 +2,9 @@ apiVersion: iam.miloapis.com/v1alpha1
 kind: Role
 metadata:
   name: organizationmembership-editor
+  annotations:
+    kubernetes.io/display-name: Organization Membership Editor
+    kubernetes.io/description: "Edit organization membership resources"
 spec:
   launchStage: Beta
   inheritedRoles:

--- a/config/roles/organizationmembership-reader.yaml
+++ b/config/roles/organizationmembership-reader.yaml
@@ -2,6 +2,9 @@ apiVersion: iam.miloapis.com/v1alpha1
 kind: Role
 metadata:
   name: organizationmembership-reader
+  annotations:
+    kubernetes.io/display-name: Organization Membership Reader
+    kubernetes.io/description: "View organization membership resources"
 spec:
   launchStage: Beta
   includedPermissions:


### PR DESCRIPTION
This commit adds display names and descriptions to the IAM roles, enhancing their metadata for improved clarity and usability. The updated roles include `iam-admin`, `iam-editor`, `iam-viewer`, `organizationmembership-admin`, `organizationmembership-editor`, and `organizationmembership-reader`.

This PR has been create as a part of this task: https://github.com/datum-cloud/milo/issues/361#issuecomment-3444647092