### PR TITLE
feat: Add viewer role and enhance owner role

### DIFF
--- a/config/roles/kustomization.yaml
+++ b/config/roles/kustomization.yaml
@@ -52,3 +52,4 @@ resources:
   - project-admin.yaml
   - iam.miloapis.com-getinvitation.yaml
   - iam.miloapis.com-acceptinvitation.yaml
+  - viewer.yaml

--- a/config/roles/owner.yaml
+++ b/config/roles/owner.yaml
@@ -2,9 +2,17 @@ apiVersion: iam.miloapis.com/v1alpha1
 kind: Role
 metadata:
   name: owner
+  annotations:
+    kubernetes.io/display-name: Owner
+    kubernetes.io/description: "Full access to all resources"
 spec:
   launchStage: Beta
   inheritedRoles:
     - name: resourcemanager-admin
     - name: core-admin
     - name: apiextensions-reader
+    - name: iam-admin
+    - name: networking.datumapis.com-admin
+    - name: telemetry.miloapis.com-admin
+    - name: organizationmembership-reader
+    - name: quota.miloapis.com-organization-quota-manager

--- a/config/roles/viewer.yaml
+++ b/config/roles/viewer.yaml
@@ -1,0 +1,18 @@
+apiVersion: iam.miloapis.com/v1alpha1
+kind: Role
+metadata:
+  name: viewer
+  annotations:
+    kubernetes.io/display-name: Viewer
+    kubernetes.io/description: "View access to all resources"
+spec:
+  launchStage: Beta
+  inheritedRoles:
+    - name: resourcemanager-reader
+    - name: core-reader
+    - name: apiextensions-reader
+    - name: iam-viewer
+    - name: networking.datumapis.com-viewer
+    - name: telemetry.miloapis.com-viewer
+    - name: organizationmembership-reader
+    - name: quota.miloapis.com-viewer


### PR DESCRIPTION
This commit introduces a new IAM role named `viewer`, providing view access to all resources with appropriate annotations for clarity. Additionally, the existing `owner` role is updated to include new annotations and several inherited roles, enhancing its capabilities and documentation.

Related to: https://github.com/datum-cloud/milo/issues/361#issuecomment-3451202248