### PR TITLE
feat: add leader election candidate namespace support

### DIFF
--- a/cmd/milo/controller-manager/controllermanager.go
+++ b/cmd/milo/controller-manager/controllermanager.go
@@ -288,6 +288,9 @@ func NewOptions() (*Options, error) {
 		KubeControllerManagerOptions: baseOpts,
 		InfraCluster: &infracluster.Options{
 			KubeconfigFile: baseOpts.Generic.ClientConnection.Kubeconfig,
+			LeaderElection: &infracluster.LeaderElectionConfig{
+				CandidateNamespace: "datum-system",
+			},
 		},
 		ControlPlane: &controlplane.Options{},
 	}
@@ -677,7 +680,7 @@ func Run(ctx context.Context, c *config.CompletedConfig, opts *Options) error {
 		// Start lease candidate controller for coordinated leader election
 		leaseCandidate, waitForSync, err := leaderelection.NewCandidate(
 			c.Client,
-			"datum-system",
+			opts.InfraCluster.LeaderElection.CandidateNamespace,
 			id,
 			"datum-controller-manager",
 			binaryVersion.FinalizeVersion(),

--- a/config/controller-manager/base/deployment.yaml
+++ b/config/controller-manager/base/deployment.yaml
@@ -31,6 +31,7 @@ spec:
           - --leader-elect-renew-deadline=10s
           - --leader-elect-retry-period=2s
           - --leader-elect-resource-namespace=$(LEADER_ELECT_RESOURCE_NAMESPACE)
+          - --leader-election-candidate-namespace=$(LEADER_ELECTION_CANDIDATE_NAMESPACE)
           - --authentication-skip-lookup
           - --client-ca-file=$(CLIENT_CA_FILE)
           - --secure-port=6443
@@ -45,6 +46,8 @@ spec:
         env:
           - name: LEADER_ELECT_RESOURCE_NAMESPACE
             value: milo-system
+          - name: LEADER_ELECTION_CANDIDATE_NAMESPACE
+            value: datum-system
           # Default to INFO level logging
           - name: LOG_LEVEL
             value: "4"

--- a/internal/infra-cluster/client.go
+++ b/internal/infra-cluster/client.go
@@ -8,14 +8,21 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 )
 
+type LeaderElectionConfig struct {
+	CandidateNamespace string
+}
+
 // Options defines the configuration options available for modifying the
 // behavior of the infrastructure cluster client.
 type Options struct {
 	KubeconfigFile string
+	LeaderElection *LeaderElectionConfig
 }
 
 func (o *Options) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&o.KubeconfigFile, "infra-cluster-kubeconfig", "-", "The path to the kubeconfig file for the infrastructure cluster. Use '-' to use the in-cluster config.")
+	fs.StringVar(&o.LeaderElection.CandidateNamespace, "leader-election-candidate-namespace", o.LeaderElection.CandidateNamespace, "The candidate namespace in which the leader election will be created.")
+
 }
 
 func (o *Options) GetClient() (*rest.Config, error) {


### PR DESCRIPTION
## Summary

This PR adds support for configuring the namespace used by the leader election candidate controller.
Previously, the candidate namespace was hardcoded to `datum-system`, which caused conflicts when running multiple milo instances in different namespaces (e.g., preview environments).

## Details

- Introduced a new `LeaderElectionConfig` struct under `infraCluster` to define `CandidateNamespace`.
- Updated controller-manager to read the namespace value from `infraCluster.LeaderElection.CandidateNamespace` instead of a fixed string.
- Exposed a new CLI flag `--leader-election-candidate-namespace` for configuration.
- Added environment variable (`LEADER_ELECTION_CANDIDATE_NAMESPACE`) and argument in the controller manager deployment manifest.

---

Closes #389