### PR TITLE
feat: allow configurable namespace for owner roles

### DIFF
--- a/cmd/milo/controller-manager/controllermanager.go
+++ b/cmd/milo/controller-manager/controllermanager.go
@@ -106,8 +106,16 @@ var (
 	// OrganizationOwnerRoleName is the name of the role that will be used to grant organization owner permissions.
 	OrganizationOwnerRoleName string
 
+	// OrganizationOwnerRoleNamespace is the namespace where the organization owner role is located.
+	// This allows service providers to configure where owner roles are stored.
+	OrganizationOwnerRoleNamespace string
+
 	// ProjectOwnerRoleName is the name of the role that will be used to grant project owner permissions.
 	ProjectOwnerRoleName string
+
+	// ProjectOwnerRoleNamespace is the namespace where the project owner role is located.
+	// This allows service providers to configure where owner roles are stored.
+	ProjectOwnerRoleNamespace string
 
 	// GetInvitationRoleName is the name of the role that will be used to grant get invitation permissions.
 	GetInvitationRoleName string
@@ -190,6 +198,14 @@ func NewCommand() *cobra.Command {
 			}
 			cliflag.PrintFlags(cmd.Flags())
 
+			// Default owner role namespaces to SystemNamespace if not explicitly set
+			if OrganizationOwnerRoleNamespace == "" {
+				OrganizationOwnerRoleNamespace = SystemNamespace
+			}
+			if ProjectOwnerRoleNamespace == "" {
+				ProjectOwnerRoleNamespace = SystemNamespace
+			}
+
 			c, err := s.Config(KnownControllers(), nil, ControllerAliases())
 			if err != nil {
 				return err
@@ -231,7 +247,9 @@ func NewCommand() *cobra.Command {
 	// TODO: Investigate why these aren't showing up in the help output
 	fs.StringVar(&SystemNamespace, "system-namespace", "milo-system", "The namespace to use for system components and resources that are automatically created to run the system.")
 	fs.StringVar(&OrganizationOwnerRoleName, "organization-owner-role-name", "resourcemanager.miloapis.com-organizationowner", "The name of the role that will be used to grant organization owner permissions.")
+	fs.StringVar(&OrganizationOwnerRoleNamespace, "organization-owner-role-namespace", "", "The namespace where the organization owner role is located. Defaults to system-namespace if not specified.")
 	fs.StringVar(&ProjectOwnerRoleName, "project-owner-role-name", "resourcemanager.miloapis.com-projectowner", "The name of the role that will be used to grant project owner permissions.")
+	fs.StringVar(&ProjectOwnerRoleNamespace, "project-owner-role-namespace", "", "The namespace where the project owner role is located. Defaults to system-namespace if not specified.")
 	fs.StringVar(&GetInvitationRoleName, "get-invitation-role-name", "iam.miloapis.com-getinvitation", "The name of the role that will be used to grant get invitation permissions.")
 	fs.StringVar(&AcceptInvitationRoleName, "accept-invitation-role-name", "iam.miloapis.com-acceptinvitation", "The name of the role that will be used to grant accept invitation permissions.")
 	fs.StringVar(&UserInvitationEmailTemplate, "user-invitation-email-template", "emailtemplates.notification.miloapis.com-userinvitationemailtemplate", "The name of the template that will be used to send the user invitation email.")
@@ -419,15 +437,15 @@ func Run(ctx context.Context, c *config.CompletedConfig, opts *Options) error {
 				klog.FlushAndExit(klog.ExitFlushTimeout, 1)
 			}
 
-			if err := resourcemanagerv1alpha1webhook.SetupProjectWebhooksWithManager(ctrl, SystemNamespace, ProjectOwnerRoleName); err != nil {
+			if err := resourcemanagerv1alpha1webhook.SetupProjectWebhooksWithManager(ctrl, SystemNamespace, ProjectOwnerRoleName, ProjectOwnerRoleNamespace); err != nil {
 				logger.Error(err, "Error setting up project webhook")
 				klog.FlushAndExit(klog.ExitFlushTimeout, 1)
 			}
-			if err := resourcemanagerv1alpha1webhook.SetupOrganizationWebhooksWithManager(ctrl, SystemNamespace, OrganizationOwnerRoleName); err != nil {
+			if err := resourcemanagerv1alpha1webhook.SetupOrganizationWebhooksWithManager(ctrl, SystemNamespace, OrganizationOwnerRoleName, OrganizationOwnerRoleNamespace); err != nil {
 				logger.Error(err, "Error setting up organization webhook")
 				klog.FlushAndExit(klog.ExitFlushTimeout, 1)
 			}
-			if err := resourcemanagerv1alpha1webhook.SetupOrganizationMembershipWebhooksWithManager(ctrl, SystemNamespace, OrganizationOwnerRoleName); err != nil {
+			if err := resourcemanagerv1alpha1webhook.SetupOrganizationMembershipWebhooksWithManager(ctrl, OrganizationOwnerRoleName, OrganizationOwnerRoleNamespace); err != nil {
 				logger.Error(err, "Error setting up organizationmembership webhook")
 				klog.FlushAndExit(klog.ExitFlushTimeout, 1)
 			}

--- a/internal/webhooks/resourcemanager/v1alpha1/organization_webhook.go
+++ b/internal/webhooks/resourcemanager/v1alpha1/organization_webhook.go
@@ -25,25 +25,27 @@ var organizationlog = logf.Log.WithName("organization-resource")
 // +kubebuilder:webhook:path=/validate-resourcemanager-miloapis-com-v1alpha1-organization,mutating=false,failurePolicy=fail,sideEffects=NoneOnDryRun,groups=resourcemanager.miloapis.com,resources=organizations,verbs=create,versions=v1alpha1,name=vorganization.datum.net,admissionReviewVersions={v1,v1beta1},serviceName=milo-controller-manager,servicePort=9443,serviceNamespace=milo-system
 
 // SetupWebhooksWithManager sets up all resourcemanager.miloapis.com webhooks
-func SetupOrganizationWebhooksWithManager(mgr ctrl.Manager, systemNamespace string, organizationOwnerRoleName string) error {
+func SetupOrganizationWebhooksWithManager(mgr ctrl.Manager, systemNamespace string, organizationOwnerRoleName string, organizationOwnerRoleNamespace string) error {
 	organizationlog.Info("Setting up resourcemanager.miloapis.com organization webhooks")
 
 	return ctrl.NewWebhookManagedBy(mgr).
 		For(&resourcemanagerv1alpha1.Organization{}).
 		WithValidator(&OrganizationValidator{
-			client:          mgr.GetClient(),
-			systemNamespace: systemNamespace,
-			ownerRoleName:   organizationOwnerRoleName,
+			client:               mgr.GetClient(),
+			systemNamespace:      systemNamespace,
+			ownerRoleName:        organizationOwnerRoleName,
+			ownerRoleNamespace:   organizationOwnerRoleNamespace,
 		}).
 		Complete()
 }
 
 // OrganizationValidator validates Organizations
 type OrganizationValidator struct {
-	client          client.Client
-	decoder         admission.Decoder
-	systemNamespace string
-	ownerRoleName   string
+	client               client.Client
+	decoder              admission.Decoder
+	systemNamespace      string
+	ownerRoleName        string
+	ownerRoleNamespace   string
 }
 
 func (v *OrganizationValidator) ValidateCreate(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
@@ -190,7 +192,7 @@ func (v *OrganizationValidator) createOrganizationMembership(ctx context.Context
 			Roles: []resourcemanagerv1alpha1.RoleReference{
 				{
 					Name:      v.ownerRoleName,
-					Namespace: v.systemNamespace,
+					Namespace: v.ownerRoleNamespace,
 				},
 			},
 		},

--- a/internal/webhooks/resourcemanager/v1alpha1/organizationmembership_webhook.go
+++ b/internal/webhooks/resourcemanager/v1alpha1/organizationmembership_webhook.go
@@ -23,7 +23,7 @@ var organizationmembershiplog = logf.Log.WithName("organizationmembership-resour
 // +kubebuilder:webhook:path=/validate-resourcemanager-miloapis-com-v1alpha1-organizationmembership,mutating=false,failurePolicy=fail,sideEffects=None,groups=resourcemanager.miloapis.com,resources=organizationmemberships,verbs=create;update;delete,versions=v1alpha1,name=vorganizationmembership.datum.net,admissionReviewVersions={v1,v1beta1},serviceName=milo-controller-manager,servicePort=9443,serviceNamespace=milo-system
 
 // SetupOrganizationMembershipWebhooksWithManager sets up OrganizationMembership webhooks
-func SetupOrganizationMembershipWebhooksWithManager(mgr ctrl.Manager, systemNamespace string, organizationOwnerRoleName string) error {
+func SetupOrganizationMembershipWebhooksWithManager(mgr ctrl.Manager, organizationOwnerRoleName string, organizationOwnerRoleNamespace string) error {
 	organizationmembershiplog.Info("Setting up resourcemanager.miloapis.com organizationmembership webhooks")
 
 	return ctrl.NewWebhookManagedBy(mgr).
@@ -31,7 +31,7 @@ func SetupOrganizationMembershipWebhooksWithManager(mgr ctrl.Manager, systemName
 		WithValidator(&OrganizationMembershipValidator{
 			client:             mgr.GetClient(),
 			ownerRoleName:      organizationOwnerRoleName,
-			ownerRoleNamespace: systemNamespace,
+			ownerRoleNamespace: organizationOwnerRoleNamespace,
 		}).
 		Complete()
 }


### PR DESCRIPTION
Adds configuration flags to specify the namespace where organization and project owner roles are located, separate from the system namespace. This enables service providers to organize roles according to their requirements.