### PR TITLE
feat: ensure dnszoneclass

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,9 @@ require (
 	github.com/spf13/cobra v1.9.1
 	github.com/spf13/pflag v1.0.7
 	github.com/stretchr/testify v1.11.1
+	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.55.0
+	go.opentelemetry.io/otel v1.35.0
+	go.opentelemetry.io/otel/trace v1.35.0
 	golang.org/x/sync v0.16.0
 	golang.org/x/time v0.12.0
 	gopkg.in/square/go-jose.v2 v2.6.0
@@ -95,13 +98,10 @@ require (
 	go.etcd.io/etcd/pkg/v3 v3.6.4 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.60.0 // indirect
-	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.55.0 // indirect
-	go.opentelemetry.io/otel v1.35.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.32.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.32.0 // indirect
 	go.opentelemetry.io/otel/metric v1.35.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.34.0 // indirect
-	go.opentelemetry.io/otel/trace v1.35.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.3.1 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.27.0 // indirect


### PR DESCRIPTION
This pull request refactors the `ProjectController` logic to improve resource discovery and management for per-project Kubernetes resources. The main changes include switching from hardcoded resource checks to dynamic discovery, introducing support for DNSZoneClass resources, and restructuring client creation for better efficiency and clarity.

**This refactor builds all per-project clients once per reconcile, replaces costly RESTMapper discovery with lightweight direct discovery calls**

Resource discovery and management improvements:

* Added support for discovering and ensuring the existence of `DNSZoneClass` resources, alongside `GatewayClass`, for each project. This allows the controller to manage DNS-related resources similarly to gateway resources. 
* Refactored resource existence checks to use the new `hasResource` function, which dynamically discovers resources via the Kubernetes API instead of relying on static type checks.

Client management and code simplification:

* Introduced the `projectClients` struct and the `buildProjectClients` function to efficiently construct and reuse Kubernetes, dynamic, and discovery clients for each project, improving performance and code clarity. 
* Updated `ensureDefaultNamespace` and `ensureGatewayClass` to accept client interfaces rather than configs, streamlining their usage and making them more testable and flexible. 
