### PR TITLE
feat: Add permission for listing user invitations in IAM role `iam-user-self-manage`

### DIFF
--- a/config/roles/iam-user-self-manage.yaml
+++ b/config/roles/iam-user-self-manage.yaml
@@ -17,3 +17,5 @@ spec:
   - identity.miloapis.com/sessions.list
   - identity.miloapis.com/sessions.get
   - identity.miloapis.com/sessions.delete
+  - iam.miloapis.com/userinvitations.get
+  - iam.miloapis.com/userinvitations.list


### PR DESCRIPTION
This PR updates the IAM role `iam-user-self-manage` with the necessary permissions so that users can retrieve their UserInvitations.