### PR TITLE
feat: add selectable field for user email in CRD

### DIFF
--- a/config/crd/bases/iam/iam.miloapis.com_users.yaml
+++ b/config/crd/bases/iam/iam.miloapis.com_users.yaml
@@ -175,6 +175,7 @@ spec:
         type: object
     selectableFields:
     - jsonPath: .status.registrationApproval
+    - jsonPath: .spec.email
     served: true
     storage: true
     subresources:

--- a/pkg/apis/iam/v1alpha1/user_types.go
+++ b/pkg/apis/iam/v1alpha1/user_types.go
@@ -32,6 +32,7 @@ const (
 // +kubebuilder:printcolumn:name="Registration Approval",type="string",JSONPath=".status.registrationApproval"
 // +kubebuilder:resource:path=users,scope=Cluster
 // +kubebuilder:selectablefield:JSONPath=".status.registrationApproval"
+// +kubebuilder:selectablefield:JSONPath=".spec.email"
 type User struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`


### PR DESCRIPTION
This update introduces a new selectable field for the user email in the IAM user CRD, allowing for enhanced querying capabilities. The change is reflected in both the CRD definition and the corresponding API types.

This change was requested by @mustela in order to query Users by email.