### PR TITLE
refactor: update ContactSpec fields to optional

### DIFF
--- a/config/crd/bases/notification/notification.miloapis.com_contacts.yaml
+++ b/config/crd/bases/notification/notification.miloapis.com_contacts.yaml
@@ -91,8 +91,6 @@ spec:
                 type: object
             required:
             - email
-            - familyName
-            - givenName
             type: object
           status:
             properties:

--- a/docs/api/notification.md
+++ b/docs/api/notification.md
@@ -857,14 +857,14 @@ ContactSpec defines the desired state of Contact.
         <td>
           <br/>
         </td>
-        <td>true</td>
+        <td>false</td>
       </tr><tr>
         <td><b>givenName</b></td>
         <td>string</td>
         <td>
           <br/>
         </td>
-        <td>true</td>
+        <td>false</td>
       </tr><tr>
         <td><b><a href="#contactspecsubject">subject</a></b></td>
         <td>object</td>

--- a/pkg/apis/notification/v1alpha1/contact_types.go
+++ b/pkg/apis/notification/v1alpha1/contact_types.go
@@ -61,10 +61,10 @@ type ContactSpec struct {
 	// +kubebuilder:validation:Optional
 	SubjectRef *SubjectReference `json:"subject,omitempty"`
 
-	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:Optional
 	FamilyName string `json:"familyName,omitempty"`
 
-	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:Optional
 	GivenName string `json:"givenName,omitempty"`
 
 	// +kubebuilder:validation:Required


### PR DESCRIPTION
This PR updates the Contact CRD, giving Name and FamilyName to be optional.

This change was requested on Nov 5 Sync, as Newsleet contacts may not include these fields.