### PR TITLE
fix: improve error handling in organization membership reconciliation

### DIFF
--- a/internal/controllers/resourcemanager/organization_membership_controller.go
+++ b/internal/controllers/resourcemanager/organization_membership_controller.go
@@ -116,7 +116,7 @@ func (r *OrganizationMembershipController) Reconcile(ctx context.Context, req ct
 				return ctrl.Result{}, fmt.Errorf("failed to update organization membership status: %w", err)
 			}
 		}
-		return ctrl.Result{}, nil
+		return ctrl.Result{}, fmt.Errorf("failed to get organization: %w", err)
 	}
 
 	// Fetch the referenced User
@@ -143,7 +143,7 @@ func (r *OrganizationMembershipController) Reconcile(ctx context.Context, req ct
 				return ctrl.Result{}, fmt.Errorf("failed to update organization membership status: %w", err)
 			}
 		}
-		return ctrl.Result{}, nil
+		return ctrl.Result{}, fmt.Errorf("failed to get user: %w", err)
 	}
 
 	// Update the status with information from the Organization and User


### PR DESCRIPTION
This PR improves error handling in the scenarios where users or organizations are not found when an organizationmembership reconciles.

This reduces the server resources consumption, as the server will use an exponential retry logic after each retry.

Relate to this incident:
https://datum-inc.slack.com/archives/C084W6XRVS7/p1762543292084779