### PR TITLE
feat: add organization membership self-delete role and functionality

### DIFF
--- a/cmd/milo/controller-manager/controllermanager.go
+++ b/cmd/milo/controller-manager/controllermanager.go
@@ -137,6 +137,13 @@ var (
 
 	// AssignableRolesNamespace is an extra namespace that the system allows to be used for assignable roles.
 	AssignableRolesNamespace string
+
+	// OrganizationMembershipSelfDeleteRoleName is the name of the role that will be used to grant organization membership self delete permissions.
+	OrganizationMembershipSelfDeleteRoleName string
+
+	// OrganizationMembershipSelfDeleteRoleNamespace is the namespace where the organization membership self delete role is located.
+	// This allows service providers to configure where self delete roles are stored.
+	OrganizationMembershipSelfDeleteRoleNamespace string
 )
 
 func init() {
@@ -265,6 +272,8 @@ func NewCommand() *cobra.Command {
 	fs.StringVar(&PlatformInvitationEmailTemplate, "platform-invitation-email-template", "emailtemplates.notification.miloapis.com-platforminvitationemailtemplate", "The name of the template that will be used to send the platform invitation email.")
 	fs.StringVar(&WaitlistRelatedResourcesNamespace, "waitlist-related-resources-namespace", "milo-system", "The namespace that contains the waitlist related resources.")
 	fs.StringVar(&PlatformInvitationEmailVariableActionUrl, "platform-invitation-email-variable-action-url", "https://cloud.datum.net", "The action url for the platform invitation email.")
+	fs.StringVar(&OrganizationMembershipSelfDeleteRoleName, "organization-membership-self-delete-role-name", "organizationmembership-self-delete", "The name of the role that will be used to grant organization membership self delete actions.")
+	fs.StringVar(&OrganizationMembershipSelfDeleteRoleNamespace, "organization-membership-self-delete-role-namespace", "milo-system", "The namespace where the organization membership self delete role is located. Defaults to system-namespace if not specified.")
 
 	fs.IntVar(&s.ControllerRuntimeWebhookPort, "controller-runtime-webhook-port", 9443, "The port to use for the controller-runtime webhook server.")
 
@@ -528,7 +537,9 @@ func Run(ctx context.Context, c *config.CompletedConfig, opts *Options) error {
 			}
 
 			organizationMembershipCtrl := resourcemanagercontroller.OrganizationMembershipController{
-				Client: ctrl.GetClient(),
+				Client:                  ctrl.GetClient(),
+				SelfDeleteRoleName:      OrganizationMembershipSelfDeleteRoleName,
+				SelfDeleteRoleNamespace: OrganizationMembershipSelfDeleteRoleNamespace,
 			}
 			if err := organizationMembershipCtrl.SetupWithManager(ctrl); err != nil {
 				logger.Error(err, "Error setting up organization membership controller")

--- a/config/roles/kustomization.yaml
+++ b/config/roles/kustomization.yaml
@@ -43,6 +43,7 @@ resources:
   - organizationmembership-reader.yaml
   - organizationmembership-editor.yaml
   - organizationmembership-admin.yaml
+  - organizationmembership-self-delete.yaml
   - iam-role-reader.yaml
   - iam-role-editor.yaml
   - iam-role-admin.yaml

--- a/config/roles/organizationmembership-self-delete.yaml
+++ b/config/roles/organizationmembership-self-delete.yaml
@@ -1,0 +1,15 @@
+apiVersion: iam.miloapis.com/v1alpha1
+kind: Role
+metadata:
+  name: organizationmembership-self-delete
+  annotations:
+    kubernetes.io/display-name: Organization Membership Self Delete
+    kubernetes.io/description: "Allows a user to delete their own organization membership"
+spec:
+  launchStage: Beta
+  includedPermissions:
+    - resourcemanager.miloapis.com/organizationmemberships.get
+    - resourcemanager.miloapis.com/organizationmemberships.list
+    - resourcemanager.miloapis.com/organizationmemberships.delete
+
+


### PR DESCRIPTION
This PR adds the necessary functionality to OrganizationMemberships so that Users can deleted their own organization memberships.

Related to: https://github.com/datum-cloud/cloud-portal/issues/704