### PR TITLE
feat: enhance Email resource with additional fields for email content

### DIFF
--- a/config/crd/bases/notification/notification.miloapis.com_emails.yaml
+++ b/config/crd/bases/notification/notification.miloapis.com_emails.yaml
@@ -207,11 +207,26 @@ spec:
                   - type
                   type: object
                 type: array
+              emailAddress:
+                description: |-
+                  EmailAddress stores the final recipient address used for delivery,
+                  after resolving any referenced User.
+                type: string
+              htmlBody:
+                description: HTMLBody stores the rendered HTML content of the e-mail.
+                type: string
               providerID:
                 description: |-
                   ProviderID is the identifier returned by the underlying email provider
                   (e.g. Resend) when the e-mail is accepted for delivery. It is usually
                   used to track the email delivery status (e.g. provider webhooks).
+                type: string
+              subject:
+                description: Subject stores the subject line used for the e-mail.
+                type: string
+              textBody:
+                description: TextBody stores the rendered plain-text content of the
+                  e-mail.
                 type: string
             type: object
         type: object

--- a/docs/api/notification.md
+++ b/docs/api/notification.md
@@ -1663,12 +1663,41 @@ Standard condition is "Delivered" which tracks email delivery status.<br/>
         </td>
         <td>false</td>
       </tr><tr>
+        <td><b>emailAddress</b></td>
+        <td>string</td>
+        <td>
+          EmailAddress stores the final recipient address used for delivery,
+after resolving any referenced User.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>htmlBody</b></td>
+        <td>string</td>
+        <td>
+          HTMLBody stores the rendered HTML content of the e-mail.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
         <td><b>providerID</b></td>
         <td>string</td>
         <td>
           ProviderID is the identifier returned by the underlying email provider
 (e.g. Resend) when the e-mail is accepted for delivery. It is usually
 used to track the email delivery status (e.g. provider webhooks).<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>subject</b></td>
+        <td>string</td>
+        <td>
+          Subject stores the subject line used for the e-mail.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>textBody</b></td>
+        <td>string</td>
+        <td>
+          TextBody stores the rendered plain-text content of the e-mail.<br/>
         </td>
         <td>false</td>
       </tr></tbody>

--- a/pkg/apis/notification/v1alpha1/email_types.go
+++ b/pkg/apis/notification/v1alpha1/email_types.go
@@ -122,6 +122,23 @@ type EmailStatus struct {
 	// used to track the email delivery status (e.g. provider webhooks).
 	// +optional
 	ProviderID string `json:"providerID,omitempty"`
+
+	// HTMLBody stores the rendered HTML content of the e-mail.
+	// +optional
+	HTMLBody string `json:"htmlBody,omitempty"`
+
+	// TextBody stores the rendered plain-text content of the e-mail.
+	// +optional
+	TextBody string `json:"textBody,omitempty"`
+
+	// Subject stores the subject line used for the e-mail.
+	// +optional
+	Subject string `json:"subject,omitempty"`
+
+	// EmailAddress stores the final recipient address used for delivery,
+	// after resolving any referenced User.
+	// +optional
+	EmailAddress string `json:"emailAddress,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object


### PR DESCRIPTION
This update adds new fields to the Email resource, including 'emailAddress', 'htmlBody', 'textBody', and 'subject', to store the recipient address and email content.

Related to: 
https://datum-inc.slack.com/archives/C084W6XRVS7/p1763155065297189?thread_ts=1763065833.716799&cid=C084W6XRVS7