### PR TITLE
Add docs for Marketing Contact migration into Milo

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ kubectl get organizations
 
 📚 **[Full setup guide →](docs/getting-started.md)**
 📖 **[API documentation →](docs/api/)**
+🧱 **[Manual migrations →](docs/migrations/README.md)**
 
 ## What We Prefer Not to Build
 

--- a/docs/migrations/001-contacts-from-csv/README.md
+++ b/docs/migrations/001-contacts-from-csv/README.md
@@ -1,0 +1,124 @@
+# 001 – Import contacts and newsletter memberships from CSV
+
+## Overview
+
+This migration imports a set of **marketing contacts** into Milo and, for a subset of them, creates **newsletter list memberships**. It is intended for one‑off/batch imports where we are working from an existing CSV export.
+
+The migration lives in the directory `docs/migrations/001-contacts-from-csv` and is implemented by the script `create_contacts_from_csv.py` in that directory. A minimal example CSV with the expected headers (`contacts.csv`) is also provided there; it is for structure only, the real data remains private.
+
+At a high level:
+
+1. We prepare a CSV file with basic contact details.
+2. We convert the CSV into Milo CRDs.
+3. The script generates two YAML files:
+   - one containing a series of `Contact` resources.
+   - one containing a series of `ContactGroupMembership` resources.
+4. We apply those YAML files directly to the target cluster.
+
+---
+
+### CSV shape
+
+The CSV itself is private, but the **shape** (headers and expected values) is:
+
+- **fname** – contact’s given/first name (optional).
+- **lname** – contact’s family/last name (optional).
+- **Email Address** – contact’s email address (required; rows without this are skipped).
+- **List** – text label describing the mailing list for the contact.
+  - Rows with the case‑insensitive value `newsletter` will be added to the
+    default email newsletter contact group.
+- **Company** – company/organization name (optional; currently not written to the CRDs).
+- **Notes** – free‑form notes (optional; currently not written to the CRDs).
+
+Example (sanitized) header and row:
+
+```text
+fname,lname,Email Address,List,Company,Notes
+Jane,Doe,jane@example.com,Newsletter,Example Corp,Met at conference
+```
+
+The script normalizes whitespace and ignores rows that do not include an email.
+
+---
+
+### Running the migration
+
+#### 1. Prerequisites
+
+- Python 3 available on your workstation.
+- The `PyYAML` package installed:
+
+  ```bash
+  pip3 install pyyaml
+  ```
+
+- Your CSV file present on disk (for example: `contacts.csv`).
+- `kubectl` configured to point at the target Milo cluster (`KUBECONFIG`
+  or current context).
+
+#### 2. Generate YAML from the CSV
+
+From the migration directory:
+
+```bash
+cd docs/migrations/001-contacts-from-csv
+python3 create_contacts_from_csv.py \
+  --input ./contacts.csv \
+  --contacts-output ./contacts_from_csv.yaml \
+  --memberships-output ./contact_group_memberships_from_csv.yaml
+```
+
+If you omit the flags, the script defaults to:
+
+- **Input CSV**: `contacts.csv` (expected to live in this directory)
+- **Contacts output**: `contacts_from_csv.yaml`
+- **Memberships output**: `contact_group_memberships_from_csv.yaml`
+
+The script:
+
+- Reads the CSV and, for each row with an email, creates a `Contact` resource.
+- For rows where the `List` column is `Newsletter` (case‑insensitive), also
+  creates a `ContactGroupMembership` resource.
+- Prints all generated manifests to `stdout` (for inspection) and writes them
+  to the two output YAML files.
+
+#### 3. What the generated files contain
+
+- **`contacts_from_csv.yaml`**
+  - A multi‑document YAML file.
+  - Each document is a `Contact` (`notification.miloapis.com/v1alpha1`).
+  - Each contact:
+    - Lives in the `milo-system` namespace.
+    - Has a deterministic name derived from the email
+      (pattern: `contact-<short-id>`).
+    - Includes the email, and where present, `givenName` and `familyName`.
+
+- **`contact_group_memberships_from_csv.yaml`**
+  - A multi‑document YAML file.
+  - Each document is a `ContactGroupMembership`
+    (`notification.miloapis.com/v1alpha1`).
+  - Each membership:
+    - Lives in the `milo-system` namespace.
+    - References the default email newsletter contact group:
+      - `spec.contactGroupRef.name`: `emailnewsletter-contact-group-3a3ar9`
+      - `spec.contactGroupRef.namespace`: `default`
+    - References one of the `Contact` resources generated in
+      `contacts_from_csv.yaml`.
+
+Together, **each file represents a series of CRDs**:
+
+- `contacts_from_csv.yaml` – a series of `Contact` resources.
+- `contact_group_memberships_from_csv.yaml` – a series of `ContactGroupMembership` resources.
+
+---
+
+### 4. Applying the migration to the cluster
+
+Ensure your `kubectl` context is pointing at the target Milo cluster (for
+example, by exporting `KUBECONFIG`):
+
+```bash
+export KUBECONFIG=.milo/kubeconfig   # or another kubeconfig pointing to the target cluster
+```
+
+Then apply the generated YAML files (from the same migration directory):

--- a/docs/migrations/001-contacts-from-csv/contact_group_memberships_from_csv.yaml
+++ b/docs/migrations/001-contacts-from-csv/contact_group_memberships_from_csv.yaml
@@ -1,0 +1,12 @@
+apiVersion: notification.miloapis.com/v1alpha1
+kind: ContactGroupMembership
+metadata:
+  name: contact-group-membership-13db4
+  namespace: milo-system
+spec:
+  contactGroupRef:
+    name: emailnewsletter-contact-group-3a3ar9
+    namespace: default
+  contactRef:
+    name: contact-0850a
+    namespace: milo-system

--- a/docs/migrations/001-contacts-from-csv/contacts.csv
+++ b/docs/migrations/001-contacts-from-csv/contacts.csv
@@ -1,0 +1,3 @@
+fname,lname,Email Address,List,Company,Notes
+Jane,Doe,jane@example.com,Newsletter,Example Corp,Met at conference
+

--- a/docs/migrations/001-contacts-from-csv/contacts_from_csv.yaml
+++ b/docs/migrations/001-contacts-from-csv/contacts_from_csv.yaml
@@ -1,0 +1,9 @@
+apiVersion: notification.miloapis.com/v1alpha1
+kind: Contact
+metadata:
+  name: contact-0850a
+  namespace: milo-system
+spec:
+  email: jane@example.com
+  givenName: Jane
+  familyName: Doe

--- a/docs/migrations/001-contacts-from-csv/create_contacts_from_csv.py
+++ b/docs/migrations/001-contacts-from-csv/create_contacts_from_csv.py
@@ -1,0 +1,231 @@
+#!/usr/bin/env python3
+import argparse
+import csv
+import hashlib
+import re
+import sys
+from typing import Any, Dict, List, Optional
+
+try:
+    import yaml  # PyYAML
+except ImportError:
+    print("Missing dependency: PyYAML. Install with: pip install pyyaml", file=sys.stderr)
+    sys.exit(1)
+
+
+DEFAULT_NAMESPACE = "milo-system"
+NEWSLETTER_GROUP_NAME = "emailnewsletter-contact-group-3a3ar9"
+CONTACT_GROUP_NAMESPACE = "default"
+
+
+def slugify(value: str) -> str:
+    """
+    Lowercase, trim, replace non-alphanumeric with '-', collapse repeats, strip '-'.
+    """
+    value = (value or "").strip().lower()
+    value = re.sub(r"[^a-z0-9]+", "-", value)
+    value = re.sub(r"-{2,}", "-", value)
+    return value.strip("-")
+
+
+def short_id_from_email(email: str, length: int = 5) -> str:
+    """
+    Deterministic short suffix from email for stable names.
+    """
+    digest = hashlib.sha1((email or "").strip().lower().encode("utf-8")).hexdigest()
+    return digest[:length]
+
+
+def build_contact_name(given_name: str, family_name: str, email: str) -> str:
+    """
+    Produce a DNS-safe name for the Contact resource.
+    Pattern: 'contact-<id>' where <id> is a short deterministic suffix.
+    """
+    suffix = short_id_from_email(email)
+    return f"contact-{suffix}"
+
+
+def make_contact_doc(fname: str, lname: str, email: str) -> Dict[str, Any]:
+    """
+    Build a Contact CRD manifest from basic person fields.
+    Returns a dict ready to be dumped as YAML.
+    """
+    name = build_contact_name(fname, lname, email)
+    doc: Dict[str, Any] = {
+        "apiVersion": "notification.miloapis.com/v1alpha1",
+        "kind": "Contact",
+        "metadata": {
+            "name": name,
+            "namespace": DEFAULT_NAMESPACE,
+        },
+        "spec": {
+            "email": email,
+        },
+    }
+    if fname:
+        doc["spec"]["givenName"] = fname
+    if lname:
+        doc["spec"]["familyName"] = lname
+    return doc
+
+
+def make_membership_doc(contact_name: str) -> Dict[str, Any]:
+    """
+    Build a ContactGroupMembership CRD manifest that links the given contact
+    to the default Email Newsletter contact group.
+    """
+    doc: Dict[str, Any] = {
+        "apiVersion": "notification.miloapis.com/v1alpha1",
+        "kind": "ContactGroupMembership",
+        "metadata": {
+            # We could also use generateName: 'contact-group-membership-' and omit name.
+            "name": f"contact-group-membership-{hashlib.sha1(contact_name.encode('utf-8')).hexdigest()[:5]}",
+            "namespace": DEFAULT_NAMESPACE,
+        },
+        "spec": {
+            "contactGroupRef": {
+                "name": NEWSLETTER_GROUP_NAME,
+                "namespace": CONTACT_GROUP_NAMESPACE,
+            },
+            "contactRef": {
+                "name": contact_name,
+                "namespace": DEFAULT_NAMESPACE,
+            },
+        },
+    }
+    return doc
+
+
+def parse_bool_newsletter(value: str) -> bool:
+    """
+    Returns True if the CSV 'List' column indicates Newsletter.
+    Accepts case-insensitive 'newsletter'.
+    """
+    if value is None:
+        return False
+    return value.strip().lower() == "newsletter"
+
+
+def read_csv(path: str) -> List[Dict[str, str]]:
+    """
+    Read the input CSV and normalize the columns we care about.
+    Returns a list of dict rows with keys: fname, lname, email, list, company, notes.
+    """
+    with open(path, "r", encoding="utf-8") as f:
+        reader = csv.DictReader(f)
+        rows: List[Dict[str, str]] = []
+        for row in reader:
+            # Normalize keys we care about and trim whitespace
+            normalized = {
+                "fname": (row.get("fname") or "").strip(),
+                "lname": (row.get("lname") or "").strip(),
+                "email": (row.get("Email Address") or "").strip(),
+                "list": (row.get("List") or "").strip(),
+                "company": (row.get("Company") or "").strip(),
+                "notes": (row.get("Notes") or "").strip(),
+            }
+            rows.append(normalized)
+        return rows
+
+
+def dump_yaml_docs(docs: List[Dict[str, Any]]) -> None:
+    """
+    Print a sequence of YAML documents to stdout, separated by '---'.
+    """
+    for idx, doc in enumerate(docs):
+        print(yaml.safe_dump(doc, sort_keys=False).rstrip())
+        if idx != len(docs) - 1:
+            print("---")
+
+
+def write_yaml_file(docs: List[Dict[str, Any]], out_path: str) -> None:
+    """
+    Write the YAML documents to a file as a multi-document stream.
+    """
+    with open(out_path, "w", encoding="utf-8") as f:
+        for idx, doc in enumerate(docs):
+            f.write(yaml.safe_dump(doc, sort_keys=False))
+            if idx != len(docs) - 1:
+                f.write("---\n")
+
+
+def process_csv(path: str, contacts_out_path: Optional[str], memberships_out_path: Optional[str]) -> None:
+    """
+    End-to-end CSV processing:
+    - Reads rows
+    - Builds Contact documents
+    - Adds ContactGroupMembership documents for Newsletter rows
+    - Prints all documents as YAML
+    """
+    rows = read_csv(path)
+    contact_docs: List[Dict[str, Any]] = []
+    membership_docs: List[Dict[str, Any]] = []
+
+    for row in rows:
+        email = row["email"]
+        if not email:
+            # Skip rows without email
+            continue
+        # Clean stray commas/spaces that sometimes appear in CSV cells
+        email = email.strip().rstrip(",")
+
+        contact_doc = make_contact_doc(row["fname"], row["lname"], email)
+        contact_docs.append(contact_doc)
+
+        if parse_bool_newsletter(row["list"]):
+            membership_doc = make_membership_doc(contact_doc["metadata"]["name"])
+            membership_docs.append(membership_doc)
+
+    # Print to console: contacts first, then memberships
+    dump_yaml_docs(contact_docs)
+    if membership_docs:
+        print("---")
+        dump_yaml_docs(membership_docs)
+
+    # Also write to files if requested
+    if contacts_out_path:
+        write_yaml_file(contact_docs, contacts_out_path)
+    if memberships_out_path:
+        write_yaml_file(membership_docs, memberships_out_path)
+
+
+def parse_args(argv: Optional[List[str]] = None) -> argparse.Namespace:
+    """
+    Parse CLI arguments.
+    """
+    parser = argparse.ArgumentParser(
+        description="Read CSV, build Contact and ContactGroupMembership YAML. Prints to stdout and writes files."
+    )
+    parser.add_argument(
+        "-i",
+        "--input",
+        default="./contacts.csv",
+        help="Path to input CSV. Default: 'contacts.csv'",
+    )
+    parser.add_argument(
+        "--contacts-output",
+        "-oc",
+        default="contacts_from_csv.yaml",
+        help="Path to write Contacts YAML. Default: contacts_from_csv.yaml",
+    )
+    parser.add_argument(
+        "--memberships-output",
+        "-om",
+        default="contact_group_memberships_from_csv.yaml",
+        help="Path to write ContactGroupMemberships YAML. Default: contact_group_memberships_from_csv.yaml",
+    )
+    return parser.parse_args(argv)
+
+
+def main() -> None:
+    """
+    Program entry point: parse args and process the CSV file.
+    """
+    args = parse_args()
+    process_csv(args.input, args.contacts_output, args.memberships_output)
+
+
+if __name__ == "__main__":
+    main()
+
+

--- a/docs/migrations/README.md
+++ b/docs/migrations/README.md
@@ -1,0 +1,15 @@
+# Migrations
+
+This section documents **manual migrations** that we run directly against a Milo cluster (for example, bulk data imports or one‑off resource changes).
+
+Each migration is written as a small, repeatable runbook:
+
+- **What** the migration does.
+- **Why** it exists / background.
+- **How** to run it (exact commands).
+- **What** gets created/changed in the cluster.
+
+Individual migrations live in numbered files so we can track the order they
+were introduced:
+
+- `001-contacts-from-csv` – import marketing contacts and newsletter memberships from a CSV file.


### PR DESCRIPTION
This PR adds concise documentation for the Marketing Contact migration into the Milo cluster, including the steps, inputs, and example manifests used.

It exists so future migrations are reproducible, auditable, and easier to reason about when onboarding new teams or running similar data imports.


Related to: https://datum-inc.slack.com/archives/C084W6XRVS7/p1763480341060909