### PR TITLE
feat: remove automatic platform access approval migration to legacy users

### DIFF
--- a/config/crd/bases/iam/iam.miloapis.com_platformaccessapprovals.yaml
+++ b/config/crd/bases/iam/iam.miloapis.com_platformaccessapprovals.yaml
@@ -84,6 +84,9 @@ spec:
             - message: spec is immutable
               rule: self == oldSelf
         type: object
+    selectableFields:
+    - jsonPath: .spec.subjectRef.email
+    - jsonPath: .spec.subjectRef.userRef.name
     served: true
     storage: true
     subresources:

--- a/config/crd/bases/iam/iam.miloapis.com_platformaccessrejections.yaml
+++ b/config/crd/bases/iam/iam.miloapis.com_platformaccessrejections.yaml
@@ -73,6 +73,8 @@ spec:
             - message: spec is immutable
               rule: self == oldSelf
         type: object
+    selectableFields:
+    - jsonPath: .spec.subjectRef.name
     served: true
     storage: true
     subresources:

--- a/pkg/apis/iam/v1alpha1/platformaccessapproval_types.go
+++ b/pkg/apis/iam/v1alpha1/platformaccessapproval_types.go
@@ -17,6 +17,8 @@ const (
 // PlatformAccessApproval is the Schema for the platformaccessapprovals API.
 // It represents a platform access approval for a user. Once the platform access approval is created, an email will be sent to the user.
 // +kubebuilder:resource:scope=Cluster
+// +kubebuilder:selectablefield:JSONPath=".spec.subjectRef.email"
+// +kubebuilder:selectablefield:JSONPath=".spec.subjectRef.userRef.name"
 type PlatformAccessApproval struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/pkg/apis/iam/v1alpha1/platformaccessrejection_types.go
+++ b/pkg/apis/iam/v1alpha1/platformaccessrejection_types.go
@@ -17,6 +17,7 @@ const (
 // PlatformAccessRejection is the Schema for the platformaccessrejections API.
 // It represents a formal denial of platform access for a user. Once the rejection is created, a notification can be sent to the user.
 // +kubebuilder:resource:scope=Cluster
+// +kubebuilder:selectablefield:JSONPath=".spec.subjectRef.name"
 type PlatformAccessRejection struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`


### PR DESCRIPTION
This PR sets all legacy users who do not have a proper platform access approval into the pending approval state. (Previously, we decided to left this users as active).

Additionally, we added selectable field selectors to the PlatformAccessApprovals and PlatformAccessRejections, so these resources can be deleted in the UI using the user's name or email address, allowing them to be moved back to the pending state.

Related to:
https://datum-inc.slack.com/archives/C084W6XRVS7/p1763642563020069