### PR TITLE
chore: update Slack notification formatting

### DIFF
--- a/internal/controllers/iam/userslacknotification_controller.go
+++ b/internal/controllers/iam/userslacknotification_controller.go
@@ -102,41 +102,29 @@ func (r *UserSlackNotificationController) sendSlackNotification(ctx context.Cont
 		displayName = user.Spec.Email
 	}
 
-	// Example: "12 Jan 2025 14:32 UTC"
-	createdAt := user.CreationTimestamp.Time.UTC().Format("02 Jan 2006 15:04 MST")
-
-	createdText := fmt.Sprintf("*Created At:* %s", createdAt)
-
 	link := fmt.Sprintf("https://staff.datum.net/customers/users/%s", user.Name)
-	createdText = fmt.Sprintf("%s\n\n<%s|View in Staff Portal>", createdText, link)
 
 	payload := map[string]interface{}{
 		"blocks": []map[string]interface{}{
 			{
-				"type": "header",
-				"text": map[string]interface{}{
-					"type": "plain_text",
-					"text": "🎉 New User Created",
-				},
-			},
-			{
-				"type": "section",
-				"fields": []map[string]interface{}{
-					{
-						"type": "mrkdwn",
-						"text": fmt.Sprintf("*Name:* %s", displayName),
-					},
-					{
-						"type": "mrkdwn",
-						"text": fmt.Sprintf("*Email:* %s", user.Spec.Email),
-					},
-				},
-			},
-			{
 				"type": "section",
 				"text": map[string]interface{}{
 					"type": "mrkdwn",
-					"text": createdText,
+					"text": "*User signed up*",
+				},
+			},
+		},
+		"attachments": []map[string]interface{}{
+			{
+				"color": "#f2c744",
+				"blocks": []map[string]interface{}{
+					{
+						"type": "section",
+						"text": map[string]interface{}{
+							"type": "mrkdwn",
+							"text": fmt.Sprintf("Customer: <%s|%s> - %s", link, displayName, user.Spec.Email),
+						},
+					},
 				},
 			},
 		},


### PR DESCRIPTION
This PR updates the Slack notification message sent when a user is created. The formatting was requested to be tighter.

Previous message:
<img width="958" height="178" alt="Screenshot 2025-11-25 at 2 03 47 PM" src="https://github.com/user-attachments/assets/9c28ef89-1a55-474b-9056-a62212b9f14a" />

New message:
<img width="946" height="130" alt="Screenshot 2025-11-25 at 2 01 11 PM" src="https://github.com/user-attachments/assets/1c11945e-2623-42ba-af17-ea8f6dc9489a" />


Related to:
https://datum-inc.slack.com/archives/C09SWE4N53P/p1763991456360089

Thanks @mustela for the message design.