### PR TITLE
chore(ci): upgrade workflow actions to v1.8.1 and add job dependency

### DIFF
--- a/.github/workflows/build-apiserver.yaml
+++ b/.github/workflows/build-apiserver.yaml
@@ -12,17 +12,22 @@ jobs:
       contents: read
       packages: write
       attestations: write
-    uses: datum-cloud/actions/.github/workflows/publish-docker.yaml@v1.7.2
+    uses: datum-cloud/actions/.github/workflows/publish-docker.yaml@v1.8.1
     with:
       image-name: milo
     secrets: inherit
 
   publish-kustomize-bundles:
+    # Add explicit dependency so that the kustomize bundles only get published
+    # if the container image has been built successfully. This helps prevent
+    # situations where the deployment manifests are picked up by flux but the
+    # container is still being created.
+    needs: [publish-container-image]
     permissions:
       id-token: write
       contents: read
       packages: write
-    uses: datum-cloud/actions/.github/workflows/publish-kustomize-bundle.yaml@v1.7.2
+    uses: datum-cloud/actions/.github/workflows/publish-kustomize-bundle.yaml@v1.8.1
     with:
       bundle-name: ghcr.io/datum-cloud/milo-kustomize
       bundle-path: config


### PR DESCRIPTION
- Upgrade publish-docker workflow from v1.7.2 to v1.8.1
- Upgrade publish-kustomize-bundle workflow from v1.7.2 to v1.8.1
- Add explicit dependency between kustomize and container image jobs
- Ensure kustomize bundles only publish after successful image build