### PR TITLE
Add Avatar URL and Last Login Provider to UserStatus in User API

### DIFF
--- a/config/crd/bases/iam/iam.miloapis.com_users.yaml
+++ b/config/crd/bases/iam/iam.miloapis.com_users.yaml
@@ -76,6 +76,12 @@ spec:
           status:
             description: UserStatus defines the observed state of User
             properties:
+              avatarUrl:
+                description: |-
+                  AvatarURL points to the avatar image associated with the user. This value is
+                  populated by the auth provider or any service that provides a user avatar URL.
+                format: uri
+                type: string
               conditions:
                 default:
                 - lastTransitionTime: "1970-01-01T00:00:00Z"
@@ -140,6 +146,19 @@ spec:
                   - type
                   type: object
                 type: array
+              lastLoginProvider:
+                allOf:
+                - enum:
+                  - github
+                  - google
+                - enum:
+                  - github
+                  - google
+                description: |-
+                  LastLoginProvider records the identity provider that was most recently used by the
+                  user to log in (e.g., "github" or "google"). This field is set by the auth provider
+                  based on authentication events.
+                type: string
               registrationApproval:
                 description: |-
                   RegistrationApproval represents the administrator’s decision on the user’s registration request.

--- a/docs/api/iam.md
+++ b/docs/api/iam.md
@@ -3809,12 +3809,31 @@ UserStatus defines the observed state of User
         </tr>
     </thead>
     <tbody><tr>
+        <td><b>avatarUrl</b></td>
+        <td>string</td>
+        <td>
+          AvatarURL points to the avatar image associated with the user. This value is
+populated by the auth provider or any service that provides a user avatar URL.<br/>
+          <br/>
+            <i>Format</i>: uri<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
         <td><b><a href="#userstatusconditionsindex">conditions</a></b></td>
         <td>[]object</td>
         <td>
           Conditions provide conditions that represent the current status of the User.<br/>
           <br/>
             <i>Default</i>: [map[lastTransitionTime:1970-01-01T00:00:00Z message:Waiting for control plane to reconcile reason:Unknown status:Unknown type:Ready]]<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>lastLoginProvider</b></td>
+        <td>string</td>
+        <td>
+          LastLoginProvider records the identity provider that was most recently used by the
+user to log in (e.g., "github" or "google"). This field is set by the auth provider
+based on authentication events.<br/>
         </td>
         <td>false</td>
       </tr><tr>

--- a/pkg/apis/iam/v1alpha1/user_types.go
+++ b/pkg/apis/iam/v1alpha1/user_types.go
@@ -98,6 +98,19 @@ type UserStatus struct {
 	// *Pending* and *Rejected* users are prevented for interacting with resources.
 	// +kubebuilder:validation:Enum=Pending;Approved;Rejected
 	RegistrationApproval RegistrationApprovalState `json:"registrationApproval,omitempty"`
+
+	// LastLoginProvider records the identity provider that was most recently used by the
+	// user to log in (e.g., "github" or "google"). This field is set by the auth provider
+	// based on authentication events.
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:validation:Enum=github;google
+	LastLoginProvider AuthProvider `json:"lastLoginProvider,omitempty"`
+
+	// AvatarURL points to the avatar image associated with the user. This value is
+	// populated by the auth provider or any service that provides a user avatar URL.
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:validation:Format=uri
+	AvatarURL string `json:"avatarUrl,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
@@ -108,3 +121,12 @@ type UserList struct {
 	metav1.ListMeta `json:"metadata,omitempty"`
 	Items           []User `json:"items"`
 }
+
+// AuthProvider represents an external identity provider used for user authentication.
+// +kubebuilder:validation:Enum=github;google
+type AuthProvider string
+
+const (
+	AuthProviderGitHub AuthProvider = "github"
+	AuthProviderGoogle AuthProvider = "google"
+)


### PR DESCRIPTION
This pull request introduces two new fields to the `UserStatus` struct of the User CRD:

- **avatarUrl**: A URL field representing the user's avatar, populated by the auth provider or any relevant service.
- **lastLoginProvider**: A string enum field that indicates the most recent authentication provider used by the user (supported: `github`, `google`). Useful for displaying in the front end.

Relates  https://github.com/datum-cloud/enhancements/issues/489