### PR TITLE
feat: include scope annotations in audit logs

### DIFF
--- a/cmd/milo/apiserver/config.go
+++ b/cmd/milo/apiserver/config.go
@@ -291,6 +291,10 @@ func DefaultBuildHandlerChain(apiHandler http.Handler, c *server.Config) http.Ha
 	handler = genericapifilters.WithAudit(handler, c.AuditBackend, c.AuditPolicyRuleEvaluator, c.LongRunningFunc)
 	handler = filterlatency.TrackStarted(handler, c.TracerProvider, "audit")
 
+	// Add platform scope annotations to audit events before the audit filter processes them.
+	// This must run AFTER the context decorators below have set user.extra with parent context.
+	handler = datumfilters.AuditScopeAnnotationDecorator(handler)
+
 	// These decorators are added after the audit filter to ensure they're run
 	// prior to the audit filter being run so they will include the user and
 	// organization contexts.

--- a/pkg/server/filters/audit_scope.go
+++ b/pkg/server/filters/audit_scope.go
@@ -1,0 +1,124 @@
+package filters
+
+import (
+	"net/http"
+
+	"k8s.io/apiserver/pkg/audit"
+	"k8s.io/apiserver/pkg/authentication/user"
+	"k8s.io/apiserver/pkg/endpoints/request"
+	"k8s.io/klog/v2"
+)
+
+const (
+	// PlatformNamespace is the namespace for platform-wide annotations
+	PlatformNamespace = "platform.miloapis.com/"
+
+	// Scope annotation keys - immediate scope only
+	ScopeTypeKey = PlatformNamespace + "scope.type"
+	ScopeNameKey = PlatformNamespace + "scope.name"
+
+	// Scope type values
+	ScopeTypeGlobal       = "global"
+	ScopeTypeOrganization = "organization"
+	ScopeTypeProject      = "project"
+	ScopeTypeUser         = "user"
+
+	// User extra keys (from iam.miloapis.com/v1alpha1/doc.go)
+	ParentTypeExtraKey = "iam.miloapis.com/parent-type"
+	ParentNameExtraKey = "iam.miloapis.com/parent-name"
+)
+
+// AuditScopeAnnotationDecorator adds platform scope annotations to audit events
+// based on the immediate parent context set in user.extra by earlier filters.
+//
+// This filter MUST run after:
+//   - UserContextAuthorizationDecorator
+//   - OrganizationContextAuthorizationDecorator
+//   - ProjectContextAuthorizationDecorator
+//
+// And BEFORE:
+//   - WithAudit (audit filter)
+//
+// This ensures user.extra is populated and annotations are added before
+// audit events are generated.
+func AuditScopeAnnotationDecorator(handler http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		ctx := req.Context()
+
+		// Get authenticated user from request context
+		userInfo, ok := request.UserFrom(ctx)
+		if !ok {
+			// No user info available, skip annotation (system requests, health checks)
+			handler.ServeHTTP(w, req)
+			return
+		}
+
+		// Determine immediate scope annotations from user.extra
+		annotations := determineScopeAnnotations(userInfo)
+
+		// Log for debugging
+		if klog.V(4).Enabled() {
+			klog.InfoS("AuditScopeAnnotationDecorator",
+				"user", userInfo.GetName(),
+				"scope.type", annotations[ScopeTypeKey],
+				"scope.name", annotations[ScopeNameKey],
+			)
+		}
+
+		// Add annotations to audit context
+		audit.AddAuditAnnotationsMap(ctx, annotations)
+
+		handler.ServeHTTP(w, req)
+	})
+}
+
+// determineScopeAnnotations extracts immediate scope information from user.Info.Extra
+// and returns platform scope annotations.
+//
+// This only captures the IMMEDIATE scope of the request (what's in user.extra),
+// not any parent/hierarchical relationships. Hierarchical queries should be
+// handled in the analytics layer by joining with resource metadata.
+func determineScopeAnnotations(userInfo user.Info) map[string]string {
+	annotations := make(map[string]string)
+
+	extra := userInfo.GetExtra()
+	parentType := getFirstExtraValue(extra, ParentTypeExtraKey)
+	parentName := getFirstExtraValue(extra, ParentNameExtraKey)
+
+	switch parentType {
+	case "Project":
+		annotations[ScopeTypeKey] = ScopeTypeProject
+		if parentName != "" {
+			annotations[ScopeNameKey] = parentName
+		}
+
+	case "Organization":
+		annotations[ScopeTypeKey] = ScopeTypeOrganization
+		if parentName != "" {
+			annotations[ScopeNameKey] = parentName
+		}
+
+	case "User":
+		annotations[ScopeTypeKey] = ScopeTypeUser
+		if parentName != "" {
+			annotations[ScopeNameKey] = parentName
+		}
+
+	default:
+		// No parent context = global/platform scope
+		annotations[ScopeTypeKey] = ScopeTypeGlobal
+		// No scope.name for global requests
+	}
+
+	return annotations
+}
+
+// getFirstExtraValue returns the first value from user.Extra for the given key,
+// or empty string if the key doesn't exist or has no values.
+func getFirstExtraValue(extra map[string][]string, key string) string {
+	values, ok := extra[key]
+	if !ok || len(values) == 0 {
+		return ""
+	}
+	return values[0]
+}

--- a/pkg/server/filters/audit_scope_test.go
+++ b/pkg/server/filters/audit_scope_test.go
@@ -1,0 +1,172 @@
+package filters
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apiserver/pkg/authentication/user"
+)
+
+func TestDetermineScopeAnnotations(t *testing.T) {
+	tests := []struct {
+		name     string
+		userInfo user.Info
+		want     map[string]string
+	}{
+		{
+			name: "project scope",
+			userInfo: &user.DefaultInfo{
+				Name: "test-user",
+				Extra: map[string][]string{
+					ParentTypeExtraKey: {"Project"},
+					ParentNameExtraKey: {"backend-api"},
+				},
+			},
+			want: map[string]string{
+				ScopeTypeKey: ScopeTypeProject,
+				ScopeNameKey: "backend-api",
+			},
+		},
+		{
+			name: "organization scope",
+			userInfo: &user.DefaultInfo{
+				Name: "test-user",
+				Extra: map[string][]string{
+					ParentTypeExtraKey: {"Organization"},
+					ParentNameExtraKey: {"acme-corp"},
+				},
+			},
+			want: map[string]string{
+				ScopeTypeKey: ScopeTypeOrganization,
+				ScopeNameKey: "acme-corp",
+			},
+		},
+		{
+			name: "user scope",
+			userInfo: &user.DefaultInfo{
+				Name: "test-user",
+				Extra: map[string][]string{
+					ParentTypeExtraKey: {"User"},
+					ParentNameExtraKey: {"alice"},
+				},
+			},
+			want: map[string]string{
+				ScopeTypeKey: ScopeTypeUser,
+				ScopeNameKey: "alice",
+			},
+		},
+		{
+			name: "global scope (no parent)",
+			userInfo: &user.DefaultInfo{
+				Name: "test-user",
+				Extra: map[string][]string{},
+			},
+			want: map[string]string{
+				ScopeTypeKey: ScopeTypeGlobal,
+				// No scope.name for global
+			},
+		},
+		{
+			name: "missing parent name (still sets type)",
+			userInfo: &user.DefaultInfo{
+				Name: "test-user",
+				Extra: map[string][]string{
+					ParentTypeExtraKey: {"Organization"},
+					// ParentNameExtraKey missing
+				},
+			},
+			want: map[string]string{
+				ScopeTypeKey: ScopeTypeOrganization,
+				// No scope.name since name is missing
+			},
+		},
+		{
+			name: "empty parent name array",
+			userInfo: &user.DefaultInfo{
+				Name: "test-user",
+				Extra: map[string][]string{
+					ParentTypeExtraKey: {"Project"},
+					ParentNameExtraKey: {}, // Empty array
+				},
+			},
+			want: map[string]string{
+				ScopeTypeKey: ScopeTypeProject,
+				// No scope.name since array is empty
+			},
+		},
+		{
+			name: "unknown parent type defaults to global",
+			userInfo: &user.DefaultInfo{
+				Name: "test-user",
+				Extra: map[string][]string{
+					ParentTypeExtraKey: {"UnknownType"},
+					ParentNameExtraKey: {"some-name"},
+				},
+			},
+			want: map[string]string{
+				ScopeTypeKey: ScopeTypeGlobal,
+				// No scope.name for global
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := determineScopeAnnotations(tt.userInfo)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestGetFirstExtraValue(t *testing.T) {
+	tests := []struct {
+		name  string
+		extra map[string][]string
+		key   string
+		want  string
+	}{
+		{
+			name: "value exists",
+			extra: map[string][]string{
+				"test-key": {"value1", "value2"},
+			},
+			key:  "test-key",
+			want: "value1",
+		},
+		{
+			name: "multiple values returns first",
+			extra: map[string][]string{
+				"test-key": {"first", "second", "third"},
+			},
+			key:  "test-key",
+			want: "first",
+		},
+		{
+			name:  "key missing",
+			extra: map[string][]string{},
+			key:   "missing-key",
+			want:  "",
+		},
+		{
+			name: "empty array",
+			extra: map[string][]string{
+				"test-key": {},
+			},
+			key:  "test-key",
+			want: "",
+		},
+		{
+			name:  "nil extra map",
+			extra: nil,
+			key:   "any-key",
+			want:  "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := getFirstExtraValue(tt.extra, tt.key)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

The apiserver will now include scope annotations on audit log data that's generated so it's easy to understand what scope the user's request was executed in when processed by the apiserver. This helps reduce the scope of what the vector processing pipeline needs to be responsible for.

The vector pipeline is unchanged to remain backwards compatible with the existing pipeline so it doesn't break when these changes are introduced.

### Details

Audit log annotations for requests made in the scope of an organization:

```json
  "annotations": {
    "platform.miloapis.com/scope.type": "organization",
    "platform.miloapis.com/scope.name": "acme-corp",
  }
```

Audit log annotations for requests made in the scope of a project:

```json
  "annotations": {
    "platform.miloapis.com/scope.type": "project",
    "platform.miloapis.com/scope.name": "frontend-app",
  }
```

Audit log annotations for requests made in the scope of a user:

```json
  "annotations": {
    "platform.miloapis.com/scope.type": "user",
    "platform.miloapis.com/scope.name": "alice",
  }
```
---

See: https://github.com/datum-cloud/enhancements/issues/536