### PR TITLE
feat: add fingerprintID to sessions

### DIFF
--- a/pkg/apis/identity/v1alpha1/types.go
+++ b/pkg/apis/identity/v1alpha1/types.go
@@ -13,11 +13,12 @@ type Session struct {
 }
 
 type SessionStatus struct {
-	UserUID   string       `json:"userUID"`
-	Provider  string       `json:"provider"`
-	IP        string       `json:"ip,omitempty"`
-	CreatedAt metav1.Time  `json:"createdAt"`
-	ExpiresAt *metav1.Time `json:"expiresAt,omitempty"`
+	UserUID       string       `json:"userUID"`
+	Provider      string       `json:"provider"`
+	IP            string       `json:"ip,omitempty"`
+	FingerprintID string       `json:"fingerprintID,omitempty"`
+	CreatedAt     metav1.Time  `json:"createdAt"`
+	ExpiresAt     *metav1.Time `json:"expiresAt,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/apis/identity/v1alpha1/zz_generated.openapi.go
+++ b/pkg/apis/identity/v1alpha1/zz_generated.openapi.go
@@ -134,6 +134,12 @@ func schema_pkg_apis_identity_v1alpha1_SessionStatus(ref common.ReferenceCallbac
 							Format: "",
 						},
 					},
+					"fingerprintID": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
 					"createdAt": {
 						SchemaProps: spec.SchemaProps{
 							Default: map[string]interface{}{},


### PR DESCRIPTION
Adding fingerprintID to sessions object so that we can group or identify active sessions by the devices user agent