### PR TITLE
chore: expose avatarUrl in OrganizationMemberships

### DIFF
--- a/config/crd/bases/resourcemanager/resourcemanager.miloapis.com_organizationmemberships.yaml
+++ b/config/crd/bases/resourcemanager/resourcemanager.miloapis.com_organizationmemberships.yaml
@@ -373,6 +373,9 @@ spec:
                   User contains cached information about the user in this membership.
                   This information is populated by the controller from the referenced user.
                 properties:
+                  avatarUrl:
+                    description: AvatarURL is the avatar URL of the user in the membership.
+                    type: string
                   email:
                     description: Email is the email of the user in the membership.
                     type: string

--- a/docs/api/resourcemanager.md
+++ b/docs/api/resourcemanager.md
@@ -639,6 +639,13 @@ This information is populated by the controller from the referenced user.
         </tr>
     </thead>
     <tbody><tr>
+        <td><b>avatarUrl</b></td>
+        <td>string</td>
+        <td>
+          AvatarURL is the avatar URL of the user in the membership.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
         <td><b>email</b></td>
         <td>string</td>
         <td>

--- a/internal/controllers/resourcemanager/organization_membership_controller.go
+++ b/internal/controllers/resourcemanager/organization_membership_controller.go
@@ -172,6 +172,7 @@ func (r *OrganizationMembershipController) Reconcile(ctx context.Context, req ct
 		Email:      user.Spec.Email,
 		GivenName:  user.Spec.GivenName,
 		FamilyName: user.Spec.FamilyName,
+		AvatarURL:  user.Status.AvatarURL,
 	}
 
 	// Set ready condition to true

--- a/pkg/apis/resourcemanager/v1alpha1/organizationmembership_types.go
+++ b/pkg/apis/resourcemanager/v1alpha1/organizationmembership_types.go
@@ -303,6 +303,9 @@ type OrganizationMembershipUserStatus struct {
 	// FamilyName is the family name of the user in the membership.
 	// +kubebuilder:validation:Optional
 	FamilyName string `json:"familyName,omitempty"`
+	// AvatarURL is the avatar URL of the user in the membership.
+	// +kubebuilder:validation:Optional
+	AvatarURL string `json:"avatarUrl,omitempty"`
 }
 
 // OrganizationMembershipOrganizationStatus defines the observed state of an organization in a membership.


### PR DESCRIPTION
Add avatarUrl field to OrganizationMembership status to expose user avatar information through the API endpoint. This allows clients to display user avatars without making additional requests to the User resource.

Changes:
- Add AvatarURL field to OrganizationMembershipUserStatus struct
- Update controller to populate avatarUrl from User.Status.AvatarURL
- Field automatically refreshes when user avatar changes via existing watch mechanism

The controller already watches User resources and reconciles affected OrganizationMemberships, so avatar updates propagate automatically.