### PR TITLE
remove 'organizations.list' permission from viewer role

### DIFF
--- a/config/roles/organization-viewer.yaml
+++ b/config/roles/organization-viewer.yaml
@@ -11,5 +11,4 @@ spec:
     - name: organizationmembership-reader
   includedPermissions:
     - resourcemanager.miloapis.com/organizations.get
-    - resourcemanager.miloapis.com/organizations.list
     - resourcemanager.miloapis.com/organizations.watch


### PR DESCRIPTION
End-users should not have the ability to list organizations. They're required to query organizations through the OrganizationMembership resource which shows only the organizations they have access to.