### PR TITLE
feat: add proxy client certificate support

### DIFF
--- a/cmd/milo/apiserver/server.go
+++ b/cmd/milo/apiserver/server.go
@@ -140,7 +140,23 @@ func NewCommand() *cobra.Command {
 	s.Metrics.AddFlags(namedFlagSets.FlagSet("metrics"))
 	logsapi.AddFlags(s.Logs, namedFlagSets.FlagSet("logs"))
 	s.Traces.AddFlags(namedFlagSets.FlagSet("traces"))
-	// Add misc flags for event ttl
+
+	// Add misc flags for event ttl, proxy client certs, etc.
+	miscfs := namedFlagSets.FlagSet("misc")
+	miscfs.DurationVar(&s.EventTTL, "event-ttl", s.EventTTL,
+		"Amount of time to retain events.")
+	miscfs.StringVar(&s.ProxyClientCertFile, "proxy-client-cert-file", s.ProxyClientCertFile,
+		"Client certificate used to prove the identity of the aggregator or kube-apiserver "+
+			"when it must call out during a request. This includes proxying requests to a user "+
+			"api-server and calling out to webhook admission plugins. It is expected that this "+
+			"cert includes a signature from the CA in the --requestheader-client-ca-file flag. "+
+			"That CA is published in the 'extension-apiserver-authentication' configmap in "+
+			"the kube-system namespace. Components receiving calls from kube-aggregator should "+
+			"use that CA to perform their half of the mutual TLS verification.")
+	miscfs.StringVar(&s.ProxyClientKeyFile, "proxy-client-key-file", s.ProxyClientKeyFile,
+		"Private key for the client certificate used to prove the identity of the aggregator or kube-apiserver "+
+			"when it must call out during a request. This includes proxying requests to a user "+
+			"api-server and calling out to webhook admission plugins.")
 
 	verflag.AddFlags(namedFlagSets.FlagSet("global"))
 	globalflag.AddGlobalFlags(namedFlagSets.FlagSet("global"), cmd.Name(), logs.SkipLoggingConfigurationFlags())

--- a/config/apiserver/deployment.yaml
+++ b/config/apiserver/deployment.yaml
@@ -51,6 +51,8 @@ spec:
           - --audit-webhook-config-file=$(AUDIT_WEBHOOK_CONFIG_FILE)
           - --audit-webhook-mode=$(AUDIT_WEBHOOK_MODE)
           - --audit-webhook-initial-backoff=$(AUDIT_WEBHOOK_INITIAL_BACKOFF)
+          - --proxy-client-cert-file=$(PROXY_CLIENT_CERT_FILE)
+          - --proxy-client-key-file=$(PROXY_CLIENT_KEY_FILE)
           - --feature-sessions=true
           - --sessions-provider-url=$(SESSIONS_PROVIDER_URL)
           - --sessions-provider-ca-file=$(SESSIONS_PROVIDER_CA_FILE)
@@ -111,6 +113,10 @@ spec:
           - name: AUDIT_WEBHOOK_MODE
             value: ""
           - name: AUDIT_WEBHOOK_INITIAL_BACKOFF
+            value: ""
+          - name: PROXY_CLIENT_CERT_FILE
+            value: ""
+          - name: PROXY_CLIENT_KEY_FILE
             value: ""
           - name: SESSIONS_PROVIDER_URL
             value: ""


### PR DESCRIPTION
## Summary

Add `--proxy-client-cert-file` and `--proxy-client-key-file` flags to enable mTLS authentication when proxying requests to aggregated API servers.

This allows aggregated API servers to trust authentication headers (`X-Remote-User`, `X-Remote-Group`, etc.) forwarded by Milo, resolving `system:anonymous` user issues.

## Detail

As I was working through deploying the activity-apiserver as an aggregated API on Milo's platform, I ran into issues where the activity apiserver was receiving requests with the `system:anonymous` user instead of the end-user I was authenticating as. 

I was able to trace this down to being caused by Milo not having a proxy client certificate issued that it uses to communicate with aggregated apiservers. 

---

Causes https://github.com/datum-cloud/enhancements/issues/536#issuecomment-3687933423