### PR TITLE
feat: enable remote UID proxying feature gate

### DIFF
--- a/cmd/milo/apiserver/server.go
+++ b/cmd/milo/apiserver/server.go
@@ -49,6 +49,7 @@ func init() {
 	utilruntime.Must(logsapi.AddFeatureGates(utilfeature.DefaultMutableFeatureGate))
 	// Enable JSON logging support by default
 	utilfeature.DefaultMutableFeatureGate.Set("LoggingBetaOptions=true")
+	utilfeature.DefaultMutableFeatureGate.Set("RemoteRequestHeaderUID=true")
 }
 
 var (


### PR DESCRIPTION
Our authorization system expects to use the UID to resolve the authenticated user to their user profile in the system so we can confirm they're a valid user. 

By default, the k8s apiserver does not include the UID when proxying requests to aggregated apiservers. This leads to authorization failures from aggregated apiservers because they don't receive the UID and can't include it when creating the **SubjectAccessReview**.

From the docs on this feature flag:

> Enable the API server to accept UIDs (user IDs) via request header authentication. This will also make the kube-apiserver's API aggregator add UIDs via standard headers when forwarding requests to the servers serving the aggregated API.

See: https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/

---

Relates to https://github.com/datum-cloud/enhancements/issues/536