### PR TITLE
fix(notes): resolve subject API version dynamically instead of hardcoding

### DIFF
--- a/cmd/milo/controller-manager/controllermanager.go
+++ b/cmd/milo/controller-manager/controllermanager.go
@@ -466,6 +466,11 @@ func Run(ctx context.Context, c *config.CompletedConfig, opts *Options) error {
 					Metrics: metricsserver.Options{
 						BindAddress: "0",
 					},
+					// Use the same REST mapper as the controller context to share the
+					// cached API discovery across the webhook manager and controllers.
+					MapperProvider: func(c *restclient.Config, httpClient *http.Client) (meta.RESTMapper, error) {
+						return controllerContext.RESTMapper, nil
+					},
 					WebhookServer: webhook.NewServer(webhook.Options{
 						Port:    opts.ControllerRuntimeWebhookPort,
 						CertDir: opts.SecureServing.ServerCert.CertDirectory,

--- a/internal/webhooks/notes/v1alpha1/clusternote_webhook_test.go
+++ b/internal/webhooks/notes/v1alpha1/clusternote_webhook_test.go
@@ -16,6 +16,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
+// Note: newTestRESTMapper is defined in note_webhook_test.go and shared across tests in this package
+
 func TestClusterNoteMutator_Default(t *testing.T) {
 	tests := map[string]struct {
 		clusterNote   *notesv1alpha1.ClusterNote
@@ -124,8 +126,9 @@ func TestClusterNoteMutator_Default(t *testing.T) {
 
 			fakeClient := fake.NewClientBuilder().WithScheme(testScheme).WithObjects(objects...).Build()
 			mutator := &ClusterNoteMutator{
-				Client: fakeClient,
-				Scheme: testScheme,
+				Client:     fakeClient,
+				Scheme:     testScheme,
+				RESTMapper: newTestRESTMapper(),
 			}
 
 			// Create admission request context

--- a/internal/webhooks/notes/v1alpha1/note_webhook_test.go
+++ b/internal/webhooks/notes/v1alpha1/note_webhook_test.go
@@ -8,9 +8,11 @@ import (
 	"github.com/stretchr/testify/require"
 	iamv1alpha1 "go.miloapis.com/milo/pkg/apis/iam/v1alpha1"
 	notesv1alpha1 "go.miloapis.com/milo/pkg/apis/notes/v1alpha1"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -23,6 +25,27 @@ var testScheme = runtime.NewScheme()
 func init() {
 	utilruntime.Must(iamv1alpha1.AddToScheme(testScheme))
 	utilruntime.Must(notesv1alpha1.AddToScheme(testScheme))
+}
+
+// newTestRESTMapper creates a RESTMapper for testing that knows about common test resources
+func newTestRESTMapper() meta.RESTMapper {
+	mapper := meta.NewDefaultRESTMapper([]schema.GroupVersion{
+		{Group: "networking.datumapis.com", Version: "v1alpha1"},
+		{Group: "resourcemanager.miloapis.com", Version: "v1alpha1"},
+	})
+	// Register Domain as a namespaced resource
+	mapper.Add(schema.GroupVersionKind{
+		Group:   "networking.datumapis.com",
+		Version: "v1alpha1",
+		Kind:    "Domain",
+	}, meta.RESTScopeNamespace)
+	// Register Organization as a cluster-scoped resource
+	mapper.Add(schema.GroupVersionKind{
+		Group:   "resourcemanager.miloapis.com",
+		Version: "v1alpha1",
+		Kind:    "Organization",
+	}, meta.RESTScopeRoot)
+	return mapper
 }
 
 func TestNoteMutator_Default(t *testing.T) {
@@ -137,8 +160,9 @@ func TestNoteMutator_Default(t *testing.T) {
 
 			fakeClient := fake.NewClientBuilder().WithScheme(testScheme).WithObjects(objects...).Build()
 			mutator := &NoteMutator{
-				Client: fakeClient,
-				Scheme: testScheme,
+				Client:     fakeClient,
+				Scheme:     testScheme,
+				RESTMapper: newTestRESTMapper(),
 			}
 
 			// Create admission request context


### PR DESCRIPTION
## Summary
- Fixes error when creating notes on Domain resources: "no matches for kind Domain in version networking.datumapis.com/v1alpha1"
- The webhook was assuming all resources use `v1alpha1`, but Domain uses `v1alpha`
- Now the webhook automatically discovers the correct API version

## Test plan
- [x] Unit tests passing
- [ ] Create a note on a Domain resource and verify it succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)