### PR TITLE
feat: add Events proxy for Activity API forwarding

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,736 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with
+code in this repository.
+
+## Project Overview
+
+Milo is a "business operating system" for product-led B2B companies built on
+Kubernetes. It provides a comprehensive system of record for organizations,
+projects, users, audit logs, and other business operations through a
+Kubernetes-like API experience.
+
+## Core Architecture
+
+Milo is built on the Kubernetes API server library and provides its own
+dedicated API server with custom resource definitions (CRDs). The system follows
+standard Kubernetes controller patterns with multi-cluster capabilities.
+
+### Key Components
+
+- **API Server**: Built on k8s.io/apiserver library, provides the main API
+  interface
+- **Controllers**: Standard Kubernetes controllers that reconcile custom
+  resources
+- **Multi-cluster Runtime**: Cross-cluster resource management using
+  sigs.k8s.io/multicluster-runtime
+- **Provider Framework**: Extensible integration system for third-party services
+
+### Resource Hierarchy
+
+1. **Organizations** (cluster-scoped): Top-level business entities with types
+   (Personal/Standard/Business)
+2. **Projects** (namespaced): Resource organization units within organizations
+3. **Users & Groups** (IAM): Identity management with RBAC
+4. **OrganizationMemberships**: Link users to organizations
+5. **ProjectControlPlanes**: Cross-cluster project provisioning
+
+### API Structure
+
+Custom resources are organized under three main API groups:
+- `resourcemanager.miloapis.com/v1alpha1`: Organizations, Projects,
+  OrganizationMemberships
+- `iam.miloapis.com/v1alpha1`: Users, Groups, Roles, PolicyBindings
+- `infrastructure.miloapis.com/v1alpha1`: ProjectControlPlanes
+
+## Development Commands
+
+### Code Generation
+```bash
+# Generate deepcopy, CRDs, webhooks, and RBAC
+task generate
+
+# Generate API documentation
+task api-docs
+```
+
+### Development Certificates
+```bash
+# Generate self-signed certs for local webhook development
+task generate-dev-certs
+```
+
+### Build and Run
+```bash
+# Build container image (preferred approach)
+task dev:build
+
+# For local development, use the complete development setup
+task dev:setup    # Sets up test infrastructure + deploys Milo
+
+# Access Milo API server (instead of running locally)
+task kubectl -- get organizations
+task kubectl -- apply -f config/samples/resourcemanager/v1alpha1/organization.yaml
+```
+
+### Testing
+```bash
+# Run unit tests
+task test:unit
+
+# Run end-to-end tests with Chainsaw
+task test:end-to-end
+
+# Individual test directories contain chainsaw-test.yaml files
+# Use task commands instead of running chainsaw directly
+```
+
+### Development Environment
+```bash
+# PREFERRED: Use complete Task-based development setup
+task dev:setup    # Creates test infrastructure + deploys Milo
+
+# Alternative: Start local development dependencies only
+docker-compose up -d    # Start OpenFGA, Zitadel, Mailhog
+
+# Use Task commands for deployment instead of direct kubectl
+task kubectl -- apply -k config/dev
+```
+
+### Test Infrastructure
+```bash
+# Deploy complete test infrastructure with etcd, API server, and controller manager
+task dev:setup
+
+# Deploy test infrastructure with OpenFGA authorization provider
+task dev:setup:openfga
+
+# Deploy only (assumes cluster already exists)
+task dev:deploy           # Standard deployment
+task dev:deploy:openfga   # With OpenFGA provider
+
+# Switch to use Milo API server
+export KUBECONFIG=.milo/kubeconfig
+
+# Then test with Task wrapper (automatically uses .milo/kubeconfig):
+task kubectl -- get organizations
+task kubectl -- get projects  
+task kubectl -- get users
+
+# Task kubectl wrapper handles kubeconfig automatically
+```
+
+### Test Infrastructure Management
+The Milo taskfile includes remote access to the `datum-cloud/test-infra` repository for managing test environments. This uses Go Task's experimental remote taskfiles feature.
+
+```bash
+# Direct access to test-infra commands (requires TASK_X_REMOTE_TASKFILES=1)
+task test-infra:cluster-up        # Start a new test cluster
+task test-infra:cluster-down      # Tear down the cluster
+task test-infra:install-tools     # Install required tools
+task test-infra:status            # Check infrastructure status
+
+# Convenience wrapper commands (automatically set environment variable)
+task test-infra-cluster           # Start cluster (wrapper)
+task test-infra-cluster-down      # Stop cluster (wrapper)
+task test-infra-install-tools     # Install tools (wrapper)
+task test-infra-status            # Status check (wrapper)
+task test-infra-clean             # Clean up resources (wrapper)
+```
+
+**Note**: Remote taskfiles are an experimental feature. The environment variable `TASK_X_REMOTE_TASKFILES=1` is automatically set in the taskfile configuration.
+
+### Authentication
+The test-infra deployment includes pre-configured authentication:
+- **Kubeconfig**: `.milo/kubeconfig` (standard location, committed to repo)
+- **Admin Token**: `test-admin-token` (system:masters group)
+- **User Token**: `test-user-token` (system:authenticated group)
+- **API Endpoint**: `http://localhost:8080` (via Envoy Gateway)
+
+## Code Structure
+
+### Controllers
+- Located in `internal/controllers/`
+- Follow standard controller-runtime patterns
+- Support both single-cluster and multi-cluster operations
+- Use finalizers for proper cleanup
+
+### API Types
+- Located in `pkg/apis/`
+- Follow Kubernetes API conventions
+- Use kubebuilder markers for code generation
+- Include validation and printer columns
+
+### Multi-cluster Support
+- `pkg/multicluster-runtime/` contains cross-cluster abstractions
+- Controllers can manage resources across multiple clusters
+- Infrastructure cluster client separate from control plane client
+
+### Webhooks
+- Located in `internal/webhooks/`
+- Provide validation and mutation for custom resources
+- Generated manifests in `config/webhook/`
+
+## Important Patterns
+
+### Organization Namespacing
+Organizations automatically get associated namespaces named
+`organization-{name}`. The organization controller sets owner references to
+manage namespace lifecycle.
+
+### Project Control Planes
+Projects can provision dedicated control planes in infrastructure clusters
+through ProjectControlPlane resources. This enables true multi-tenancy and
+resource isolation.
+
+### Provider Integration
+The system uses a provider pattern for integrating with external services like
+authentication (Zitadel), authorization (OpenFGA), and future integrations for
+billing, support, etc.
+
+### Cross-cluster Resource Management
+Controllers can watch and manage resources across multiple Kubernetes clusters
+using the multicluster-runtime framework.
+
+## Configuration Management
+
+- Kustomize overlays in `config/` directory
+- Base configurations in `config/*/base/`
+- Environment-specific overlays in `config/*/overlays/`
+- Sample resources in `config/samples/`
+- Protected resources (system defaults) in `config/protected-resources/`
+
+## Task Automation
+
+**IMPORTANT: This project uses Taskfile.yaml for ALL automation and development commands. Always use `task` commands instead of running tools directly.**
+
+### Core Development Tasks
+```bash
+# See all available tasks
+task --list
+
+# Code generation (REQUIRED after API changes)
+task generate              # Generate deepcopy, CRDs, webhooks, RBAC
+task generate:docs         # Generate API documentation with crdoc
+
+# Development environment
+task dev:setup             # Complete test infrastructure setup
+task dev:deploy            # Deploy Milo to existing cluster
+task dev:redeploy          # Quick rebuild and redeploy during development
+
+# Build and container management
+task dev:build             # Build Milo container image
+task dev:load              # Load image into kind cluster
+
+# Testing
+task test:unit             # Run Go unit tests
+task test:end-to-end       # Run Chainsaw e2e tests against Milo API
+
+# Milo API server access (use instead of direct kubectl)
+task kubectl -- get organizations    # Access Milo API server
+task kubectl -- get projects         # Using .milo/kubeconfig automatically
+task kubectl -- apply -f resource.yaml
+```
+
+### Test Infrastructure Management
+```bash
+# Test infrastructure (remote taskfile integration)
+task test-infra-cluster          # Start test cluster
+task test-infra-cluster-down     # Stop and cleanup cluster
+task test-infra-status           # Check infrastructure status
+task test-infra-install-tools    # Install required development tools
+
+# Direct test-infra access (requires TASK_X_REMOTE_TASKFILES=1)
+task test-infra:kubectl -- get pods -A    # Access infrastructure cluster
+```
+
+**Rule: NEVER run tools like `controller-gen`, `chainsaw`, `kubectl` directly. Always use the appropriate `task` command.**
+
+## Claude Agent Specializations
+
+This repository includes specialized Claude agent configurations in `.claude/agents/` to provide domain-specific expertise:
+
+### Development Agents
+- **kubernetes-controller-specialist**: Controller development, reconciliation logic, RBAC, multi-cluster operations
+- **kubernetes-api-designer**: CRD creation, API validation, webhook implementation, schema design
+- **milo-devops-automation**: Deployment workflows, Taskfile management, infrastructure automation
+
+### Quality & Security Agents  
+- **chainsaw-test-specialist**: End-to-end testing with Chainsaw framework, test scenario design
+- **milo-security-auditor**: Security analysis, RBAC auditing, vulnerability assessment
+- **milo-architecture-documenter**: API documentation generation, architectural decision records
+
+### Agent Activation
+Agents activate automatically based on:
+- **File paths**: `internal/controllers/` → controller-specialist, `pkg/apis/` → api-designer
+- **Keywords**: "reconcile", "CRD", "deploy", "test", "security", "docs"
+- **Tasks**: Controller development, API changes, deployment issues, testing, security reviews
+
+See `.claude/agents/README.md` for complete agent documentation and collaboration patterns.
+
+## Orchestration and Subagent Usage
+
+**IMPORTANT**: Always use specialized subagents (via the Task tool) for complex
+work to manage context effectively and provide focused expertise.
+
+### When to Use Subagents
+
+- **Investigation tasks**: Use `datum-platform:sre` for cluster debugging,
+  `Explore` for codebase exploration
+- **Implementation tasks**: Use `datum-platform:api-dev` for Go backend work,
+  `datum-platform:frontend-dev` for UI changes
+- **Review tasks**: Use `datum-platform:code-reviewer` after implementation
+- **Testing tasks**: Use `datum-platform:test-engineer` for writing tests
+
+### Orchestration Pattern
+
+1. **Analyze the request** and determine which specialized agent(s) to invoke
+2. **Launch subagents** with clear, focused prompts describing the specific task
+3. **Monitor progress** and provide high-level status updates to the user
+4. **Synthesize results** from subagents into concise summaries
+5. **Ask for feedback** when subagents surface multiple approaches or need
+   clarification
+
+### Subagent Communication
+
+Subagents should report back with:
+
+- **Findings**: What was discovered or accomplished
+- **Status**: Success, failure, or blocked (with reason)
+- **Recommendations**: Suggested next steps or decisions needed
+- **Artifacts**: File paths, code changes, or outputs produced
+
+The orchestrating agent then:
+
+- Provides high-level summaries to the user
+- Synthesizes information across multiple subagents
+- Escalates decisions that require user input
+- Coordinates handoffs between specialized agents
+
+### Benefits
+
+- **Context management**: Each subagent focuses on its domain without consuming
+  main conversation context
+- **Expertise**: Specialized agents have domain-specific knowledge and patterns
+- **Parallelism**: Multiple subagents can work simultaneously on independent
+  tasks
+- **Quality**: Dedicated review and testing agents ensure implementation
+  quality
+
+# User Rules
+
+## Kubernetes API Conventions - use when writing APIs and operators with kubebuilder / controller-runtime
+
+### Kubernetes API conventions — distilled cheatsheet
+
+Use this as background context when writing or reviewing Kubernetes‑style APIs,
+CRDs, or controllers.  (Each bullet is a rule‑of‑thumb; details and corner‑cases
+exist in the full SIG‑Architecture document.)
+
+---
+
+#### 1. Object hierarchy & vocabulary
+
+* **Resource** = REST endpoint (`/pods`, `/deployments`).
+* **Kind / Type** = schema name inside `apiVersion` & `kind` fields (e.g.
+  `Pod`). Grouped into: Objects (persistent), Lists, and Aux/Simple types.
+  ([GitHub][1])
+* **Sub‑resources** (e.g. `/status`, `/scale`, `/binding`) expose limited views
+  or verbs on the parent resource.
+
+---
+
+#### 2. Standard top‑level fields
+
+```yaml
+apiVersion: group/majorVersion
+kind: Kind
+metadata: …   # identity & bookkeeping
+spec: …       # desired state (set by users/controllers)
+status: …     # observed state (set by controllers only)
+```
+
+Spec ↔ Status separation is mandatory; controllers must not mutate `spec` and
+users must not write `status`. ([Kubernetes][2], [Kubernetes][3])
+
+---
+
+#### 3. `metadata` essentials
+
+* **name**: DNS‑label (≤ 253 chars); immutable once created.
+* **namespace**: optional; cluster‑scoped kinds omit it.
+* **uid**: system‑assigned UUID; never reused.
+* **resourceVersion**: for optimistic concurrency & watch bookmarks.
+  ([GitHub][4])
+* **generation / observedGeneration**: bump on `spec` changes; controllers copy
+  to `status.observedGeneration`.
+* **labels** = indexed, 63‑char segments; **annotations** = unindexed, arbitrary
+  size.
+* **ownerReferences** + **finalizers** for garbage‑collection & ordered
+  deletion.
+
+---
+
+#### 4. Field design rules
+
+* **Names**: `camelCase` for JSON/YAML, GoStruct `CamelCase`.
+* **Primitives**: use `int32` for counts/ports, `int64` for resources;
+  quantities go through `resource.Quantity`.
+* **Booleans**: use `*bool` when “unset” differs from “false”.
+* **Lists**: stateful sets should be strictly ordered; otherwise treat as sets
+  (unique items).
+* **Maps**: keys are strings (DNS‑label or label‑key form).
+* **Enums**: `PascalCase` strings; avoid magic integers.
+
+---
+
+#### 5. Defaulting & validation
+
+* Provide API‑server defaults via admission.
+* Mark required fields with `+kubebuilder:validation:Required` (or similar).
+* Never change the meaning of an existing default.
+
+---
+
+#### 6. API versioning & compatibility
+
+* Minor/patch changes must be **backward‑compatible** within a given `v1` group.
+* **No field deletions or rename breaks** once GA.
+* Behaviors may be extended only in opt‑in way (feature gates or new fields).
+* Deprecate in `vNbetaX` first, remove no sooner than **2 stable releases**
+  later.
+
+---
+
+#### 7. Concurrency & consistency patterns
+
+* Use `resourceVersion` preconditions (`metadata.resourceVersion` in PUT/PATCH)
+  for CAS updates. ([pulumi][5])
+* Controllers reconcile desired vs. observed; must tolerate stale reads
+  (level‑based logic).
+
+---
+
+#### 8. Sub‑resource conventions
+
+* `/status` : PATCH/PUT only status fields.
+* `/scale` : `spec.replicas`, `status.replicas`.
+* `/finalize`, `/eviction`, `/binding`, `/proxy`, etc. follow reserved
+  semantics.
+
+---
+
+#### 9. Error & status objects
+
+`Status{ status:"Failure", reason:"Invalid", message:"...", code:400 }` is the
+canonical error envelope.
+
+---
+
+#### 10. Label/selector patterns
+
+* Labels map to field selectors & set‑based selectors (`matchLabels`,
+  `matchExpressions`).
+* Never assume global uniqueness—always pair `namespace` + `name`.
+
+---
+
+**Remember:** this is a terse reference; the full SIG‑Architecture *API
+Conventions* doc covers edge‑cases, historical context, and nuanced exceptions.
+([iximiuz.com][6])
+
+[1]:
+    https://github.com/zecke/Kubernetes/blob/master/docs/devel/api-conventions.md?utm_source=chatgpt.com
+    "Kubernetes/docs/devel/api-conventions.md at master - GitHub"
+[2]:
+    https://kubernetes.io/docs/concepts/overview/working-with-objects/?utm_source=chatgpt.com
+    "Objects In Kubernetes"
+[3]:
+    https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/?utm_source=chatgpt.com
+    "Custom Resources - Kubernetes"
+[4]:
+    https://github.com/kubernetes-client/ruby/blob/master/kubernetes/docs/V1ListMeta.md?utm_source=chatgpt.com
+    "V1ListMeta.md - kubernetes-client/ruby - GitHub"
+[5]:
+    https://www.pulumi.com/registry/packages/kubernetes/api-docs/events/v1beta1/event/?utm_source=chatgpt.com
+    "kubernetes.events.k8s.io.v1beta1.Event | Pulumi Registry"
+[6]:
+    https://iximiuz.com/en/posts/kubernetes-api-structure-and-terminology/?utm_source=chatgpt.com
+    "Kubernetes API Basics - Resources, Kinds, and Objects"
+
+
+### Technical Writing Guidance
+
+### Core Principles
+
+Technical writing prioritizes **clarity above all other considerations**. Every
+choice should serve the goal of making information clearer, more accessible, and
+more actionable for your target audience.
+
+---
+
+### 1. Words and Terminology
+
+#### Use Terms Consistently
+
+- **MUST**: Define abbreviations and acronyms on first use: "Application
+  Programming Interface (API)"
+- **MUST**: Use the same term throughout a document (don't vary between
+  "directory" and "folder")
+- **SHOULD**: Only define acronyms that are significantly shorter and appear
+  multiple times
+- **SHOULD NOT**: Define acronyms used only once or twice
+
+#### Choose Strong, Specific Verbs
+
+- **PREFER**: Precise, strong verbs over weak, generic ones
+- **AVOID**: Overusing forms of "be" (is, are, was, were)
+- **AVOID**: Generic verbs like "occur" and "happen"
+
+**Examples:**
+
+- ❌ "The exception occurs when dividing by zero"
+- ✅ "Dividing by zero raises the exception"
+- ❌ "We are very careful to ensure..."
+- ✅ "We carefully ensure..."
+
+#### Avoid Ambiguous Pronouns
+
+- **MUST**: Place pronouns close to their referring nouns (within 5 words)
+- **MUST**: Make clear what "it," "they," "this," and "that" refer to
+- **SHOULD**: Replace ambiguous pronouns with specific nouns
+- **SHOULD**: Add clarifying nouns after "this" and "that"
+
+**Examples:**
+
+- ❌ "Running the process configures permissions and generates a user ID. This
+  lets users authenticate."
+- ✅ "Running the process configures permissions and generates a user ID. This
+  user ID lets users authenticate."
+
+---
+
+### 2. Voice and Sentence Structure
+
+#### Use Active Voice
+
+- **PREFER**: Active voice over passive voice
+- **FORMULA**: Active = actor + verb + target
+- **RECOGNIZE**: Passive = form of "be" + past participle verb
+
+**Examples:**
+
+- ❌ "The code is compiled by the system"
+- ✅ "The system compiles the code"
+- ❌ "Mistakes were made"
+- ✅ "The team made mistakes"
+
+#### Write Clear, Focused Sentences
+
+- **MUST**: Focus each sentence on a single idea
+- **SHOULD**: Convert long sentences to lists when appropriate
+- **SHOULD**: Eliminate unnecessary words
+
+#### Reduce "There is/There are" Constructions
+
+- **AVOID**: Starting sentences with "There is" or "There are"
+- **REPLACE**: With actual subjects and verbs
+
+**Examples:**
+
+- ❌ "There is a variable called `met_trick` that stores the current accuracy"
+- ✅ "The `met_trick` variable stores the current accuracy"
+
+---
+
+### 3. Lists and Structure
+
+#### Use Appropriate List Types
+
+- **USE**: Numbered lists when order matters (procedures, rankings)
+- **USE**: Bulleted lists when order doesn't matter
+- **MUST**: Keep list items parallel in structure
+- **SHOULD**: Start numbered list items with imperative verbs
+
+#### Format Lists Properly
+
+- **MUST**: Introduce lists with appropriate lead-in text
+- **SHOULD**: Use parallel structure across all list items
+- **CONSIDER**: Breaking long paragraphs into lists for scannability
+
+---
+
+### 4. Paragraphs and Document Structure
+
+#### Focus Paragraphs
+
+- **MUST**: Focus each paragraph on a single topic
+- **MUST**: Start paragraphs with strong opening sentences
+- **SHOULD**: State the paragraph's main point early
+
+#### Organize Documents
+
+- **MUST**: State key points at the start of the document
+- **MUST**: Define your document's scope and audience upfront
+- **SHOULD**: Break long topics into appropriate sections
+- **SHOULD**: Use clear, descriptive headings
+
+---
+
+### 5. Audience and Accessibility
+
+#### Know Your Audience
+
+- **MUST**: Identify your target audience explicitly
+- **MUST**: Determine what your audience already knows
+- **MUST**: Determine what your audience needs to learn
+- **AVOID**: The "curse of knowledge" (assuming readers know what you know)
+
+#### Write for Accessibility
+
+- **MUST**: Provide alt text for all images
+- **MUST**: Ensure sufficient color contrast
+- **MUST**: Use descriptive link text (not "click here")
+- **AVOID**: Relying solely on visual indicators
+- **USE**: Inclusive language that doesn't exclude groups
+
+#### Alt Text Guidelines
+
+- **MUST**: Describe the purpose and context of images
+- **SHOULD**: Be concise but informative
+- **FOCUS**: On what readers need to understand from the image
+
+---
+
+### 6. Visual Elements and Formatting
+
+#### Illustrations and Diagrams
+
+- **WRITE**: Captions before creating illustrations
+- **LIMIT**: Information in single diagrams (avoid visual clutter)
+- **USE**: Callouts to focus attention on key elements
+- **ITERATE**: Revise illustrations for clarity
+
+#### Code and Technical Elements
+
+- **FORMAT**: Code-related text in code font
+- **PLACE**: Code examples close to explanatory text
+- **ENSURE**: Code examples are:
+  - Useful and accurate
+  - Concise but complete
+  - Well-commented
+  - Demonstrating appropriate complexity range
+
+---
+
+### 7. Error Messages and Instructions
+
+#### Error Message Principles
+
+Great error messages answer two questions:
+
+1. **What went wrong?**
+2. **How does the user fix it?**
+
+#### Error Message Requirements
+
+- **IDENTIFY**: The specific cause of the error
+- **SPECIFY**: Invalid inputs when applicable
+- **EXPLAIN**: Requirements and constraints
+- **PROVIDE**: Clear solution steps
+- **INCLUDE**: Examples when helpful
+
+#### Error Message Writing
+
+- **BE**: Concise but not cryptic
+- **AVOID**: Double negatives
+- **USE**: Consistent terminology
+- **SET**: Positive, helpful tone
+- **DON'T**: Be overly apologetic
+
+---
+
+### 8. Style and Tone
+
+#### General Style
+
+- **WRITE**: In second person ("you") for instructions
+- **PLACE**: Conditions before instructions
+- **USE**: Present tense when possible
+- **AVOID**: Idioms and colloquialisms
+
+#### Punctuation Guidelines
+
+- **USE**: Serial/Oxford commas in lists
+- **USE**: Parentheses for brief clarifications
+- **USE**: Em dashes for longer explanations
+- **USE**: Colons to introduce lists or explanations
+
+#### Formatting Standards
+
+- **FORMAT**: UI elements consistently
+- **USE**: Bold for emphasis (sparingly)
+- **USE**: Code formatting for technical terms
+- **MAINTAIN**: Consistent heading structure
+
+---
+
+### 9. Editing and Review
+
+#### Self-Editing Process
+
+- **ADOPT**: A consistent style guide
+- **READ**: Drafts aloud to check flow
+- **STEP**: Away from writing and return with fresh eyes
+- **CHANGE**: Context (print, different font) for review
+- **SEEK**: Peer editor feedback
+
+#### Review Checklist
+
+- [ ] Is the purpose clear?
+- [ ] Is the audience appropriate?
+- [ ] Are terms used consistently?
+- [ ] Is active voice used where appropriate?
+- [ ] Are sentences focused and clear?
+- [ ] Are lists properly formatted?
+- [ ] Is the content accessible?
+- [ ] Are error messages helpful and actionable?
+
+---
+
+### 10. Documentation Types and Approach
+
+#### Different Documentation Needs
+
+- **TUTORIALS**: Step-by-step guidance for beginners
+- **REFERENCES**: Comprehensive technical details
+- **GUIDES**: Task-oriented instructions
+- **OVERVIEWS**: High-level conceptual information
+
+#### Writing Process
+
+1. **IDENTIFY**: Your audience and their needs
+2. **DEFINE**: Your document's scope and goals
+3. **STRUCTURE**: Information logically
+4. **WRITE**: First draft focusing on content
+5. **EDIT**: For clarity, accuracy, and style
+6. **REVIEW**: With target audience perspective
+7. **ITERATE**: Based on feedback
+
+---
+
+### Application in Code Documentation
+
+When writing code documentation, API references, or technical specifications:
+
+- **DOCUMENT**: Functions with clear purpose, parameters, and return values
+- **PROVIDE**: Usage examples for complex APIs
+- **EXPLAIN**: Edge cases and error conditions
+- **MAINTAIN**: Consistency with codebase conventions
+- **UPDATE**: Documentation with code changes
+
+---
+
+*This guidance prioritizes clarity, accessibility, and user focus in all
+technical communication. Apply these principles consistently across
+documentation, comments, error messages, and user-facing content.*

--- a/cmd/milo/apiserver/server.go
+++ b/cmd/milo/apiserver/server.go
@@ -33,6 +33,7 @@ import (
 	_ "k8s.io/component-base/metrics/prometheus/workqueue"
 	"k8s.io/component-base/term"
 	"k8s.io/component-base/version"
+	utilversion "k8s.io/component-base/version"
 	"k8s.io/component-base/version/verflag"
 	"k8s.io/klog/v2"
 	aggregatorapiserver "k8s.io/kube-aggregator/pkg/apiserver"
@@ -43,35 +44,37 @@ import (
 	"k8s.io/kubernetes/pkg/controlplane/apiserver/options"
 
 	admissionquota "go.miloapis.com/milo/internal/quota/admission"
+
+	// Import features package to register Milo feature gates via init()
+	_ "go.miloapis.com/milo/pkg/features"
 )
 
 func init() {
 	utilruntime.Must(logsapi.AddFeatureGates(utilfeature.DefaultMutableFeatureGate))
-	// Enable JSON logging support by default
 	utilfeature.DefaultMutableFeatureGate.Set("LoggingBetaOptions=true")
 	utilfeature.DefaultMutableFeatureGate.Set("RemoteRequestHeaderUID=true")
 }
 
 var (
-	// Configure the namespace that is used for system components and resources
-	// automatically bootstrapped by the control plane.
-	SystemNamespace string
-	// Sessions feature/config flags
-	featureSessions bool
-	// Standalone provider connection (direct URL + mTLS)
-	sessionsProviderURL        string
-	sessionsProviderCAFile     string
-	sessionsProviderClientCert string
-	sessionsProviderClientKey  string
-	providerTimeoutSeconds     int
-	providerRetries            int
-	forwardExtras              []string
-	// UserIdentities feature/config flags
-	featureUserIdentities            bool
+	SystemNamespace                  string
+	sessionsProviderURL              string
+	sessionsProviderCAFile           string
+	sessionsProviderClientCert       string
+	sessionsProviderClientKey        string
+	providerTimeoutSeconds           int
+	providerRetries                  int
+	forwardExtras                    []string
 	userIdentitiesProviderURL        string
 	userIdentitiesProviderCAFile     string
 	userIdentitiesProviderClientCert string
 	userIdentitiesProviderClientKey  string
+	eventsProviderURL                string
+	eventsProviderCAFile             string
+	eventsProviderClientCert         string
+	eventsProviderClientKey          string
+	eventsProviderTimeoutSeconds     int
+	eventsProviderRetries            int
+	eventsForwardExtras              []string
 )
 
 // NewCommand creates a *cobra.Command object with default parameters
@@ -84,11 +87,8 @@ func NewCommand() *cobra.Command {
 		Short: "Extendable API server",
 		Long:  `The Milo API server provides an extensible API platform.`,
 
-		// stop printing usage when the command errors
 		SilenceUsage: true,
 		PersistentPreRunE: func(*cobra.Command, []string) error {
-			// silence client-go warnings.
-			// kube-apiserver loopback clients should not log self-issued warnings.
 			rest.SetDefaultWarningHandler(rest.NoWarnings{})
 			return nil
 		},
@@ -96,8 +96,6 @@ func NewCommand() *cobra.Command {
 			verflag.PrintAndExitIfRequested()
 			fs := cmd.Flags()
 
-			// Activate logging as soon as possible, after that
-			// show flags with the final logging configuration.
 			if err := logsapi.ValidateAndApply(s.Logs, utilfeature.DefaultFeatureGate); err != nil {
 				return err
 			}
@@ -109,15 +107,12 @@ func NewCommand() *cobra.Command {
 				return err
 			}
 
-			// utilfeature.DefaultMutableFeatureGate.Set("ExternalServiceAccountTokenSigner=true")
-			// Enable tracing to support trace continuation from incoming requests
 			utilfeature.DefaultMutableFeatureGate.Set("APIServerTracing=true")
 
 			if errs := completedOptions.Validate(); len(errs) != 0 {
 				return utilerrors.NewAggregate(errs)
 			}
 
-			// add feature enablement metrics
 			utilfeature.DefaultMutableFeatureGate.AddMetrics()
 
 			ctx := genericapiserver.SetupSignalContext()
@@ -133,9 +128,9 @@ func NewCommand() *cobra.Command {
 		},
 	}
 
-	// Override the ComponentGlobalsRegistry to avoid k8s feature flags from being added.
-	// Add our own feature gates or expose native k8s ones if necessary
 	s.GenericServerRunOptions.ComponentGlobalsRegistry = featuregate.NewComponentGlobalsRegistry()
+	s.GenericServerRunOptions.ComponentGlobalsRegistry.ComponentGlobalsOrRegister(
+		featuregate.DefaultKubeComponent, utilversion.DefaultKubeEffectiveVersion(), utilfeature.DefaultMutableFeatureGate)
 	s.GenericServerRunOptions.AddUniversalFlags(namedFlagSets.FlagSet("generic"))
 	s.Etcd.AddFlags(namedFlagSets.FlagSet("etcd"))
 	s.SecureServing.AddFlags(namedFlagSets.FlagSet("secure serving"))
@@ -143,12 +138,10 @@ func NewCommand() *cobra.Command {
 	s.Features.AddFlags(namedFlagSets.FlagSet("features"))
 	s.Authentication.AddFlags(namedFlagSets.FlagSet("authentication"))
 	s.Authorization.AddFlags(namedFlagSets.FlagSet("authorization"))
-	// Add our own Admission flags
 	s.Metrics.AddFlags(namedFlagSets.FlagSet("metrics"))
 	logsapi.AddFlags(s.Logs, namedFlagSets.FlagSet("logs"))
 	s.Traces.AddFlags(namedFlagSets.FlagSet("traces"))
 
-	// Add misc flags for event ttl, proxy client certs, etc.
 	miscfs := namedFlagSets.FlagSet("misc")
 	miscfs.DurationVar(&s.EventTTL, "event-ttl", s.EventTTL,
 		"Amount of time to retain events.")
@@ -180,7 +173,6 @@ func NewCommand() *cobra.Command {
 		"Path to socket where a external JWT signer is listening. This flag is mutually exclusive with --service-account-signing-key-file and --service-account-key-file. Requires enabling feature gate (ExternalServiceAccountTokenSigner)")
 
 	fs.StringVar(&SystemNamespace, "system-namespace", "milo-system", "The namespace to use for system components and resources that are automatically created to run the system.")
-	fs.BoolVar(&featureSessions, "feature-sessions", false, "Enable identity sessions virtual API")
 	fs.StringVar(&sessionsProviderURL, "sessions-provider-url", "", "Direct provider base URL (e.g., https://zitadel-apiserver:8443)")
 	fs.StringVar(&sessionsProviderCAFile, "sessions-provider-ca-file", "", "Path to CA file to validate provider TLS")
 	fs.StringVar(&sessionsProviderClientCert, "sessions-provider-client-cert", "", "Client certificate for mTLS to provider")
@@ -188,11 +180,17 @@ func NewCommand() *cobra.Command {
 	fs.IntVar(&providerTimeoutSeconds, "provider-timeout", 3, "Provider request timeout in seconds")
 	fs.IntVar(&providerRetries, "provider-retries", 2, "Provider request retries")
 	fs.StringSliceVar(&forwardExtras, "forward-extras", []string{"iam.miloapis.com/parent-api-group", "iam.miloapis.com/parent-type", "iam.miloapis.com/parent-name"}, "User extras keys to forward during impersonation")
-	fs.BoolVar(&featureUserIdentities, "feature-useridentities", false, "Enable identity useridentities virtual API")
 	fs.StringVar(&userIdentitiesProviderURL, "useridentities-provider-url", "", "Direct provider base URL for useridentities (e.g., https://zitadel-apiserver:8443)")
 	fs.StringVar(&userIdentitiesProviderCAFile, "useridentities-provider-ca-file", "", "Path to CA file to validate useridentities provider TLS")
 	fs.StringVar(&userIdentitiesProviderClientCert, "useridentities-provider-client-cert", "", "Client certificate for mTLS to useridentities provider")
 	fs.StringVar(&userIdentitiesProviderClientKey, "useridentities-provider-client-key", "", "Client private key for mTLS to useridentities provider")
+	fs.StringVar(&eventsProviderURL, "events-provider-url", "", "Activity API server URL for events storage (e.g., https://activity-apiserver.activity-system.svc:443)")
+	fs.StringVar(&eventsProviderCAFile, "events-provider-ca-file", "", "Path to CA file to validate Activity provider TLS")
+	fs.StringVar(&eventsProviderClientCert, "events-provider-client-cert", "", "Client certificate for mTLS to Activity provider")
+	fs.StringVar(&eventsProviderClientKey, "events-provider-client-key", "", "Client private key for mTLS to Activity provider")
+	fs.IntVar(&eventsProviderTimeoutSeconds, "events-provider-timeout", 30, "Activity provider request timeout in seconds")
+	fs.IntVar(&eventsProviderRetries, "events-provider-retries", 3, "Activity provider request retries")
+	fs.StringSliceVar(&eventsForwardExtras, "events-forward-extras", []string{"iam.miloapis.com/parent-api-group", "iam.miloapis.com/parent-type", "iam.miloapis.com/parent-name"}, "User extras keys to forward to Activity for events")
 
 	cols, _, _ := term.TerminalSize(cmd.OutOrStdout())
 	cliflag.SetUsageAndHelpFunc(cmd, namedFlagSets, cols)
@@ -207,15 +205,10 @@ func NewOptions() *options.Options {
 		s.Admission.GenericAdmission.Plugins = admission.NewPlugins()
 	}
 
-	// Register custom admission plugins BEFORE determining which plugins to disable
-	// This ensures our plugins are known when DefaultOffAdmissionPlugins() is called
 	admissionquota.Register(s.Admission.GenericAdmission.Plugins)
 
-	// Set custom plugin order that includes our ClaimCreationQuota plugin
-	// This dynamically extends Kubernetes' plugin order with our custom plugins
 	s.Admission.GenericAdmission.RecommendedPluginOrder = GetMiloOrderedPlugins()
 
-	// Configure which plugins should be disabled
 	s.Admission.GenericAdmission.DefaultOffPlugins = DefaultOffAdmissionPlugins()
 
 	lifecycle.Register(s.Admission.GenericAdmission.Plugins)
@@ -227,16 +220,14 @@ func NewOptions() *options.Options {
 	wd, _ := os.Getwd()
 	s.SecureServing.ServerCert.CertDirectory = filepath.Join(wd, ".sample-minimal-controlplane")
 
-	// Wire ServiceAccount authentication without relying on pods and nodes.
 	s.Authentication.ServiceAccounts.OptionalTokenGetter = genericTokenGetter
 	s.ServiceAccountIssuer = &jwtTokenGenerator{}
 
 	return s
 }
 
-// Run runs the specified APIServer. This should never exit.
+// Run runs the specified APIServer
 func Run(ctx context.Context, opts options.CompletedOptions) error {
-	// To help debugging, immediately log version
 	klog.Infof("Version: %+v", version.Get())
 
 	klog.InfoS("Golang settings", "GOGC", os.Getenv("GOGC"), "GOMAXPROCS", os.Getenv("GOMAXPROCS"), "GOTRACEBACK", os.Getenv("GOTRACEBACK"))
@@ -246,8 +237,6 @@ func Run(ctx context.Context, opts options.CompletedOptions) error {
 		return err
 	}
 
-	// inject flag-derived extra config
-	config.ExtraConfig.FeatureSessions = featureSessions
 	config.ExtraConfig.SessionsProvider.URL = sessionsProviderURL
 	config.ExtraConfig.SessionsProvider.CAFile = sessionsProviderCAFile
 	config.ExtraConfig.SessionsProvider.ClientCertFile = sessionsProviderClientCert
@@ -256,7 +245,6 @@ func Run(ctx context.Context, opts options.CompletedOptions) error {
 	config.ExtraConfig.SessionsProvider.Retries = providerRetries
 	config.ExtraConfig.SessionsProvider.ForwardExtras = forwardExtras
 
-	config.ExtraConfig.FeatureUserIdentities = featureUserIdentities
 	config.ExtraConfig.UserIdentitiesProvider.URL = userIdentitiesProviderURL
 	config.ExtraConfig.UserIdentitiesProvider.CAFile = userIdentitiesProviderCAFile
 	config.ExtraConfig.UserIdentitiesProvider.ClientCertFile = userIdentitiesProviderClientCert
@@ -264,6 +252,14 @@ func Run(ctx context.Context, opts options.CompletedOptions) error {
 	config.ExtraConfig.UserIdentitiesProvider.TimeoutSeconds = providerTimeoutSeconds
 	config.ExtraConfig.UserIdentitiesProvider.Retries = providerRetries
 	config.ExtraConfig.UserIdentitiesProvider.ForwardExtras = forwardExtras
+
+	config.ExtraConfig.EventsProvider.URL = eventsProviderURL
+	config.ExtraConfig.EventsProvider.CAFile = eventsProviderCAFile
+	config.ExtraConfig.EventsProvider.ClientCertFile = eventsProviderClientCert
+	config.ExtraConfig.EventsProvider.ClientKeyFile = eventsProviderClientKey
+	config.ExtraConfig.EventsProvider.TimeoutSeconds = eventsProviderTimeoutSeconds
+	config.ExtraConfig.EventsProvider.Retries = eventsProviderRetries
+	config.ExtraConfig.EventsProvider.ForwardExtras = eventsForwardExtras
 
 	completed, err := config.Complete()
 	if err != nil {
@@ -283,12 +279,10 @@ func Run(ctx context.Context, opts options.CompletedOptions) error {
 	return prepared.Run(ctx)
 }
 
-// CreateServerChain creates the apiservers connected via delegation.
+// CreateServerChain creates the apiservers connected via delegation
 func CreateServerChain(config CompletedConfig) (*aggregatorapiserver.APIAggregator, error) {
-	// 1. CRDs
 	notFoundHandler := notfoundhandler.New(config.ControlPlane.Generic.Serializer, genericapifilters.NoMuxAndDiscoveryIncompleteKey)
 
-	// Use loopback config to enable automatic namespace bootstrapping in project control planes
 	loopbackConfig := config.ControlPlane.Generic.LoopbackClientConfig
 
 	config.APIExtensions.GenericConfig.RESTOptionsGetter =
@@ -303,7 +297,6 @@ func CreateServerChain(config CompletedConfig) (*aggregatorapiserver.APIAggregat
 	}
 	crdAPIEnabled := config.APIExtensions.GenericConfig.MergedResourceConfig.ResourceEnabled(apiextensionsv1.SchemeGroupVersion.WithResource("customresourcedefinitions"))
 
-	// 2. Natively implemented resources
 	nativeAPIs, err := config.ControlPlane.New("datum-apiserver", apiExtensionsServer.GenericAPIServer)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create datum controlplane apiserver: %w", err)
@@ -326,7 +319,6 @@ func CreateServerChain(config CompletedConfig) (*aggregatorapiserver.APIAggregat
 		return nil, fmt.Errorf("failed to install APIs: %w", err)
 	}
 
-	// 3. Aggregator for APIServices, discovery and OpenAPI
 	aggregatorServer, err := controlplaneapiserver.CreateAggregatorServer(
 		config.Aggregator,
 		nativeAPIs.GenericAPIServer,
@@ -335,20 +327,16 @@ func CreateServerChain(config CompletedConfig) (*aggregatorapiserver.APIAggregat
 		controlplaneapiserver.DefaultGenericAPIServicePriorities(),
 	)
 	if err != nil {
-		// we don't need special handling for innerStopCh because the aggregator server doesn't create any go routines
 		return nil, fmt.Errorf("failed to create kube-aggregator: %w", err)
 	}
 
 	return aggregatorServer, nil
 }
 
-// bootstrapCRDsHook installs all embedded CRDs into the cluster as a post-start hook.
-// This is called after the API server starts but before readiness checks pass.
-// This follows KCP's pattern of bootstrapping CRDs with polling retry.
+// bootstrapCRDsHook installs all embedded CRDs into the cluster as a post-start hook
 func bootstrapCRDsHook(hookCtx genericapiserver.PostStartHookContext, loopbackConfig *rest.Config) error {
 	logger := klog.FromContext(hookCtx).WithName("bootstrap-crds")
 
-	// Create apiextensions client from loopback config
 	extClient, err := apiextensionsclient.NewForConfig(loopbackConfig)
 	if err != nil {
 		return fmt.Errorf("failed to create apiextensions client: %w", err)
@@ -356,20 +344,17 @@ func bootstrapCRDsHook(hookCtx genericapiserver.PostStartHookContext, loopbackCo
 
 	logger.Info("Starting CRD bootstrap from embedded filesystem")
 
-	// Use polling with retry in case the apiextensions server isn't fully ready yet.
-	// Post-start hooks run after the server starts listening but before readiness.
-	// The embedded Context in PostStartHookContext is cancelled when the server stops.
 	err = wait.PollUntilContextCancel(hookCtx, time.Second, true, func(ctx context.Context) (bool, error) {
 		if err := crd.Bootstrap(ctx, extClient); err != nil {
 			logger.Error(err, "failed to bootstrap CRDs, retrying")
-			return false, nil // keep retrying
+			return false, nil
 		}
 		return true, nil
 	})
 
 	if err != nil {
 		logger.Error(err, "failed to bootstrap CRDs")
-		return nil // don't fail the server start, just log the error
+		return nil
 	}
 
 	logger.Info("CRD bootstrap completed successfully")

--- a/config/apiserver/deployment.yaml
+++ b/config/apiserver/deployment.yaml
@@ -53,20 +53,37 @@ spec:
           - --audit-webhook-initial-backoff=$(AUDIT_WEBHOOK_INITIAL_BACKOFF)
           - --proxy-client-cert-file=$(PROXY_CLIENT_CERT_FILE)
           - --proxy-client-key-file=$(PROXY_CLIENT_KEY_FILE)
-          - --feature-sessions=true
+          # Feature gates controlled via FEATURE_GATES env var
+          # Default: Sessions and UserIdentities enabled
+          # To enable EventsProxy: FEATURE_GATES=Sessions=true,UserIdentities=true,EventsProxy=true
+          - --feature-gates=$(FEATURE_GATES)
+          # Sessions provider configuration
           - --sessions-provider-url=$(SESSIONS_PROVIDER_URL)
           - --sessions-provider-ca-file=$(SESSIONS_PROVIDER_CA_FILE)
           - --sessions-provider-client-cert=$(SESSIONS_PROVIDER_CLIENT_CERT_FILE)
           - --sessions-provider-client-key=$(SESSIONS_PROVIDER_CLIENT_KEY_FILE)
-          - --feature-useridentities=true
+          - --provider-timeout=3
+          - --provider-retries=2
+          - --forward-extras=iam.miloapis.com/parent-api-group,iam.miloapis.com/parent-type,iam.miloapis.com/parent-name
+          # UserIdentities provider configuration
           - --useridentities-provider-url=$(USERIDENTITIES_PROVIDER_URL)
           - --useridentities-provider-ca-file=$(USERIDENTITIES_PROVIDER_CA_FILE)
           - --useridentities-provider-client-cert=$(USERIDENTITIES_PROVIDER_CLIENT_CERT_FILE)
           - --useridentities-provider-client-key=$(USERIDENTITIES_PROVIDER_CLIENT_KEY_FILE)
-          - --provider-timeout=3
-          - --provider-retries=2
-          - --forward-extras=iam.miloapis.com/parent-api-group,iam.miloapis.com/parent-type,iam.miloapis.com/parent-name
+          # Events proxy provider configuration (requires EventsProxy feature gate)
+          - --events-provider-url=$(EVENTS_PROVIDER_URL)
+          - --events-provider-ca-file=$(EVENTS_PROVIDER_CA_FILE)
+          - --events-provider-client-cert=$(EVENTS_PROVIDER_CLIENT_CERT_FILE)
+          - --events-provider-client-key=$(EVENTS_PROVIDER_CLIENT_KEY_FILE)
+          - --events-provider-timeout=$(EVENTS_PROVIDER_TIMEOUT)
+          - --events-provider-retries=$(EVENTS_PROVIDER_RETRIES)
+          - --events-forward-extras=$(EVENTS_FORWARD_EXTRAS)
         env:
+          # Feature gates configuration
+          # Sessions and UserIdentities are GA (enabled by default)
+          # Add EventsProxy=true to enable Events proxy to Activity service
+          - name: FEATURE_GATES
+            value: ""
           - name: LOG_LEVEL
             value: "4"
           - name: LOGGING_FORMAT
@@ -139,6 +156,21 @@ spec:
             value: ""
           - name: USERIDENTITIES_PROVIDER_CLIENT_KEY_FILE
             value: ""
+          # Events proxy provider configuration (requires --feature-gates=EventsProxy=true)
+          - name: EVENTS_PROVIDER_URL
+            value: ""
+          - name: EVENTS_PROVIDER_CA_FILE
+            value: ""
+          - name: EVENTS_PROVIDER_CLIENT_CERT_FILE
+            value: ""
+          - name: EVENTS_PROVIDER_CLIENT_KEY_FILE
+            value: ""
+          - name: EVENTS_PROVIDER_TIMEOUT
+            value: "30"
+          - name: EVENTS_PROVIDER_RETRIES
+            value: "3"
+          - name: EVENTS_FORWARD_EXTRAS
+            value: "iam.miloapis.com/parent-api-group,iam.miloapis.com/parent-type,iam.miloapis.com/parent-name"
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/config/components/events-proxy/README.md
+++ b/config/components/events-proxy/README.md
@@ -1,0 +1,77 @@
+# Events Proxy Component
+
+This component enables the Events proxy feature that forwards Kubernetes Events
+to the Activity API server.
+
+## What It Does
+
+Intercepts requests to the core/v1.Event API and proxies them to the Activity
+service. This provides centralized event storage with consistent retention and
+querying. The proxy automatically injects scope annotations and forwards user
+context via X-Remote-* headers.
+
+## Prerequisites
+
+- Activity API server deployed and accessible
+- mTLS certificates in a secret named `milo-activity-client-cert`
+- Network connectivity from Milo to Activity
+
+## Configuration
+
+### Feature Gate
+
+This component enables the `EventsProxy` feature gate (currently Alpha).
+Sessions and UserIdentities are GA and enabled by default.
+
+```yaml
+- name: FEATURE_GATES
+  value: "EventsProxy=true"
+```
+
+### Required Configuration in Your Overlay
+
+1. **Enable the component** in `kustomization.yaml`:
+   ```yaml
+   components:
+     - ../../components/events-proxy
+   ```
+
+2. **Set Activity URL** via environment variable:
+   ```yaml
+   - name: EVENTS_PROVIDER_URL
+     value: "https://activity-apiserver.activity-system.svc.cluster.local:443"
+   ```
+
+3. **Provision mTLS certificate** secret with `ca.crt`, `tls.crt`, and `tls.key`
+
+## Verification
+
+Check API server logs for Events proxy initialization:
+```bash
+kubectl logs -n milo-system deployment/milo-apiserver | grep -i "events"
+```
+
+Create a test event and verify it appears in Activity:
+```bash
+kubectl get events test-event -o yaml
+```
+
+## Troubleshooting
+
+**Events proxy not initialized**: Verify `FEATURE_GATES` includes `EventsProxy=true`,
+`EVENTS_PROVIDER_URL` is set, and certificate secret exists.
+
+**Certificate errors**: Verify certificate is signed by Activity's CA, includes
+`client auth` usage, and hasn't expired.
+
+**Network issues**: Check Activity is running, DNS resolves, and network
+policies allow traffic.
+
+**Events not appearing**: Verify `EVENTS_FORWARD_EXTRAS` is configured and
+Activity processes Event resources.
+
+## Implementation
+
+See `internal/apiserver/events/` for implementation details including storage
+provider wrapping, REST storage with proxying, dynamic client with header
+injection, and scope annotation handling.

--- a/config/components/events-proxy/kustomization.yaml
+++ b/config/components/events-proxy/kustomization.yaml
@@ -1,0 +1,46 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+# This component enables the Events proxy feature that forwards Kubernetes Events
+# to the Activity API server for storage and retrieval.
+#
+# Requirements:
+# - Activity API server must be deployed and accessible
+# - mTLS certificates for Milo -> Activity communication must be configured
+# - Activity API server must be accessible via the configured URL
+#
+# Usage:
+# Add this component to your kustomization.yaml:
+#   components:
+#     - ../../components/events-proxy
+
+patches:
+  # Enable EventsProxy feature gate and configure Activity provider connection
+  - patch: |-
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: milo-apiserver
+      spec:
+        template:
+          spec:
+            containers:
+            - name: milo-apiserver
+              env:
+                # Enable EventsProxy feature gate (Sessions and UserIdentities are GA/default)
+                - name: FEATURE_GATES
+                  value: "EventsProxy=true"
+              volumeMounts:
+                - name: activity-client-cert
+                  mountPath: /etc/kubernetes/pki/activity
+                  readOnly: true
+            volumes:
+              - name: activity-client-cert
+                secret:
+                  secretName: milo-activity-client-cert
+                  optional: false
+    target:
+      group: apps
+      version: v1
+      kind: Deployment
+      name: milo-apiserver

--- a/docs/enhancements/events/activity-events-proxy.md
+++ b/docs/enhancements/events/activity-events-proxy.md
@@ -1,0 +1,258 @@
+# Activity Events Proxy
+
+Milo proxies Kubernetes Events to the Activity API server for ClickHouse-backed storage with longer retention and richer querying than etcd.
+
+## Configuration
+
+Enable the feature gate:
+
+```bash
+--feature-gates=EventsProxy=true
+```
+
+Configure the Activity API server connection:
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `--events-provider-url` | Activity API server URL | Required |
+| `--events-provider-ca-file` | TLS CA certificate | Required |
+| `--events-provider-client-cert` | mTLS client certificate | Required |
+| `--events-provider-client-key` | mTLS client key | Required |
+| `--events-provider-timeout` | Request timeout in seconds | `30` |
+| `--events-provider-retries` | Retry attempts for transient errors | `3` |
+| `--events-forward-extras` | User.Extra keys to forward | `iam.miloapis.com/parent-type`, `iam.miloapis.com/parent-name`, `iam.miloapis.com/parent-api-group` |
+
+Example:
+
+```bash
+milo apiserver \
+  --feature-gates=EventsProxy=true \
+  --events-provider-url=https://activity-apiserver.activity-system.svc:443 \
+  --events-provider-ca-file=/etc/milo/activity/ca.crt \
+  --events-provider-client-cert=/etc/milo/activity/tls.crt \
+  --events-provider-client-key=/etc/milo/activity/tls.key
+```
+
+## Supported Operations
+
+Both `core/v1.Event` and `events.k8s.io/v1.Event` APIs are proxied:
+
+| Operation | Method | Endpoint |
+|-----------|--------|----------|
+| Create | POST | `/api/v1/namespaces/{ns}/events` |
+| Get | GET | `/api/v1/namespaces/{ns}/events/{name}` |
+| List | GET | `/api/v1/namespaces/{ns}/events` |
+| Update | PUT | `/api/v1/namespaces/{ns}/events/{name}` |
+| Delete | DELETE | `/api/v1/namespaces/{ns}/events/{name}` |
+| Watch | GET | `/api/v1/namespaces/{ns}/events?watch=true` |
+
+Field selectors work as expected:
+
+```bash
+kubectl get events --field-selector involvedObject.name=my-pod
+kubectl get events --field-selector type=Warning
+```
+
+## Architecture
+
+```
+┌────────────────────────────────────────────────────────┐
+│                    Milo API Server                     │
+│                                                         │
+│  Authentication → Authorization → EventsREST           │
+│                                        │                │
+│                                        ▼                │
+│                               DynamicProvider           │
+│                         (injects X-Remote-* headers)    │
+└────────────────────────────────┬───────────────────────┘
+                                 │ HTTPS + mTLS
+                                 ▼
+┌────────────────────────────────────────────────────────┐
+│              Activity API Server                        │
+│                                                         │
+│  activity.miloapis.com/v1alpha1/namespaces/{ns}/events │
+└────────────────────────────────────────────────────────┘
+```
+
+### Components
+
+**CoreProviderWrapper** (`storageprovider.go`): Wraps the core API provider to inject events proxy storage. Only one provider can register `core/v1` resources, so we override the events storage after the core provider creates the base APIGroupInfo.
+
+**DynamicProvider** (`dynamic.go`): Proxies requests to Activity using client-go's dynamic client. Injects X-Remote-User, X-Remote-Group, and X-Remote-Extra-* headers from the authenticated user context.
+
+**REST** (`rest.go`): Implements Kubernetes REST storage interfaces (Creater, Getter, Lister, Updater, Deleter, Watcher). Calls `injectScopeAnnotations` before Create/Update to add multi-tenant scope.
+
+**Scope Injection** (`scope.go`): Extracts scope from `user.Extra["iam.miloapis.com/parent-type"]` and `user.Extra["iam.miloapis.com/parent-name"]` and injects as `platform.miloapis.com/scope.type` and `platform.miloapis.com/scope.name` annotations.
+
+### Multi-Tenancy
+
+Events are automatically scoped based on the authenticated user's context.
+
+The proxy extracts scope from user.Extra fields:
+
+- `iam.miloapis.com/parent-type` → `platform.miloapis.com/scope.type` (annotation)
+- `iam.miloapis.com/parent-name` → `platform.miloapis.com/scope.name` (annotation)
+
+Activity filters events based on these scope annotations:
+
+| User Scope | Visibility |
+|------------|------------|
+| Platform | All events |
+| Organization | Events with matching scope.type=Organization and scope.name |
+| Project | Events with matching scope.type=Project and scope.name |
+
+Users cannot modify scope annotations. The proxy re-injects scope on every Create and Update operation to prevent tampering.
+
+### Retry Logic
+
+Transient errors are retried automatically:
+
+- Network errors
+- Timeouts
+- 5xx server errors
+- 429 Too Many Requests
+
+Non-transient errors fail immediately:
+
+- 400 Bad Request
+- 404 Not Found
+- 403 Forbidden
+- 409 Conflict
+
+## Deployment
+
+### Certificate Setup
+
+Create mTLS certificates for Milo to authenticate with Activity:
+
+```yaml
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: milo-activity-client
+  namespace: milo-system
+spec:
+  secretName: milo-activity-client-cert
+  issuerRef:
+    name: activity-ca-issuer
+    kind: ClusterIssuer
+  commonName: milo-apiserver
+  dnsNames:
+    - milo-apiserver.milo-system.svc
+  usages:
+    - client auth
+```
+
+### API Server Deployment
+
+Update the Milo API server deployment:
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: milo-apiserver
+  namespace: milo-system
+spec:
+  template:
+    spec:
+      containers:
+        - name: apiserver
+          args:
+            - --feature-gates=EventsProxy=true
+            - --events-provider-url=https://activity-apiserver.activity-system.svc:443
+            - --events-provider-ca-file=/etc/milo/activity/ca.crt
+            - --events-provider-client-cert=/etc/milo/activity/tls.crt
+            - --events-provider-client-key=/etc/milo/activity/tls.key
+            - --events-provider-timeout=30
+            - --events-provider-retries=3
+            - --events-forward-extras=iam.miloapis.com/parent-type
+            - --events-forward-extras=iam.miloapis.com/parent-name
+            - --events-forward-extras=iam.miloapis.com/parent-api-group
+          volumeMounts:
+            - name: activity-certs
+              mountPath: /etc/milo/activity
+              readOnly: true
+      volumes:
+        - name: activity-certs
+          secret:
+            secretName: milo-activity-client-cert
+```
+
+### Kustomization
+
+Use kustomize patches to enable the feature:
+
+```yaml
+# config/overlays/staging/kustomization.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../base
+
+patches:
+  - target:
+      kind: Deployment
+      name: milo-apiserver
+    patch: |-
+      - op: add
+        path: /spec/template/spec/containers/0/args/-
+        value: --feature-gates=EventsProxy=true
+      - op: add
+        path: /spec/template/spec/containers/0/args/-
+        value: --events-provider-url=https://activity-apiserver.activity-system.svc:443
+      # ... additional flags
+```
+
+## Verification
+
+Check that events are proxied to Activity:
+
+```bash
+# Create a test event
+kubectl create -f - <<EOF
+apiVersion: v1
+kind: Event
+metadata:
+  name: test-event
+  namespace: default
+involvedObject:
+  kind: Pod
+  name: test-pod
+reason: Testing
+message: This is a test event
+type: Normal
+EOF
+
+# Verify it appears in kubectl
+kubectl get events -n default
+
+# Verify it's stored in Activity (not etcd)
+# Check Activity logs for incoming requests
+kubectl logs -n activity-system -l app=activity-apiserver
+```
+
+## Troubleshooting
+
+**Events not appearing**:
+- Check EventsProxy feature gate is enabled
+- Verify Activity API server URL is reachable
+- Check mTLS certificates are valid
+- Review Milo API server logs for proxy errors
+
+**Permission errors**:
+- Verify Activity trusts Milo's client certificate
+- Check X-Remote-* headers are being forwarded
+- Ensure scope annotations are being injected
+
+**High latency**:
+- Increase `--events-provider-timeout`
+- Check Activity API server performance
+- Review network latency between Milo and Activity
+
+## References
+
+- Activity Events Storage: `activity-events-pipeline/docs/enhancements/001-kubernetes-events-storage.md`
+- Sessions Provider: `internal/apiserver/identity/sessions/`
+- Feature Gates: `pkg/features/features.go`

--- a/internal/apiserver/events/config.go
+++ b/internal/apiserver/events/config.go
@@ -1,0 +1,22 @@
+package events
+
+import (
+	"time"
+
+	"k8s.io/client-go/rest"
+)
+
+// Config holds connection parameters for the Activity API server proxy
+type Config struct {
+	BaseConfig *rest.Config
+
+	ProviderURL string
+
+	CAFile         string
+	ClientCertFile string
+	ClientKeyFile  string
+
+	Timeout     time.Duration
+	Retries     int
+	ExtrasAllow map[string]struct{}
+}

--- a/internal/apiserver/events/dynamic.go
+++ b/internal/apiserver/events/dynamic.go
@@ -1,0 +1,502 @@
+package events
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"net/url"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	eventsv1 "k8s.io/api/events/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/watch"
+	apirequest "k8s.io/apiserver/pkg/endpoints/request"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/transport"
+)
+
+// DynamicProvider proxies Kubernetes Events to the Activity API server,
+// injecting X-Remote-* headers to forward user context
+type DynamicProvider struct {
+	base        *rest.Config
+	gvr         schema.GroupVersionResource
+	eventsv1GVR schema.GroupVersionResource
+	to          time.Duration
+	retries     int
+	allowExtras map[string]struct{}
+}
+
+// NewDynamicProvider creates a new events provider that proxies to the Activity service.
+func NewDynamicProvider(cfg Config) (*DynamicProvider, error) {
+	if cfg.ProviderURL == "" {
+		return nil, fmt.Errorf("ProviderURL is required")
+	}
+
+	base := &rest.Config{}
+	base.Host = cfg.ProviderURL
+
+	var sni string
+	if u, err := url.Parse(cfg.ProviderURL); err == nil {
+		sni = u.Hostname()
+	}
+
+	base.TLSClientConfig = rest.TLSClientConfig{
+		CAFile:     cfg.CAFile,
+		CertFile:   cfg.ClientCertFile,
+		KeyFile:    cfg.ClientKeyFile,
+		Insecure:   false,
+		ServerName: sni,
+	}
+
+	if cfg.Timeout > 0 {
+		base.Timeout = cfg.Timeout
+	}
+
+	gvr := schema.GroupVersionResource{
+		Group:    "",
+		Version:  "v1",
+		Resource: "events",
+	}
+
+	eventsv1GVR := schema.GroupVersionResource{
+		Group:    "events.k8s.io",
+		Version:  "v1",
+		Resource: "events",
+	}
+
+	return &DynamicProvider{
+		base:        base,
+		gvr:         gvr,
+		eventsv1GVR: eventsv1GVR,
+		to:          cfg.Timeout,
+		retries:     max(0, cfg.Retries),
+		allowExtras: cfg.ExtrasAllow,
+	}, nil
+}
+
+// dynForUser creates a per-request dynamic client that forwards user identity via X-Remote-* headers
+func (p *DynamicProvider) dynForUser(ctx context.Context) (dynamic.Interface, error) {
+	u, ok := apirequest.UserFrom(ctx)
+	if !ok || u == nil {
+		return nil, fmt.Errorf("no user in context")
+	}
+
+	cfg := rest.CopyConfig(p.base)
+	if p.to > 0 {
+		cfg.Timeout = p.to
+	}
+
+	prev := cfg.WrapTransport
+	cfg.WrapTransport = func(rt http.RoundTripper) http.RoundTripper {
+		if prev != nil {
+			rt = prev(rt)
+		}
+		return transport.NewAuthProxyRoundTripper(
+			u.GetName(),
+			u.GetUID(),
+			u.GetGroups(),
+			p.filterExtras(u.GetExtra()),
+			rt,
+		)
+	}
+
+	return dynamic.NewForConfig(cfg)
+}
+
+func (p *DynamicProvider) filterExtras(src map[string][]string) map[string][]string {
+	if len(p.allowExtras) == 0 || len(src) == 0 {
+		return nil
+	}
+	out := make(map[string][]string, len(src))
+	for k, v := range src {
+		if _, ok := p.allowExtras[k]; ok {
+			out[k] = v
+		}
+	}
+	return out
+}
+
+// CreateEvent creates a new event in Activity storage.
+func (p *DynamicProvider) CreateEvent(ctx context.Context, namespace string, event *corev1.Event) (*corev1.Event, error) {
+	dyn, err := p.dynForUser(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	unstructuredEvent, err := runtime.DefaultUnstructuredConverter.ToUnstructured(event)
+	if err != nil {
+		return nil, err
+	}
+	uobj := &unstructured.Unstructured{Object: unstructuredEvent}
+
+	var lastErr error
+	var result *unstructured.Unstructured
+	for i := 0; i <= p.retries; i++ {
+		result, lastErr = dyn.Resource(p.gvr).Namespace(namespace).Create(ctx, uobj, metav1.CreateOptions{})
+		if lastErr == nil {
+			break
+		}
+		if !isTransient(lastErr) {
+			return nil, lastErr
+		}
+	}
+	if lastErr != nil {
+		return nil, lastErr
+	}
+
+	out := &corev1.Event{}
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(result.UnstructuredContent(), out); err != nil {
+		return nil, err
+	}
+
+	return out, nil
+}
+
+// GetEvent retrieves an event by name from Activity storage.
+func (p *DynamicProvider) GetEvent(ctx context.Context, namespace, name string) (*corev1.Event, error) {
+	dyn, err := p.dynForUser(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	var lastErr error
+	var uobj *unstructured.Unstructured
+	for i := 0; i <= p.retries; i++ {
+		uobj, lastErr = dyn.Resource(p.gvr).Namespace(namespace).Get(ctx, name, metav1.GetOptions{})
+		if lastErr == nil {
+			break
+		}
+		if !isTransient(lastErr) {
+			return nil, lastErr
+		}
+	}
+	if lastErr != nil {
+		return nil, lastErr
+	}
+
+	out := &corev1.Event{}
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(uobj.UnstructuredContent(), out); err != nil {
+		return nil, err
+	}
+
+	return out, nil
+}
+
+// ListEvents lists events from Activity storage with optional filtering.
+func (p *DynamicProvider) ListEvents(ctx context.Context, namespace string, opts *metav1.ListOptions) (*corev1.EventList, error) {
+	if opts == nil {
+		opts = &metav1.ListOptions{}
+	}
+
+	dyn, err := p.dynForUser(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	var lastErr error
+	var ul *unstructured.UnstructuredList
+	for i := 0; i <= p.retries; i++ {
+		ul, lastErr = dyn.Resource(p.gvr).Namespace(namespace).List(ctx, *opts)
+		if lastErr == nil {
+			break
+		}
+		if !isTransient(lastErr) {
+			return nil, lastErr
+		}
+	}
+	if lastErr != nil {
+		return nil, lastErr
+	}
+
+	out := &corev1.EventList{}
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(ul.UnstructuredContent(), out); err != nil {
+		return nil, err
+	}
+
+	return out, nil
+}
+
+// UpdateEvent updates an existing event in Activity storage.
+func (p *DynamicProvider) UpdateEvent(ctx context.Context, namespace string, event *corev1.Event) (*corev1.Event, error) {
+	dyn, err := p.dynForUser(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	unstructuredEvent, err := runtime.DefaultUnstructuredConverter.ToUnstructured(event)
+	if err != nil {
+		return nil, err
+	}
+	uobj := &unstructured.Unstructured{Object: unstructuredEvent}
+
+	var lastErr error
+	var result *unstructured.Unstructured
+	for i := 0; i <= p.retries; i++ {
+		result, lastErr = dyn.Resource(p.gvr).Namespace(namespace).Update(ctx, uobj, metav1.UpdateOptions{})
+		if lastErr == nil {
+			break
+		}
+		if !isTransient(lastErr) {
+			return nil, lastErr
+		}
+	}
+	if lastErr != nil {
+		return nil, lastErr
+	}
+
+	out := &corev1.Event{}
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(result.UnstructuredContent(), out); err != nil {
+		return nil, err
+	}
+
+	return out, nil
+}
+
+// DeleteEvent deletes an event from Activity storage.
+func (p *DynamicProvider) DeleteEvent(ctx context.Context, namespace, name string, opts *metav1.DeleteOptions) error {
+	if opts == nil {
+		opts = &metav1.DeleteOptions{}
+	}
+
+	dyn, err := p.dynForUser(ctx)
+	if err != nil {
+		return err
+	}
+
+	var lastErr error
+	for i := 0; i <= p.retries; i++ {
+		lastErr = dyn.Resource(p.gvr).Namespace(namespace).Delete(ctx, name, *opts)
+		if lastErr == nil {
+			return nil
+		}
+		if !isTransient(lastErr) {
+			return lastErr
+		}
+	}
+
+	return lastErr
+}
+
+// WatchEvents establishes a watch connection to Activity storage for event changes.
+func (p *DynamicProvider) WatchEvents(ctx context.Context, namespace string, opts *metav1.ListOptions) (watch.Interface, error) {
+	if opts == nil {
+		opts = &metav1.ListOptions{}
+	}
+
+	dyn, err := p.dynForUser(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return dyn.Resource(p.gvr).Namespace(namespace).Watch(ctx, *opts)
+}
+
+// isTransient returns true if the error should be retried
+func isTransient(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	var netErr net.Error
+	if errors.As(err, &netErr) {
+		return true
+	}
+
+	if apierrors.IsTimeout(err) || apierrors.IsServerTimeout(err) {
+		return true
+	}
+	if apierrors.IsServiceUnavailable(err) {
+		return true
+	}
+	if apierrors.IsInternalError(err) {
+		return true
+	}
+	if apierrors.IsTooManyRequests(err) {
+		return true
+	}
+
+	return false
+}
+
+// CreateEventsV1Event creates a new events.k8s.io/v1 event in Activity storage.
+func (p *DynamicProvider) CreateEventsV1Event(ctx context.Context, namespace string, event *eventsv1.Event) (*eventsv1.Event, error) {
+	dyn, err := p.dynForUser(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	unstructuredEvent, err := runtime.DefaultUnstructuredConverter.ToUnstructured(event)
+	if err != nil {
+		return nil, err
+	}
+	uobj := &unstructured.Unstructured{Object: unstructuredEvent}
+
+	var lastErr error
+	var result *unstructured.Unstructured
+	for i := 0; i <= p.retries; i++ {
+		result, lastErr = dyn.Resource(p.eventsv1GVR).Namespace(namespace).Create(ctx, uobj, metav1.CreateOptions{})
+		if lastErr == nil {
+			break
+		}
+		if !isTransient(lastErr) {
+			return nil, lastErr
+		}
+	}
+	if lastErr != nil {
+		return nil, lastErr
+	}
+
+	out := &eventsv1.Event{}
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(result.UnstructuredContent(), out); err != nil {
+		return nil, err
+	}
+
+	return out, nil
+}
+
+// GetEventsV1Event retrieves an events.k8s.io/v1 event by name from Activity storage.
+func (p *DynamicProvider) GetEventsV1Event(ctx context.Context, namespace, name string) (*eventsv1.Event, error) {
+	dyn, err := p.dynForUser(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	var lastErr error
+	var uobj *unstructured.Unstructured
+	for i := 0; i <= p.retries; i++ {
+		uobj, lastErr = dyn.Resource(p.eventsv1GVR).Namespace(namespace).Get(ctx, name, metav1.GetOptions{})
+		if lastErr == nil {
+			break
+		}
+		if !isTransient(lastErr) {
+			return nil, lastErr
+		}
+	}
+	if lastErr != nil {
+		return nil, lastErr
+	}
+
+	out := &eventsv1.Event{}
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(uobj.UnstructuredContent(), out); err != nil {
+		return nil, err
+	}
+
+	return out, nil
+}
+
+// ListEventsV1Events lists events.k8s.io/v1 events from Activity storage with optional filtering.
+func (p *DynamicProvider) ListEventsV1Events(ctx context.Context, namespace string, opts *metav1.ListOptions) (*eventsv1.EventList, error) {
+	if opts == nil {
+		opts = &metav1.ListOptions{}
+	}
+
+	dyn, err := p.dynForUser(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	var lastErr error
+	var ul *unstructured.UnstructuredList
+	for i := 0; i <= p.retries; i++ {
+		ul, lastErr = dyn.Resource(p.eventsv1GVR).Namespace(namespace).List(ctx, *opts)
+		if lastErr == nil {
+			break
+		}
+		if !isTransient(lastErr) {
+			return nil, lastErr
+		}
+	}
+	if lastErr != nil {
+		return nil, lastErr
+	}
+
+	out := &eventsv1.EventList{}
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(ul.UnstructuredContent(), out); err != nil {
+		return nil, err
+	}
+
+	return out, nil
+}
+
+// UpdateEventsV1Event updates an existing events.k8s.io/v1 event in Activity storage.
+func (p *DynamicProvider) UpdateEventsV1Event(ctx context.Context, namespace string, event *eventsv1.Event) (*eventsv1.Event, error) {
+	dyn, err := p.dynForUser(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	unstructuredEvent, err := runtime.DefaultUnstructuredConverter.ToUnstructured(event)
+	if err != nil {
+		return nil, err
+	}
+	uobj := &unstructured.Unstructured{Object: unstructuredEvent}
+
+	var lastErr error
+	var result *unstructured.Unstructured
+	for i := 0; i <= p.retries; i++ {
+		result, lastErr = dyn.Resource(p.eventsv1GVR).Namespace(namespace).Update(ctx, uobj, metav1.UpdateOptions{})
+		if lastErr == nil {
+			break
+		}
+		if !isTransient(lastErr) {
+			return nil, lastErr
+		}
+	}
+	if lastErr != nil {
+		return nil, lastErr
+	}
+
+	out := &eventsv1.Event{}
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(result.UnstructuredContent(), out); err != nil {
+		return nil, err
+	}
+
+	return out, nil
+}
+
+// DeleteEventsV1Event deletes an events.k8s.io/v1 event from Activity storage.
+func (p *DynamicProvider) DeleteEventsV1Event(ctx context.Context, namespace, name string, opts *metav1.DeleteOptions) error {
+	if opts == nil {
+		opts = &metav1.DeleteOptions{}
+	}
+
+	dyn, err := p.dynForUser(ctx)
+	if err != nil {
+		return err
+	}
+
+	var lastErr error
+	for i := 0; i <= p.retries; i++ {
+		lastErr = dyn.Resource(p.eventsv1GVR).Namespace(namespace).Delete(ctx, name, *opts)
+		if lastErr == nil {
+			return nil
+		}
+		if !isTransient(lastErr) {
+			return lastErr
+		}
+	}
+
+	return lastErr
+}
+
+// WatchEventsV1Events establishes a watch connection to Activity storage for events.k8s.io/v1 event changes.
+func (p *DynamicProvider) WatchEventsV1Events(ctx context.Context, namespace string, opts *metav1.ListOptions) (watch.Interface, error) {
+	if opts == nil {
+		opts = &metav1.ListOptions{}
+	}
+
+	dyn, err := p.dynForUser(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return dyn.Resource(p.eventsv1GVR).Namespace(namespace).Watch(ctx, *opts)
+}

--- a/internal/apiserver/events/dynamic_test.go
+++ b/internal/apiserver/events/dynamic_test.go
@@ -1,0 +1,357 @@
+package events
+
+import (
+	"context"
+	"errors"
+	"net"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	authuser "k8s.io/apiserver/pkg/authentication/user"
+	apirequest "k8s.io/apiserver/pkg/endpoints/request"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// contextWithUser creates a context with the given user info.
+func contextWithUser(u authuser.Info) context.Context {
+	return apirequest.WithUser(context.Background(), u)
+}
+
+func TestInjectScopeAnnotations_ProjectScope(t *testing.T) {
+	// User with project scope should have annotations added
+	ctx := contextWithUser(&authuser.DefaultInfo{
+		Name: "alice",
+		Extra: map[string][]string{
+			ExtraKeyParentType: {"Project"},
+			ExtraKeyParentName: {"project-123"},
+		},
+	})
+	event := &corev1.Event{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-event"},
+	}
+
+	err := injectScopeAnnotations(ctx, event)
+
+	require.NoError(t, err)
+	assert.Equal(t, "Project", event.Annotations[ScopeTypeAnnotation])
+	assert.Equal(t, "project-123", event.Annotations[ScopeNameAnnotation])
+}
+
+func TestInjectScopeAnnotations_OrganizationScope(t *testing.T) {
+	// User with organization scope should have annotations added
+	ctx := contextWithUser(&authuser.DefaultInfo{
+		Name: "bob",
+		Extra: map[string][]string{
+			ExtraKeyParentType: {"Organization"},
+			ExtraKeyParentName: {"org-456"},
+		},
+	})
+	event := &corev1.Event{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-event"},
+	}
+
+	err := injectScopeAnnotations(ctx, event)
+
+	require.NoError(t, err)
+	assert.Equal(t, "Organization", event.Annotations[ScopeTypeAnnotation])
+	assert.Equal(t, "org-456", event.Annotations[ScopeNameAnnotation])
+}
+
+func TestInjectScopeAnnotations_PlatformScope(t *testing.T) {
+	// Platform user (no scope extras) should have no annotations added
+	ctx := contextWithUser(&authuser.DefaultInfo{
+		Name: "system:serviceaccount:kube-system:default",
+	})
+	event := &corev1.Event{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-event"},
+	}
+
+	err := injectScopeAnnotations(ctx, event)
+
+	require.NoError(t, err)
+	assert.Empty(t, event.Annotations)
+}
+
+func TestInjectScopeAnnotations_PreservesExistingAnnotations(t *testing.T) {
+	// Existing annotations should be preserved, scope annotations added
+	ctx := contextWithUser(&authuser.DefaultInfo{
+		Name: "carol",
+		Extra: map[string][]string{
+			ExtraKeyParentType: {"Project"},
+			ExtraKeyParentName: {"project-789"},
+		},
+	})
+	event := &corev1.Event{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-event",
+			Annotations: map[string]string{
+				"existing-key": "existing-value",
+				"another-key":  "another-value",
+			},
+		},
+	}
+
+	err := injectScopeAnnotations(ctx, event)
+
+	require.NoError(t, err)
+	assert.Equal(t, "existing-value", event.Annotations["existing-key"])
+	assert.Equal(t, "another-value", event.Annotations["another-key"])
+	assert.Equal(t, "Project", event.Annotations[ScopeTypeAnnotation])
+	assert.Equal(t, "project-789", event.Annotations[ScopeNameAnnotation])
+}
+
+func TestInjectScopeAnnotations_NoUserInContext(t *testing.T) {
+	// Missing user in context should return error
+	ctx := context.Background()
+	event := &corev1.Event{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-event"},
+	}
+
+	err := injectScopeAnnotations(ctx, event)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no user in context")
+}
+
+func TestInjectScopeAnnotations_PartialScope(t *testing.T) {
+	// User with only parent type (missing name) should have no annotations added
+	ctx := contextWithUser(&authuser.DefaultInfo{
+		Name: "dave",
+		Extra: map[string][]string{
+			ExtraKeyParentType: {"Project"},
+			// Missing ExtraKeyParentName
+		},
+	})
+	event := &corev1.Event{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-event"},
+	}
+
+	err := injectScopeAnnotations(ctx, event)
+
+	require.NoError(t, err)
+	assert.Empty(t, event.Annotations)
+}
+
+func TestInjectScopeAnnotations_OverwritesScope(t *testing.T) {
+	// If event already has scope annotations, they should be overwritten with user's scope
+	ctx := contextWithUser(&authuser.DefaultInfo{
+		Name: "eve",
+		Extra: map[string][]string{
+			ExtraKeyParentType: {"Project"},
+			ExtraKeyParentName: {"project-new"},
+		},
+	})
+	event := &corev1.Event{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-event",
+			Annotations: map[string]string{
+				ScopeTypeAnnotation: "Organization",
+				ScopeNameAnnotation: "org-old",
+			},
+		},
+	}
+
+	err := injectScopeAnnotations(ctx, event)
+
+	require.NoError(t, err)
+	assert.Equal(t, "Project", event.Annotations[ScopeTypeAnnotation], "scope type should be overwritten")
+	assert.Equal(t, "project-new", event.Annotations[ScopeNameAnnotation], "scope name should be overwritten")
+}
+
+func TestGetFirstExtra(t *testing.T) {
+	extras := map[string][]string{
+		"key1": {"value1", "value2"},
+		"key2": {"single-value"},
+		"key3": {},
+	}
+
+	assert.Equal(t, "value1", getFirstExtra(extras, "key1"))
+	assert.Equal(t, "single-value", getFirstExtra(extras, "key2"))
+	assert.Equal(t, "", getFirstExtra(extras, "key3"))
+	assert.Equal(t, "", getFirstExtra(extras, "nonexistent"))
+}
+
+func TestNewDynamicProvider_RequiresURL(t *testing.T) {
+	_, err := NewDynamicProvider(Config{
+		// Missing ProviderURL
+		CAFile:         "/path/to/ca.crt",
+		ClientCertFile: "/path/to/client.crt",
+		ClientKeyFile:  "/path/to/client.key",
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "ProviderURL is required")
+}
+
+func TestNewDynamicProvider_ValidConfig(t *testing.T) {
+	cfg := Config{
+		ProviderURL:    "https://activity-apiserver.activity-system.svc:443",
+		CAFile:         "/etc/milo/activity/ca.crt",
+		ClientCertFile: "/etc/milo/activity/tls.crt",
+		ClientKeyFile:  "/etc/milo/activity/tls.key",
+		Timeout:        30 * time.Second,
+		Retries:        3,
+		ExtrasAllow: map[string]struct{}{
+			"iam.miloapis.com/parent-type": {},
+			"iam.miloapis.com/parent-name": {},
+		},
+	}
+
+	provider, err := NewDynamicProvider(cfg)
+
+	require.NoError(t, err)
+	assert.NotNil(t, provider)
+	assert.Equal(t, "https://activity-apiserver.activity-system.svc:443", provider.base.Host)
+	assert.Equal(t, "activity-apiserver.activity-system.svc", provider.base.ServerName)
+	assert.Equal(t, "/etc/milo/activity/ca.crt", provider.base.CAFile)
+	assert.Equal(t, "/etc/milo/activity/tls.crt", provider.base.CertFile)
+	assert.Equal(t, "/etc/milo/activity/tls.key", provider.base.KeyFile)
+	assert.False(t, provider.base.Insecure)
+	assert.Equal(t, 3, provider.retries)
+	assert.Equal(t, 30*time.Second, provider.to)
+}
+
+func TestFilterExtras(t *testing.T) {
+	provider := &DynamicProvider{
+		allowExtras: map[string]struct{}{
+			"iam.miloapis.com/parent-type": {},
+			"iam.miloapis.com/parent-name": {},
+		},
+	}
+
+	src := map[string][]string{
+		"iam.miloapis.com/parent-type": {"Project"},
+		"iam.miloapis.com/parent-name": {"project-123"},
+		"other-key":                    {"should-be-filtered"},
+		"another-key":                  {"also-filtered"},
+	}
+
+	result := provider.filterExtras(src)
+
+	assert.Len(t, result, 2)
+	assert.Equal(t, []string{"Project"}, result["iam.miloapis.com/parent-type"])
+	assert.Equal(t, []string{"project-123"}, result["iam.miloapis.com/parent-name"])
+	assert.NotContains(t, result, "other-key")
+	assert.NotContains(t, result, "another-key")
+}
+
+func TestFilterExtras_EmptyAllowList(t *testing.T) {
+	provider := &DynamicProvider{
+		allowExtras: map[string]struct{}{},
+	}
+
+	src := map[string][]string{
+		"key1": {"value1"},
+		"key2": {"value2"},
+	}
+
+	result := provider.filterExtras(src)
+
+	assert.Nil(t, result)
+}
+
+func TestFilterExtras_EmptySource(t *testing.T) {
+	provider := &DynamicProvider{
+		allowExtras: map[string]struct{}{
+			"key1": {},
+		},
+	}
+
+	result := provider.filterExtras(map[string][]string{})
+
+	assert.Nil(t, result)
+}
+
+func TestIsTransient(t *testing.T) {
+	gr := schema.GroupResource{Group: "", Resource: "events"}
+
+	tests := []struct {
+		name     string
+		err      error
+		expected bool
+	}{
+		{
+			name:     "nil error is not transient",
+			err:      nil,
+			expected: false,
+		},
+		{
+			name:     "timeout error is transient",
+			err:      apierrors.NewTimeoutError("timeout", 5),
+			expected: true,
+		},
+		{
+			name:     "server timeout is transient",
+			err:      apierrors.NewServerTimeout(gr, "get", 5),
+			expected: true,
+		},
+		{
+			name:     "service unavailable is transient",
+			err:      apierrors.NewServiceUnavailable("service down"),
+			expected: true,
+		},
+		{
+			name:     "internal error is transient",
+			err:      apierrors.NewInternalError(errors.New("internal error")),
+			expected: true,
+		},
+		{
+			name:     "too many requests is transient",
+			err:      apierrors.NewTooManyRequests("rate limited", 30),
+			expected: true,
+		},
+		{
+			name:     "not found error is not transient",
+			err:      apierrors.NewNotFound(gr, "event-name"),
+			expected: false,
+		},
+		{
+			name:     "bad request error is not transient",
+			err:      apierrors.NewBadRequest("invalid input"),
+			expected: false,
+		},
+		{
+			name:     "forbidden error is not transient",
+			err:      apierrors.NewForbidden(gr, "event-name", errors.New("denied")),
+			expected: false,
+		},
+		{
+			name:     "unauthorized error is not transient",
+			err:      apierrors.NewUnauthorized("not authenticated"),
+			expected: false,
+		},
+		{
+			name:     "conflict error is not transient",
+			err:      apierrors.NewConflict(gr, "event-name", errors.New("conflict")),
+			expected: false,
+		},
+		{
+			name: "network timeout error is transient",
+			err: &net.OpError{
+				Op:  "read",
+				Err: &timeoutError{},
+			},
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := isTransient(tt.err)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+// timeoutError is a mock net.Error that returns true for Timeout().
+type timeoutError struct{}
+
+func (e *timeoutError) Error() string   { return "timeout" }
+func (e *timeoutError) Timeout() bool   { return true }
+func (e *timeoutError) Temporary() bool { return true }

--- a/internal/apiserver/events/eventsv1_rest.go
+++ b/internal/apiserver/events/eventsv1_rest.go
@@ -1,0 +1,301 @@
+package events
+
+import (
+	"context"
+	"fmt"
+
+	eventsv1 "k8s.io/api/events/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metainternalversion "k8s.io/apimachinery/pkg/apis/meta/internalversion"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
+	apirequest "k8s.io/apiserver/pkg/endpoints/request"
+	"k8s.io/apiserver/pkg/registry/rest"
+	"k8s.io/klog/v2"
+)
+
+// EventsV1Backend defines the interface for events.k8s.io/v1 event storage operations.
+type EventsV1Backend interface {
+	CreateEventsV1Event(ctx context.Context, namespace string, event *eventsv1.Event) (*eventsv1.Event, error)
+	GetEventsV1Event(ctx context.Context, namespace, name string) (*eventsv1.Event, error)
+	ListEventsV1Events(ctx context.Context, namespace string, opts *metav1.ListOptions) (*eventsv1.EventList, error)
+	UpdateEventsV1Event(ctx context.Context, namespace string, event *eventsv1.Event) (*eventsv1.Event, error)
+	DeleteEventsV1Event(ctx context.Context, namespace, name string, opts *metav1.DeleteOptions) error
+	WatchEventsV1Events(ctx context.Context, namespace string, opts *metav1.ListOptions) (watch.Interface, error)
+}
+
+// EventsV1REST implements the REST endpoint for events.k8s.io/v1 Events
+type EventsV1REST struct {
+	backend EventsV1Backend
+}
+
+var _ rest.Scoper = &EventsV1REST{}
+var _ rest.Creater = &EventsV1REST{}
+var _ rest.Getter = &EventsV1REST{}
+var _ rest.Lister = &EventsV1REST{}
+var _ rest.Updater = &EventsV1REST{}
+var _ rest.GracefulDeleter = &EventsV1REST{}
+var _ rest.Watcher = &EventsV1REST{}
+var _ rest.Storage = &EventsV1REST{}
+var _ rest.SingularNameProvider = &EventsV1REST{}
+var _ rest.TableConvertor = &EventsV1REST{}
+
+// NewEventsV1REST creates a new REST storage for events.k8s.io/v1 Events.
+func NewEventsV1REST(backend EventsV1Backend) *EventsV1REST {
+	return &EventsV1REST{backend: backend}
+}
+
+func (r *EventsV1REST) GetSingularName() string { return "event" }
+func (r *EventsV1REST) NamespaceScoped() bool   { return true }
+func (r *EventsV1REST) New() runtime.Object     { return &eventsv1.Event{} }
+func (r *EventsV1REST) NewList() runtime.Object { return &eventsv1.EventList{} }
+func (r *EventsV1REST) Destroy()                {}
+
+// Create creates a new event with injected scope annotations.
+// Validation is delegated to the upstream Activity API server.
+func (r *EventsV1REST) Create(
+	ctx context.Context,
+	obj runtime.Object,
+	_ rest.ValidateObjectFunc,
+	_ *metav1.CreateOptions,
+) (runtime.Object, error) {
+	logger := klog.FromContext(ctx)
+	event := obj.(*eventsv1.Event)
+
+	ns, ok := apirequest.NamespaceFrom(ctx)
+	if !ok {
+		return nil, apierrors.NewBadRequest("namespace is required")
+	}
+
+	if err := injectEventsV1ScopeAnnotations(ctx, event); err != nil {
+		logger.Error(err, "Failed to inject scope annotations")
+		return nil, apierrors.NewBadRequest(fmt.Sprintf("failed to determine scope: %v", err))
+	}
+
+	logger.V(4).Info("Creating eventsv1 event", "namespace", ns, "name", event.Name, "reason", event.Reason)
+
+	result, err := r.backend.CreateEventsV1Event(ctx, ns, event)
+	if err != nil {
+		logger.Error(err, "Failed to create eventsv1 event", "namespace", ns, "name", event.Name)
+		return nil, err
+	}
+
+	logger.V(4).Info("Created eventsv1 event", "namespace", ns, "name", result.Name)
+	return result, nil
+}
+
+// Get retrieves an event by name.
+func (r *EventsV1REST) Get(ctx context.Context, name string, options *metav1.GetOptions) (runtime.Object, error) {
+	logger := klog.FromContext(ctx)
+
+	ns, ok := apirequest.NamespaceFrom(ctx)
+	if !ok {
+		return nil, apierrors.NewBadRequest("namespace is required")
+	}
+
+	logger.V(4).Info("Getting eventsv1 event", "namespace", ns, "name", name)
+
+	result, err := r.backend.GetEventsV1Event(ctx, ns, name)
+	if err != nil {
+		logger.Error(err, "Failed to get eventsv1 event", "namespace", ns, "name", name)
+		return nil, err
+	}
+
+	logger.V(4).Info("Got eventsv1 event", "namespace", ns, "name", name, "reason", result.Reason)
+	return result, nil
+}
+
+// List lists events with optional filtering.
+func (r *EventsV1REST) List(ctx context.Context, options *metainternalversion.ListOptions) (runtime.Object, error) {
+	logger := klog.FromContext(ctx)
+
+	ns, ok := apirequest.NamespaceFrom(ctx)
+	if !ok {
+		return nil, apierrors.NewBadRequest("namespace is required")
+	}
+
+	logger.V(4).Info("Listing eventsv1 events", "namespace", ns)
+
+	lo := &metav1.ListOptions{}
+	if options != nil {
+		if err := metainternalversion.Convert_internalversion_ListOptions_To_v1_ListOptions(options, lo, nil); err != nil {
+			return nil, err
+		}
+	}
+
+	result, err := r.backend.ListEventsV1Events(ctx, ns, lo)
+	if err != nil {
+		logger.Error(err, "Failed to list eventsv1 events", "namespace", ns)
+		return nil, err
+	}
+
+	logger.V(4).Info("Listed eventsv1 events", "namespace", ns, "count", len(result.Items))
+	return result, nil
+}
+
+// Update updates an existing event.
+// Validation is delegated to the upstream Activity API server.
+func (r *EventsV1REST) Update(
+	ctx context.Context,
+	name string,
+	objInfo rest.UpdatedObjectInfo,
+	_ rest.ValidateObjectFunc,
+	_ rest.ValidateObjectUpdateFunc,
+	_ bool,
+	_ *metav1.UpdateOptions,
+) (runtime.Object, bool, error) {
+	logger := klog.FromContext(ctx)
+
+	ns, ok := apirequest.NamespaceFrom(ctx)
+	if !ok {
+		return nil, false, apierrors.NewBadRequest("namespace is required")
+	}
+
+	obj, err := objInfo.UpdatedObject(ctx, nil)
+	if err != nil {
+		return nil, false, err
+	}
+	event := obj.(*eventsv1.Event)
+
+	if err := injectEventsV1ScopeAnnotations(ctx, event); err != nil {
+		logger.Error(err, "Failed to inject scope annotations")
+		return nil, false, apierrors.NewBadRequest(fmt.Sprintf("failed to determine scope: %v", err))
+	}
+
+	logger.V(4).Info("Updating eventsv1 event", "namespace", ns, "name", name)
+
+	result, err := r.backend.UpdateEventsV1Event(ctx, ns, event)
+	if err != nil {
+		logger.Error(err, "Failed to update eventsv1 event", "namespace", ns, "name", name)
+		return nil, false, err
+	}
+
+	logger.V(4).Info("Updated eventsv1 event", "namespace", ns, "name", name)
+	return result, false, nil
+}
+
+// Delete deletes an event.
+// Validation is delegated to the upstream Activity API server.
+func (r *EventsV1REST) Delete(
+	ctx context.Context,
+	name string,
+	_ rest.ValidateObjectFunc,
+	options *metav1.DeleteOptions,
+) (runtime.Object, bool, error) {
+	logger := klog.FromContext(ctx)
+
+	ns, ok := apirequest.NamespaceFrom(ctx)
+	if !ok {
+		return nil, false, apierrors.NewBadRequest("namespace is required")
+	}
+
+	logger.V(4).Info("Deleting eventsv1 event", "namespace", ns, "name", name)
+
+	if err := r.backend.DeleteEventsV1Event(ctx, ns, name, options); err != nil {
+		logger.Error(err, "Failed to delete eventsv1 event", "namespace", ns, "name", name)
+		return nil, false, err
+	}
+
+	logger.V(4).Info("Deleted eventsv1 event", "namespace", ns, "name", name)
+	return &metav1.Status{Status: metav1.StatusSuccess}, true, nil
+}
+
+// Watch establishes a watch connection for events
+func (r *EventsV1REST) Watch(ctx context.Context, options *metainternalversion.ListOptions) (watch.Interface, error) {
+	logger := klog.FromContext(ctx)
+
+	ns, ok := apirequest.NamespaceFrom(ctx)
+	if !ok {
+		return nil, apierrors.NewBadRequest("namespace is required")
+	}
+
+	logger.V(4).Info("Watching eventsv1 events", "namespace", ns)
+
+	lo := &metav1.ListOptions{}
+	if options != nil {
+		if err := metainternalversion.Convert_internalversion_ListOptions_To_v1_ListOptions(options, lo, nil); err != nil {
+			return nil, err
+		}
+	}
+
+	return r.backend.WatchEventsV1Events(ctx, ns, lo)
+}
+
+// ConvertToTable provides a table representation for kubectl output
+func (r *EventsV1REST) ConvertToTable(ctx context.Context, object runtime.Object, tableOptions runtime.Object) (*metav1.Table, error) {
+	table := &metav1.Table{
+		ColumnDefinitions: []metav1.TableColumnDefinition{
+			{Name: "Last Seen", Type: "string", Description: "Time when this Event was last observed"},
+			{Name: "Type", Type: "string", Description: "Type of this event (Normal, Warning)"},
+			{Name: "Reason", Type: "string", Description: "Short machine understandable string"},
+			{Name: "Object", Type: "string", Description: "The object this Event is about"},
+			{Name: "Message", Type: "string", Description: "Human-readable description"},
+		},
+	}
+
+	appendRow := func(event *eventsv1.Event) {
+		lastSeen := "<unknown>"
+		if !event.EventTime.Time.IsZero() {
+			lastSeen = event.EventTime.Time.Format("2006-01-02T15:04:05Z")
+		} else if !event.DeprecatedLastTimestamp.IsZero() {
+			lastSeen = event.DeprecatedLastTimestamp.Format("2006-01-02T15:04:05Z")
+		}
+
+		objectRef := fmt.Sprintf("%s/%s", event.Regarding.Kind, event.Regarding.Name)
+		if event.Regarding.Namespace != "" && event.Regarding.Namespace != event.Namespace {
+			objectRef = event.Regarding.Namespace + "/" + objectRef
+		}
+
+		table.Rows = append(table.Rows, metav1.TableRow{
+			Cells: []interface{}{
+				lastSeen,
+				event.Type,
+				event.Reason,
+				objectRef,
+				event.Note,
+			},
+			Object: runtime.RawExtension{Object: event},
+		})
+	}
+
+	switch obj := object.(type) {
+	case *eventsv1.EventList:
+		for i := range obj.Items {
+			appendRow(&obj.Items[i])
+		}
+	case *eventsv1.Event:
+		appendRow(obj)
+	default:
+		return nil, nil
+	}
+
+	return table, nil
+}
+
+// injectEventsV1ScopeAnnotations adds scope annotations to an events.k8s.io/v1 Event
+func injectEventsV1ScopeAnnotations(ctx context.Context, event *eventsv1.Event) error {
+	userInfo, ok := apirequest.UserFrom(ctx)
+	if !ok {
+		return fmt.Errorf("no user in context")
+	}
+
+	extras := userInfo.GetExtra()
+
+	parentType := getFirstExtra(extras, ExtraKeyParentType)
+	parentName := getFirstExtra(extras, ExtraKeyParentName)
+
+	// Events without scope context are normal (e.g., system components, platform-level operations)
+	if parentType == "" || parentName == "" {
+		return nil
+	}
+
+	if event.Annotations == nil {
+		event.Annotations = make(map[string]string)
+	}
+
+	event.Annotations[ScopeTypeAnnotation] = parentType
+	event.Annotations[ScopeNameAnnotation] = parentName
+
+	return nil
+}

--- a/internal/apiserver/events/eventsv1_storageprovider.go
+++ b/internal/apiserver/events/eventsv1_storageprovider.go
@@ -1,0 +1,36 @@
+package events
+
+import (
+	eventsv1 "k8s.io/api/events/v1"
+	"k8s.io/apiserver/pkg/registry/generic"
+	"k8s.io/apiserver/pkg/registry/rest"
+	genericapiserver "k8s.io/apiserver/pkg/server"
+	serverstorage "k8s.io/apiserver/pkg/server/storage"
+)
+
+// EventsV1StorageProvider provides REST storage for the events.k8s.io/v1 API group.
+type EventsV1StorageProvider struct {
+	Backend EventsV1Backend
+}
+
+// NewRESTStorage returns APIGroupInfo for the events.k8s.io/v1 API group
+func (p *EventsV1StorageProvider) NewRESTStorage(
+	apiResourceConfigSource serverstorage.APIResourceConfigSource,
+	restOptionsGetter generic.RESTOptionsGetter,
+) (genericapiserver.APIGroupInfo, error) {
+	apiGroupInfo := genericapiserver.NewDefaultAPIGroupInfo(eventsv1.GroupName, Scheme, ParameterCodec, Codecs)
+
+	if p.Backend != nil {
+		v1Storage := map[string]rest.Storage{
+			"events": NewEventsV1REST(p.Backend),
+		}
+		apiGroupInfo.VersionedResourcesStorageMap["v1"] = v1Storage
+	}
+
+	return apiGroupInfo, nil
+}
+
+// GroupName returns the API group name
+func (p *EventsV1StorageProvider) GroupName() string {
+	return eventsv1.GroupName
+}

--- a/internal/apiserver/events/integration_test.go
+++ b/internal/apiserver/events/integration_test.go
@@ -1,0 +1,638 @@
+package events
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	authuser "k8s.io/apiserver/pkg/authentication/user"
+	apirequest "k8s.io/apiserver/pkg/endpoints/request"
+	"k8s.io/apiserver/pkg/registry/rest"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestEventLifecycle tests the complete lifecycle of an event through the REST API.
+func TestEventLifecycle(t *testing.T) {
+	backend := &mockBackend{
+		createFunc: func(ctx context.Context, namespace string, event *corev1.Event) (*corev1.Event, error) {
+			// Simulate backend storing the event
+			return event.DeepCopy(), nil
+		},
+		getFunc: func(ctx context.Context, namespace, name string) (*corev1.Event, error) {
+			return &corev1.Event{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      name,
+					Namespace: namespace,
+					Annotations: map[string]string{
+						ScopeTypeAnnotation: "Project",
+						ScopeNameAnnotation: "test-project",
+					},
+				},
+				Reason:  "Started",
+				Message: "Container started",
+			}, nil
+		},
+		updateFunc: func(ctx context.Context, namespace string, event *corev1.Event) (*corev1.Event, error) {
+			return event.DeepCopy(), nil
+		},
+		deleteFunc: func(ctx context.Context, namespace, name string, opts *metav1.DeleteOptions) error {
+			return nil
+		},
+	}
+
+	r := NewREST(backend)
+
+	user := &authuser.DefaultInfo{
+		Name: "test-user",
+		Extra: map[string][]string{
+			ExtraKeyParentType: {"Project"},
+			ExtraKeyParentName: {"test-project"},
+		},
+	}
+	ctx := apirequest.WithUser(context.Background(), user)
+	ctx = apirequest.WithNamespace(ctx, "default")
+
+	// 1. Create event
+	createEvent := &corev1.Event{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "lifecycle-test-event",
+		},
+		Reason:  "Started",
+		Message: "Container started",
+	}
+
+	created, err := r.Create(ctx, createEvent, nil, &metav1.CreateOptions{})
+	require.NoError(t, err)
+	createdEvent := created.(*corev1.Event)
+	assert.Equal(t, "Project", createdEvent.Annotations[ScopeTypeAnnotation])
+	assert.Equal(t, "test-project", createdEvent.Annotations[ScopeNameAnnotation])
+
+	// 2. Get event
+	retrieved, err := r.Get(ctx, "lifecycle-test-event", &metav1.GetOptions{})
+	require.NoError(t, err)
+	retrievedEvent := retrieved.(*corev1.Event)
+	assert.Equal(t, "lifecycle-test-event", retrievedEvent.Name)
+	assert.Equal(t, "Started", retrievedEvent.Reason)
+
+	// 3. Update event
+	updatedEvent := retrievedEvent.DeepCopy()
+	updatedEvent.Message = "Container updated"
+	objInfo := &mockUpdatedObjectInfo{obj: updatedEvent}
+
+	updated, wasCreated, err := r.Update(ctx, "lifecycle-test-event", objInfo, nil, nil, false, &metav1.UpdateOptions{})
+	require.NoError(t, err)
+	assert.False(t, wasCreated)
+	updatedResult := updated.(*corev1.Event)
+	assert.Equal(t, "Container updated", updatedResult.Message)
+	// Verify scope was re-injected
+	assert.Equal(t, "Project", updatedResult.Annotations[ScopeTypeAnnotation])
+
+	// 4. Delete event
+	deleted, immediate, err := r.Delete(ctx, "lifecycle-test-event", nil, &metav1.DeleteOptions{})
+	require.NoError(t, err)
+	assert.True(t, immediate)
+	assert.NotNil(t, deleted)
+}
+
+// TestMultiTenantScenarios tests various multi-tenant isolation scenarios.
+func TestMultiTenantScenarios(t *testing.T) {
+	t.Run("different users different scopes", func(t *testing.T) {
+		backend := &mockBackend{
+			createFunc: func(ctx context.Context, namespace string, event *corev1.Event) (*corev1.Event, error) {
+				return event.DeepCopy(), nil
+			},
+		}
+
+		r := NewREST(backend)
+
+		// User in Project A
+		userA := &authuser.DefaultInfo{
+			Name: "user-a",
+			Extra: map[string][]string{
+				ExtraKeyParentType: {"Project"},
+				ExtraKeyParentName: {"project-a"},
+			},
+		}
+		ctxA := apirequest.WithUser(context.Background(), userA)
+		ctxA = apirequest.WithNamespace(ctxA, "default")
+
+		// User in Project B
+		userB := &authuser.DefaultInfo{
+			Name: "user-b",
+			Extra: map[string][]string{
+				ExtraKeyParentType: {"Project"},
+				ExtraKeyParentName: {"project-b"},
+			},
+		}
+		ctxB := apirequest.WithUser(context.Background(), userB)
+		ctxB = apirequest.WithNamespace(ctxB, "default")
+
+		// Create event as User A
+		eventA := &corev1.Event{
+			ObjectMeta: metav1.ObjectMeta{Name: "event-a"},
+		}
+		createdA, err := r.Create(ctxA, eventA, nil, &metav1.CreateOptions{})
+		require.NoError(t, err)
+		resultA := createdA.(*corev1.Event)
+		assert.Equal(t, "project-a", resultA.Annotations[ScopeNameAnnotation])
+
+		// Create event as User B
+		eventB := &corev1.Event{
+			ObjectMeta: metav1.ObjectMeta{Name: "event-b"},
+		}
+		createdB, err := r.Create(ctxB, eventB, nil, &metav1.CreateOptions{})
+		require.NoError(t, err)
+		resultB := createdB.(*corev1.Event)
+		assert.Equal(t, "project-b", resultB.Annotations[ScopeNameAnnotation])
+
+		// Verify events have different scopes
+		assert.NotEqual(t, resultA.Annotations[ScopeNameAnnotation], resultB.Annotations[ScopeNameAnnotation])
+	})
+
+	t.Run("organization vs project scope", func(t *testing.T) {
+		backend := &mockBackend{
+			createFunc: func(ctx context.Context, namespace string, event *corev1.Event) (*corev1.Event, error) {
+				return event.DeepCopy(), nil
+			},
+		}
+
+		r := NewREST(backend)
+
+		// Organization-scoped user
+		orgUser := &authuser.DefaultInfo{
+			Name: "org-user",
+			Extra: map[string][]string{
+				ExtraKeyParentType: {"Organization"},
+				ExtraKeyParentName: {"my-org"},
+			},
+		}
+		orgCtx := apirequest.WithUser(context.Background(), orgUser)
+		orgCtx = apirequest.WithNamespace(orgCtx, "default")
+
+		// Project-scoped user
+		projUser := &authuser.DefaultInfo{
+			Name: "proj-user",
+			Extra: map[string][]string{
+				ExtraKeyParentType: {"Project"},
+				ExtraKeyParentName: {"my-project"},
+			},
+		}
+		projCtx := apirequest.WithUser(context.Background(), projUser)
+		projCtx = apirequest.WithNamespace(projCtx, "default")
+
+		// Create event as org user
+		orgEvent := &corev1.Event{
+			ObjectMeta: metav1.ObjectMeta{Name: "org-event"},
+		}
+		createdOrg, err := r.Create(orgCtx, orgEvent, nil, &metav1.CreateOptions{})
+		require.NoError(t, err)
+		resultOrg := createdOrg.(*corev1.Event)
+		assert.Equal(t, "Organization", resultOrg.Annotations[ScopeTypeAnnotation])
+		assert.Equal(t, "my-org", resultOrg.Annotations[ScopeNameAnnotation])
+
+		// Create event as project user
+		projEvent := &corev1.Event{
+			ObjectMeta: metav1.ObjectMeta{Name: "proj-event"},
+		}
+		createdProj, err := r.Create(projCtx, projEvent, nil, &metav1.CreateOptions{})
+		require.NoError(t, err)
+		resultProj := createdProj.(*corev1.Event)
+		assert.Equal(t, "Project", resultProj.Annotations[ScopeTypeAnnotation])
+		assert.Equal(t, "my-project", resultProj.Annotations[ScopeNameAnnotation])
+	})
+}
+
+// TestScopeImmutability verifies that scope cannot be tampered with.
+func TestScopeImmutability(t *testing.T) {
+	t.Run("create with pre-existing scope annotations", func(t *testing.T) {
+		backend := &mockBackend{
+			createFunc: func(ctx context.Context, namespace string, event *corev1.Event) (*corev1.Event, error) {
+				return event.DeepCopy(), nil
+			},
+		}
+
+		r := NewREST(backend)
+
+		user := &authuser.DefaultInfo{
+			Name: "alice",
+			Extra: map[string][]string{
+				ExtraKeyParentType: {"Project"},
+				ExtraKeyParentName: {"project-real"},
+			},
+		}
+		ctx := apirequest.WithUser(context.Background(), user)
+		ctx = apirequest.WithNamespace(ctx, "default")
+
+		// Malicious client tries to set different scope
+		event := &corev1.Event{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "tampered-event",
+				Annotations: map[string]string{
+					ScopeTypeAnnotation: "Organization",
+					ScopeNameAnnotation: "malicious-org",
+				},
+			},
+		}
+
+		created, err := r.Create(ctx, event, nil, &metav1.CreateOptions{})
+		require.NoError(t, err)
+
+		result := created.(*corev1.Event)
+		// Verify scope was overwritten with actual user scope
+		assert.Equal(t, "Project", result.Annotations[ScopeTypeAnnotation])
+		assert.Equal(t, "project-real", result.Annotations[ScopeNameAnnotation])
+	})
+
+	t.Run("update cannot change scope", func(t *testing.T) {
+		backend := &mockBackend{
+			updateFunc: func(ctx context.Context, namespace string, event *corev1.Event) (*corev1.Event, error) {
+				return event.DeepCopy(), nil
+			},
+		}
+
+		r := NewREST(backend)
+
+		user := &authuser.DefaultInfo{
+			Name: "alice",
+			Extra: map[string][]string{
+				ExtraKeyParentType: {"Project"},
+				ExtraKeyParentName: {"project-real"},
+			},
+		}
+		ctx := apirequest.WithUser(context.Background(), user)
+		ctx = apirequest.WithNamespace(ctx, "default")
+
+		// Event with tampered scope in update
+		event := &corev1.Event{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "event-to-update",
+				Annotations: map[string]string{
+					ScopeTypeAnnotation: "Platform", // Trying to escalate
+					ScopeNameAnnotation: "",
+					"custom-key":        "custom-value",
+				},
+			},
+			Message: "Updated message",
+		}
+
+		objInfo := &mockUpdatedObjectInfo{obj: event}
+
+		updated, _, err := r.Update(ctx, "event-to-update", objInfo, nil, nil, false, &metav1.UpdateOptions{})
+		require.NoError(t, err)
+
+		result := updated.(*corev1.Event)
+		// Verify scope was re-injected correctly
+		assert.Equal(t, "Project", result.Annotations[ScopeTypeAnnotation])
+		assert.Equal(t, "project-real", result.Annotations[ScopeNameAnnotation])
+		// Verify other annotations preserved
+		assert.Equal(t, "custom-value", result.Annotations["custom-key"])
+	})
+}
+
+// TestEdgeCases tests various edge cases and error conditions.
+func TestEdgeCases(t *testing.T) {
+	t.Run("event with nil annotations", func(t *testing.T) {
+		backend := &mockBackend{
+			createFunc: func(ctx context.Context, namespace string, event *corev1.Event) (*corev1.Event, error) {
+				return event.DeepCopy(), nil
+			},
+		}
+
+		r := NewREST(backend)
+
+		user := &authuser.DefaultInfo{
+			Name: "alice",
+			Extra: map[string][]string{
+				ExtraKeyParentType: {"Project"},
+				ExtraKeyParentName: {"project-123"},
+			},
+		}
+		ctx := apirequest.WithUser(context.Background(), user)
+		ctx = apirequest.WithNamespace(ctx, "default")
+
+		event := &corev1.Event{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "nil-annotations",
+				// Annotations is nil
+			},
+		}
+
+		created, err := r.Create(ctx, event, nil, &metav1.CreateOptions{})
+		require.NoError(t, err)
+
+		result := created.(*corev1.Event)
+		assert.NotNil(t, result.Annotations, "annotations map should be initialized")
+		assert.Equal(t, "Project", result.Annotations[ScopeTypeAnnotation])
+	})
+
+	t.Run("event with empty extra values", func(t *testing.T) {
+		backend := &mockBackend{
+			createFunc: func(ctx context.Context, namespace string, event *corev1.Event) (*corev1.Event, error) {
+				return event.DeepCopy(), nil
+			},
+		}
+
+		r := NewREST(backend)
+
+		user := &authuser.DefaultInfo{
+			Name: "alice",
+			Extra: map[string][]string{
+				ExtraKeyParentType: {}, // Empty slice
+				ExtraKeyParentName: {"project-123"},
+			},
+		}
+		ctx := apirequest.WithUser(context.Background(), user)
+		ctx = apirequest.WithNamespace(ctx, "default")
+
+		event := &corev1.Event{
+			ObjectMeta: metav1.ObjectMeta{Name: "empty-extras"},
+		}
+
+		created, err := r.Create(ctx, event, nil, &metav1.CreateOptions{})
+		require.NoError(t, err)
+
+		result := created.(*corev1.Event)
+		// Should not inject scope if any required field is empty
+		assert.Empty(t, result.Annotations[ScopeTypeAnnotation])
+		assert.Empty(t, result.Annotations[ScopeNameAnnotation])
+	})
+
+	t.Run("service account without scope", func(t *testing.T) {
+		backend := &mockBackend{
+			createFunc: func(ctx context.Context, namespace string, event *corev1.Event) (*corev1.Event, error) {
+				return event.DeepCopy(), nil
+			},
+		}
+
+		r := NewREST(backend)
+
+		// Service account with no parent context
+		user := &authuser.DefaultInfo{
+			Name: "system:serviceaccount:kube-system:default",
+			Groups: []string{
+				"system:serviceaccounts",
+				"system:serviceaccounts:kube-system",
+			},
+		}
+		ctx := apirequest.WithUser(context.Background(), user)
+		ctx = apirequest.WithNamespace(ctx, "kube-system")
+
+		event := &corev1.Event{
+			ObjectMeta: metav1.ObjectMeta{Name: "sa-event"},
+		}
+
+		created, err := r.Create(ctx, event, nil, &metav1.CreateOptions{})
+		require.NoError(t, err)
+
+		result := created.(*corev1.Event)
+		// Service accounts without scope should not have annotations
+		assert.Empty(t, result.Annotations[ScopeTypeAnnotation])
+		assert.Empty(t, result.Annotations[ScopeNameAnnotation])
+	})
+}
+
+// TestConcurrentOperations tests concurrent event operations.
+func TestConcurrentOperations(t *testing.T) {
+	backend := &mockBackend{
+		createFunc: func(ctx context.Context, namespace string, event *corev1.Event) (*corev1.Event, error) {
+			// Simulate some processing time
+			time.Sleep(10 * time.Millisecond)
+			return event.DeepCopy(), nil
+		},
+	}
+
+	r := NewREST(backend)
+
+	// Create multiple users with different scopes
+	users := []*authuser.DefaultInfo{
+		{
+			Name: "user-1",
+			Extra: map[string][]string{
+				ExtraKeyParentType: {"Project"},
+				ExtraKeyParentName: {"project-1"},
+			},
+		},
+		{
+			Name: "user-2",
+			Extra: map[string][]string{
+				ExtraKeyParentType: {"Project"},
+				ExtraKeyParentName: {"project-2"},
+			},
+		},
+		{
+			Name: "user-3",
+			Extra: map[string][]string{
+				ExtraKeyParentType: {"Organization"},
+				ExtraKeyParentName: {"org-1"},
+			},
+		},
+	}
+
+	// Create events concurrently
+	type result struct {
+		event *corev1.Event
+		err   error
+	}
+	results := make(chan result, len(users))
+
+	for i, user := range users {
+		go func(idx int, u authuser.Info) {
+			ctx := apirequest.WithUser(context.Background(), u)
+			ctx = apirequest.WithNamespace(ctx, "default")
+
+			event := &corev1.Event{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "concurrent-event-" + u.GetName(),
+				},
+			}
+
+			created, err := r.Create(ctx, event, nil, &metav1.CreateOptions{})
+			if err != nil {
+				results <- result{nil, err}
+				return
+			}
+			results <- result{created.(*corev1.Event), nil}
+		}(i, user)
+	}
+
+	// Collect results
+	for i := 0; i < len(users); i++ {
+		res := <-results
+		require.NoError(t, res.err)
+		require.NotNil(t, res.event)
+
+		// Verify each event has the correct scope
+		assert.NotEmpty(t, res.event.Annotations[ScopeTypeAnnotation])
+		assert.NotEmpty(t, res.event.Annotations[ScopeNameAnnotation])
+	}
+}
+
+// TestTableConversion tests the table conversion for kubectl output.
+func TestTableConversion(t *testing.T) {
+	r := NewREST(&mockBackend{})
+
+	t.Run("handles events with various timestamp formats", func(t *testing.T) {
+		now := metav1.Now()
+		eventTime := metav1.NewMicroTime(time.Now())
+
+		events := &corev1.EventList{
+			Items: []corev1.Event{
+				{
+					ObjectMeta:    metav1.ObjectMeta{Name: "event-1"},
+					LastTimestamp: now,
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "event-2"},
+					EventTime:  eventTime,
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "event-3"},
+					// No timestamp
+				},
+			},
+		}
+
+		table, err := r.ConvertToTable(context.Background(), events, nil)
+
+		require.NoError(t, err)
+		require.NotNil(t, table)
+		assert.Len(t, table.Rows, 3)
+
+		// First event should have LastTimestamp formatted
+		assert.NotEqual(t, "<unknown>", table.Rows[0].Cells[0])
+
+		// Second event should have EventTime formatted
+		assert.NotEqual(t, "<unknown>", table.Rows[1].Cells[0])
+
+		// Third event should show unknown
+		assert.Equal(t, "<unknown>", table.Rows[2].Cells[0])
+	})
+
+	t.Run("handles involved object references correctly", func(t *testing.T) {
+		events := &corev1.EventList{
+			Items: []corev1.Event{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "same-ns-event",
+						Namespace: "default",
+					},
+					InvolvedObject: corev1.ObjectReference{
+						Kind:      "Pod",
+						Name:      "my-pod",
+						Namespace: "default",
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "diff-ns-event",
+						Namespace: "default",
+					},
+					InvolvedObject: corev1.ObjectReference{
+						Kind:      "Pod",
+						Name:      "other-pod",
+						Namespace: "other-namespace",
+					},
+				},
+			},
+		}
+
+		table, err := r.ConvertToTable(context.Background(), events, nil)
+
+		require.NoError(t, err)
+		assert.Len(t, table.Rows, 2)
+
+		// Same namespace should not include namespace prefix
+		assert.Equal(t, "Pod/my-pod", table.Rows[0].Cells[3])
+
+		// Different namespace should include namespace prefix
+		assert.Equal(t, "other-namespace/Pod/other-pod", table.Rows[1].Cells[3])
+	})
+}
+
+// TestREST_MetadataAccessors verifies the REST storage metadata accessors.
+func TestREST_MetadataAccessors(t *testing.T) {
+	r := NewREST(&mockBackend{})
+
+	t.Run("singular name", func(t *testing.T) {
+		assert.Equal(t, "event", r.GetSingularName())
+	})
+
+	t.Run("namespace scoped", func(t *testing.T) {
+		assert.True(t, r.NamespaceScoped())
+	})
+
+	t.Run("new object", func(t *testing.T) {
+		obj := r.New()
+		_, ok := obj.(*corev1.Event)
+		assert.True(t, ok, "New() should return *corev1.Event")
+	})
+
+	t.Run("new list", func(t *testing.T) {
+		list := r.NewList()
+		_, ok := list.(*corev1.EventList)
+		assert.True(t, ok, "NewList() should return *corev1.EventList")
+	})
+}
+
+// Helper function to create a minimal event for testing.
+func newTestEvent(name string, opts ...func(*corev1.Event)) *corev1.Event {
+	event := &corev1.Event{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+		InvolvedObject: corev1.ObjectReference{
+			Kind: "Pod",
+			Name: "test-pod",
+		},
+		Reason:  "Test",
+		Message: "Test event",
+		Type:    corev1.EventTypeNormal,
+	}
+
+	for _, opt := range opts {
+		opt(event)
+	}
+
+	return event
+}
+
+func withNamespace(ns string) func(*corev1.Event) {
+	return func(e *corev1.Event) {
+		e.Namespace = ns
+	}
+}
+
+func withAnnotations(annotations map[string]string) func(*corev1.Event) {
+	return func(e *corev1.Event) {
+		e.Annotations = annotations
+	}
+}
+
+func withEventType(eventType string) func(*corev1.Event) {
+	return func(e *corev1.Event) {
+		e.Type = eventType
+	}
+}
+
+// Ensure the mock backend implements all required methods.
+var _ Backend = (*mockBackend)(nil)
+
+// Ensure REST implements all required interfaces.
+var (
+	_ rest.Scoper               = (*REST)(nil)
+	_ rest.Creater              = (*REST)(nil)
+	_ rest.Getter               = (*REST)(nil)
+	_ rest.Lister               = (*REST)(nil)
+	_ rest.Updater              = (*REST)(nil)
+	_ rest.GracefulDeleter      = (*REST)(nil)
+	_ rest.Watcher              = (*REST)(nil)
+	_ rest.Storage              = (*REST)(nil)
+	_ rest.SingularNameProvider = (*REST)(nil)
+)
+
+// Ensure mockUpdatedObjectInfo implements rest.UpdatedObjectInfo.
+var _ rest.UpdatedObjectInfo = (*mockUpdatedObjectInfo)(nil)

--- a/internal/apiserver/events/rest.go
+++ b/internal/apiserver/events/rest.go
@@ -1,0 +1,274 @@
+package events
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metainternalversion "k8s.io/apimachinery/pkg/apis/meta/internalversion"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
+	apirequest "k8s.io/apiserver/pkg/endpoints/request"
+	"k8s.io/apiserver/pkg/registry/rest"
+	"k8s.io/klog/v2"
+)
+
+// Backend defines the interface for event storage operations.
+type Backend interface {
+	CreateEvent(ctx context.Context, namespace string, event *corev1.Event) (*corev1.Event, error)
+	GetEvent(ctx context.Context, namespace, name string) (*corev1.Event, error)
+	ListEvents(ctx context.Context, namespace string, opts *metav1.ListOptions) (*corev1.EventList, error)
+	UpdateEvent(ctx context.Context, namespace string, event *corev1.Event) (*corev1.Event, error)
+	DeleteEvent(ctx context.Context, namespace, name string, opts *metav1.DeleteOptions) error
+	WatchEvents(ctx context.Context, namespace string, opts *metav1.ListOptions) (watch.Interface, error)
+}
+
+// REST implements the REST endpoint for core/v1 Events
+type REST struct {
+	backend Backend
+}
+
+var _ rest.Scoper = &REST{}
+var _ rest.Creater = &REST{}
+var _ rest.Getter = &REST{}
+var _ rest.Lister = &REST{}
+var _ rest.Updater = &REST{}
+var _ rest.GracefulDeleter = &REST{}
+var _ rest.Watcher = &REST{}
+var _ rest.Storage = &REST{}
+var _ rest.SingularNameProvider = &REST{}
+var _ rest.TableConvertor = &REST{}
+
+// NewREST creates a new REST storage for Events.
+func NewREST(backend Backend) *REST {
+	return &REST{backend: backend}
+}
+
+func (r *REST) GetSingularName() string { return "event" }
+func (r *REST) NamespaceScoped() bool   { return true }
+func (r *REST) New() runtime.Object     { return &corev1.Event{} }
+func (r *REST) NewList() runtime.Object { return &corev1.EventList{} }
+func (r *REST) Destroy()                {}
+
+// Create creates a new event with injected scope annotations.
+// Validation is delegated to the upstream Activity API server.
+func (r *REST) Create(
+	ctx context.Context,
+	obj runtime.Object,
+	_ rest.ValidateObjectFunc,
+	_ *metav1.CreateOptions,
+) (runtime.Object, error) {
+	logger := klog.FromContext(ctx)
+	event := obj.(*corev1.Event)
+
+	ns, ok := apirequest.NamespaceFrom(ctx)
+	if !ok {
+		return nil, apierrors.NewBadRequest("namespace is required")
+	}
+
+	if err := injectScopeAnnotations(ctx, event); err != nil {
+		logger.Error(err, "Failed to inject scope annotations")
+		return nil, apierrors.NewBadRequest(fmt.Sprintf("failed to determine scope: %v", err))
+	}
+
+	logger.V(4).Info("Creating event", "namespace", ns, "name", event.Name, "reason", event.Reason)
+
+	result, err := r.backend.CreateEvent(ctx, ns, event)
+	if err != nil {
+		logger.Error(err, "Failed to create event", "namespace", ns, "name", event.Name)
+		return nil, err
+	}
+
+	logger.V(4).Info("Created event", "namespace", ns, "name", result.Name)
+	return result, nil
+}
+
+// Get retrieves an event by name.
+func (r *REST) Get(ctx context.Context, name string, options *metav1.GetOptions) (runtime.Object, error) {
+	logger := klog.FromContext(ctx)
+
+	ns, ok := apirequest.NamespaceFrom(ctx)
+	if !ok {
+		return nil, apierrors.NewBadRequest("namespace is required")
+	}
+
+	logger.V(4).Info("Getting event", "namespace", ns, "name", name)
+
+	result, err := r.backend.GetEvent(ctx, ns, name)
+	if err != nil {
+		logger.Error(err, "Failed to get event", "namespace", ns, "name", name)
+		return nil, err
+	}
+
+	logger.V(4).Info("Got event", "namespace", ns, "name", name, "reason", result.Reason)
+	return result, nil
+}
+
+// List lists events with optional filtering.
+func (r *REST) List(ctx context.Context, options *metainternalversion.ListOptions) (runtime.Object, error) {
+	logger := klog.FromContext(ctx)
+
+	ns, ok := apirequest.NamespaceFrom(ctx)
+	if !ok {
+		return nil, apierrors.NewBadRequest("namespace is required")
+	}
+
+	logger.V(4).Info("Listing events", "namespace", ns)
+
+	lo := &metav1.ListOptions{}
+	if options != nil {
+		if err := metainternalversion.Convert_internalversion_ListOptions_To_v1_ListOptions(options, lo, nil); err != nil {
+			return nil, err
+		}
+	}
+
+	result, err := r.backend.ListEvents(ctx, ns, lo)
+	if err != nil {
+		logger.Error(err, "Failed to list events", "namespace", ns)
+		return nil, err
+	}
+
+	logger.V(4).Info("Listed events", "namespace", ns, "count", len(result.Items))
+	return result, nil
+}
+
+// Update updates an existing event.
+// Validation is delegated to the upstream Activity API server.
+func (r *REST) Update(
+	ctx context.Context,
+	name string,
+	objInfo rest.UpdatedObjectInfo,
+	_ rest.ValidateObjectFunc,
+	_ rest.ValidateObjectUpdateFunc,
+	_ bool,
+	_ *metav1.UpdateOptions,
+) (runtime.Object, bool, error) {
+	logger := klog.FromContext(ctx)
+
+	ns, ok := apirequest.NamespaceFrom(ctx)
+	if !ok {
+		return nil, false, apierrors.NewBadRequest("namespace is required")
+	}
+
+	obj, err := objInfo.UpdatedObject(ctx, nil)
+	if err != nil {
+		return nil, false, err
+	}
+	event := obj.(*corev1.Event)
+
+	if err := injectScopeAnnotations(ctx, event); err != nil {
+		logger.Error(err, "Failed to inject scope annotations")
+		return nil, false, apierrors.NewBadRequest(fmt.Sprintf("failed to determine scope: %v", err))
+	}
+
+	logger.V(4).Info("Updating event", "namespace", ns, "name", name)
+
+	result, err := r.backend.UpdateEvent(ctx, ns, event)
+	if err != nil {
+		logger.Error(err, "Failed to update event", "namespace", ns, "name", name)
+		return nil, false, err
+	}
+
+	logger.V(4).Info("Updated event", "namespace", ns, "name", name)
+	return result, false, nil
+}
+
+// Delete deletes an event.
+// Validation is delegated to the upstream Activity API server.
+func (r *REST) Delete(
+	ctx context.Context,
+	name string,
+	_ rest.ValidateObjectFunc,
+	options *metav1.DeleteOptions,
+) (runtime.Object, bool, error) {
+	logger := klog.FromContext(ctx)
+
+	ns, ok := apirequest.NamespaceFrom(ctx)
+	if !ok {
+		return nil, false, apierrors.NewBadRequest("namespace is required")
+	}
+
+	logger.V(4).Info("Deleting event", "namespace", ns, "name", name)
+
+	if err := r.backend.DeleteEvent(ctx, ns, name, options); err != nil {
+		logger.Error(err, "Failed to delete event", "namespace", ns, "name", name)
+		return nil, false, err
+	}
+
+	logger.V(4).Info("Deleted event", "namespace", ns, "name", name)
+	return &metav1.Status{Status: metav1.StatusSuccess}, true, nil
+}
+
+// Watch establishes a watch connection for events
+func (r *REST) Watch(ctx context.Context, options *metainternalversion.ListOptions) (watch.Interface, error) {
+	logger := klog.FromContext(ctx)
+
+	ns, ok := apirequest.NamespaceFrom(ctx)
+	if !ok {
+		return nil, apierrors.NewBadRequest("namespace is required")
+	}
+
+	logger.V(4).Info("Watching events", "namespace", ns)
+
+	lo := &metav1.ListOptions{}
+	if options != nil {
+		if err := metainternalversion.Convert_internalversion_ListOptions_To_v1_ListOptions(options, lo, nil); err != nil {
+			return nil, err
+		}
+	}
+
+	return r.backend.WatchEvents(ctx, ns, lo)
+}
+
+// ConvertToTable provides a table representation for kubectl output
+func (r *REST) ConvertToTable(ctx context.Context, object runtime.Object, tableOptions runtime.Object) (*metav1.Table, error) {
+	table := &metav1.Table{
+		ColumnDefinitions: []metav1.TableColumnDefinition{
+			{Name: "Last Seen", Type: "string", Description: "Time when this Event was last observed"},
+			{Name: "Type", Type: "string", Description: "Type of this event (Normal, Warning)"},
+			{Name: "Reason", Type: "string", Description: "Short machine understandable string"},
+			{Name: "Object", Type: "string", Description: "The object this Event is about"},
+			{Name: "Message", Type: "string", Description: "Human-readable description"},
+		},
+	}
+
+	appendRow := func(event *corev1.Event) {
+		lastSeen := "<unknown>"
+		if !event.LastTimestamp.IsZero() {
+			lastSeen = event.LastTimestamp.Format("2006-01-02T15:04:05Z")
+		} else if !event.EventTime.IsZero() {
+			lastSeen = event.EventTime.Format("2006-01-02T15:04:05Z")
+		}
+
+		objectRef := fmt.Sprintf("%s/%s", event.InvolvedObject.Kind, event.InvolvedObject.Name)
+		if event.InvolvedObject.Namespace != "" && event.InvolvedObject.Namespace != event.Namespace {
+			objectRef = event.InvolvedObject.Namespace + "/" + objectRef
+		}
+
+		table.Rows = append(table.Rows, metav1.TableRow{
+			Cells: []interface{}{
+				lastSeen,
+				event.Type,
+				event.Reason,
+				objectRef,
+				event.Message,
+			},
+			Object: runtime.RawExtension{Object: event},
+		})
+	}
+
+	switch obj := object.(type) {
+	case *corev1.EventList:
+		for i := range obj.Items {
+			appendRow(&obj.Items[i])
+		}
+	case *corev1.Event:
+		appendRow(obj)
+	default:
+		return nil, nil
+	}
+
+	return table, nil
+}

--- a/internal/apiserver/events/rest_test.go
+++ b/internal/apiserver/events/rest_test.go
@@ -1,0 +1,484 @@
+package events
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
+	authuser "k8s.io/apiserver/pkg/authentication/user"
+	apirequest "k8s.io/apiserver/pkg/endpoints/request"
+	"k8s.io/apiserver/pkg/registry/rest"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// mockBackend implements the Backend interface for testing.
+type mockBackend struct {
+	createFunc func(ctx context.Context, namespace string, event *corev1.Event) (*corev1.Event, error)
+	getFunc    func(ctx context.Context, namespace, name string) (*corev1.Event, error)
+	listFunc   func(ctx context.Context, namespace string, opts *metav1.ListOptions) (*corev1.EventList, error)
+	updateFunc func(ctx context.Context, namespace string, event *corev1.Event) (*corev1.Event, error)
+	deleteFunc func(ctx context.Context, namespace, name string, opts *metav1.DeleteOptions) error
+	watchFunc  func(ctx context.Context, namespace string, opts *metav1.ListOptions) (watch.Interface, error)
+}
+
+func (m *mockBackend) CreateEvent(ctx context.Context, namespace string, event *corev1.Event) (*corev1.Event, error) {
+	if m.createFunc != nil {
+		return m.createFunc(ctx, namespace, event)
+	}
+	return event, nil
+}
+
+func (m *mockBackend) GetEvent(ctx context.Context, namespace, name string) (*corev1.Event, error) {
+	if m.getFunc != nil {
+		return m.getFunc(ctx, namespace, name)
+	}
+	return &corev1.Event{}, nil
+}
+
+func (m *mockBackend) ListEvents(ctx context.Context, namespace string, opts *metav1.ListOptions) (*corev1.EventList, error) {
+	if m.listFunc != nil {
+		return m.listFunc(ctx, namespace, opts)
+	}
+	return &corev1.EventList{}, nil
+}
+
+func (m *mockBackend) UpdateEvent(ctx context.Context, namespace string, event *corev1.Event) (*corev1.Event, error) {
+	if m.updateFunc != nil {
+		return m.updateFunc(ctx, namespace, event)
+	}
+	return event, nil
+}
+
+func (m *mockBackend) DeleteEvent(ctx context.Context, namespace, name string, opts *metav1.DeleteOptions) error {
+	if m.deleteFunc != nil {
+		return m.deleteFunc(ctx, namespace, name, opts)
+	}
+	return nil
+}
+
+func (m *mockBackend) WatchEvents(ctx context.Context, namespace string, opts *metav1.ListOptions) (watch.Interface, error) {
+	if m.watchFunc != nil {
+		return m.watchFunc(ctx, namespace, opts)
+	}
+	return nil, errors.New("watch not implemented in mock")
+}
+
+func TestREST_Create_InjectsScopeAnnotations(t *testing.T) {
+	tests := []struct {
+		name                 string
+		user                 authuser.Info
+		event                *corev1.Event
+		wantScopeType        string
+		wantScopeName        string
+		wantNoScopeInjection bool
+	}{
+		{
+			name: "project-scoped user creates event",
+			user: &authuser.DefaultInfo{
+				Name: "alice",
+				Extra: map[string][]string{
+					ExtraKeyParentType: {"Project"},
+					ExtraKeyParentName: {"project-123"},
+				},
+			},
+			event: &corev1.Event{
+				ObjectMeta: metav1.ObjectMeta{Name: "pod-started.abc"},
+			},
+			wantScopeType: "Project",
+			wantScopeName: "project-123",
+		},
+		{
+			name: "organization-scoped user creates event",
+			user: &authuser.DefaultInfo{
+				Name: "bob",
+				Extra: map[string][]string{
+					ExtraKeyParentType: {"Organization"},
+					ExtraKeyParentName: {"org-456"},
+				},
+			},
+			event: &corev1.Event{
+				ObjectMeta: metav1.ObjectMeta{Name: "deployment-scaled.def"},
+			},
+			wantScopeType: "Organization",
+			wantScopeName: "org-456",
+		},
+		{
+			name: "platform user creates event without scope",
+			user: &authuser.DefaultInfo{
+				Name: "system:serviceaccount:kube-system:default",
+			},
+			event: &corev1.Event{
+				ObjectMeta: metav1.ObjectMeta{Name: "node-ready.ghi"},
+			},
+			wantNoScopeInjection: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var capturedEvent *corev1.Event
+			backend := &mockBackend{
+				createFunc: func(ctx context.Context, namespace string, event *corev1.Event) (*corev1.Event, error) {
+					capturedEvent = event.DeepCopy()
+					return event, nil
+				},
+			}
+
+			r := NewREST(backend)
+
+			ctx := apirequest.WithUser(context.Background(), tt.user)
+			ctx = apirequest.WithNamespace(ctx, "default")
+
+			result, err := r.Create(ctx, tt.event, nil, &metav1.CreateOptions{})
+
+			require.NoError(t, err)
+			assert.NotNil(t, result)
+			require.NotNil(t, capturedEvent, "backend should have been called")
+
+			if tt.wantNoScopeInjection {
+				assert.Empty(t, capturedEvent.Annotations[ScopeTypeAnnotation])
+				assert.Empty(t, capturedEvent.Annotations[ScopeNameAnnotation])
+			} else {
+				assert.Equal(t, tt.wantScopeType, capturedEvent.Annotations[ScopeTypeAnnotation])
+				assert.Equal(t, tt.wantScopeName, capturedEvent.Annotations[ScopeNameAnnotation])
+			}
+		})
+	}
+}
+
+func TestREST_Create_RequiresNamespace(t *testing.T) {
+	backend := &mockBackend{}
+	r := NewREST(backend)
+
+	ctx := apirequest.WithUser(context.Background(), &authuser.DefaultInfo{Name: "alice"})
+	// No namespace in context
+
+	event := &corev1.Event{
+		ObjectMeta: metav1.ObjectMeta{Name: "test"},
+	}
+
+	_, err := r.Create(ctx, event, nil, &metav1.CreateOptions{})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "namespace is required")
+}
+
+func TestREST_Create_RequiresUser(t *testing.T) {
+	backend := &mockBackend{}
+	r := NewREST(backend)
+
+	ctx := apirequest.WithNamespace(context.Background(), "default")
+	// No user in context
+
+	event := &corev1.Event{
+		ObjectMeta: metav1.ObjectMeta{Name: "test"},
+	}
+
+	_, err := r.Create(ctx, event, nil, &metav1.CreateOptions{})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to determine scope")
+}
+
+func TestREST_Update_ReInjectsScopeAnnotations(t *testing.T) {
+	t.Run("prevents scope tampering", func(t *testing.T) {
+		var capturedEvent *corev1.Event
+		backend := &mockBackend{
+			updateFunc: func(ctx context.Context, namespace string, event *corev1.Event) (*corev1.Event, error) {
+				capturedEvent = event.DeepCopy()
+				return event, nil
+			},
+		}
+
+		r := NewREST(backend)
+
+		// User is scoped to Project A
+		ctx := apirequest.WithUser(context.Background(), &authuser.DefaultInfo{
+			Name: "alice",
+			Extra: map[string][]string{
+				ExtraKeyParentType: {"Project"},
+				ExtraKeyParentName: {"project-a"},
+			},
+		})
+		ctx = apirequest.WithNamespace(ctx, "default")
+
+		// Event initially claims to be scoped to Project B (malicious client)
+		event := &corev1.Event{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test-event",
+				Annotations: map[string]string{
+					ScopeTypeAnnotation: "Project",
+					ScopeNameAnnotation: "project-b",
+				},
+			},
+		}
+
+		objInfo := &mockUpdatedObjectInfo{obj: event}
+
+		result, created, err := r.Update(ctx, "test-event", objInfo, nil, nil, false, &metav1.UpdateOptions{})
+
+		require.NoError(t, err)
+		assert.False(t, created)
+		assert.NotNil(t, result)
+		require.NotNil(t, capturedEvent, "backend should have been called")
+
+		// Verify scope was re-injected from user context (Project A, not Project B)
+		assert.Equal(t, "Project", capturedEvent.Annotations[ScopeTypeAnnotation])
+		assert.Equal(t, "project-a", capturedEvent.Annotations[ScopeNameAnnotation],
+			"scope should be overwritten with user's actual scope")
+	})
+
+	t.Run("preserves other annotations", func(t *testing.T) {
+		var capturedEvent *corev1.Event
+		backend := &mockBackend{
+			updateFunc: func(ctx context.Context, namespace string, event *corev1.Event) (*corev1.Event, error) {
+				capturedEvent = event.DeepCopy()
+				return event, nil
+			},
+		}
+
+		r := NewREST(backend)
+
+		ctx := apirequest.WithUser(context.Background(), &authuser.DefaultInfo{
+			Name: "alice",
+			Extra: map[string][]string{
+				ExtraKeyParentType: {"Project"},
+				ExtraKeyParentName: {"project-123"},
+			},
+		})
+		ctx = apirequest.WithNamespace(ctx, "default")
+
+		event := &corev1.Event{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test-event",
+				Annotations: map[string]string{
+					"custom-annotation": "custom-value",
+					"another-key":       "another-value",
+				},
+			},
+		}
+
+		objInfo := &mockUpdatedObjectInfo{obj: event}
+
+		_, _, err := r.Update(ctx, "test-event", objInfo, nil, nil, false, &metav1.UpdateOptions{})
+
+		require.NoError(t, err)
+		require.NotNil(t, capturedEvent)
+
+		// Verify custom annotations preserved
+		assert.Equal(t, "custom-value", capturedEvent.Annotations["custom-annotation"])
+		assert.Equal(t, "another-value", capturedEvent.Annotations["another-key"])
+
+		// Verify scope injected
+		assert.Equal(t, "Project", capturedEvent.Annotations[ScopeTypeAnnotation])
+		assert.Equal(t, "project-123", capturedEvent.Annotations[ScopeNameAnnotation])
+	})
+}
+
+func TestREST_Get_Success(t *testing.T) {
+	expectedEvent := &corev1.Event{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-event",
+			Namespace: "default",
+		},
+		Reason: "Started",
+	}
+
+	backend := &mockBackend{
+		getFunc: func(ctx context.Context, namespace, name string) (*corev1.Event, error) {
+			assert.Equal(t, "default", namespace)
+			assert.Equal(t, "test-event", name)
+			return expectedEvent, nil
+		},
+	}
+
+	r := NewREST(backend)
+
+	ctx := apirequest.WithNamespace(context.Background(), "default")
+
+	result, err := r.Get(ctx, "test-event", &metav1.GetOptions{})
+
+	require.NoError(t, err)
+	assert.Equal(t, expectedEvent, result)
+}
+
+func TestREST_List_Success(t *testing.T) {
+	expectedList := &corev1.EventList{
+		Items: []corev1.Event{
+			{ObjectMeta: metav1.ObjectMeta{Name: "event-1"}},
+			{ObjectMeta: metav1.ObjectMeta{Name: "event-2"}},
+		},
+	}
+
+	backend := &mockBackend{
+		listFunc: func(ctx context.Context, namespace string, opts *metav1.ListOptions) (*corev1.EventList, error) {
+			assert.Equal(t, "default", namespace)
+			return expectedList, nil
+		},
+	}
+
+	r := NewREST(backend)
+
+	ctx := apirequest.WithNamespace(context.Background(), "default")
+
+	result, err := r.List(ctx, nil)
+
+	require.NoError(t, err)
+	assert.Equal(t, expectedList, result)
+}
+
+func TestREST_Delete_Success(t *testing.T) {
+	var capturedNamespace, capturedName string
+	backend := &mockBackend{
+		deleteFunc: func(ctx context.Context, namespace, name string, opts *metav1.DeleteOptions) error {
+			capturedNamespace = namespace
+			capturedName = name
+			return nil
+		},
+	}
+
+	r := NewREST(backend)
+
+	ctx := apirequest.WithNamespace(context.Background(), "default")
+
+	result, immediate, err := r.Delete(ctx, "test-event", nil, &metav1.DeleteOptions{})
+
+	require.NoError(t, err)
+	assert.True(t, immediate)
+	assert.NotNil(t, result)
+
+	status, ok := result.(*metav1.Status)
+	require.True(t, ok)
+	assert.Equal(t, metav1.StatusSuccess, status.Status)
+
+	assert.Equal(t, "default", capturedNamespace)
+	assert.Equal(t, "test-event", capturedName)
+}
+
+func TestREST_BackendError_Propagated(t *testing.T) {
+	expectedErr := errors.New("backend storage error")
+
+	backend := &mockBackend{
+		createFunc: func(ctx context.Context, namespace string, event *corev1.Event) (*corev1.Event, error) {
+			return nil, expectedErr
+		},
+	}
+
+	r := NewREST(backend)
+
+	ctx := apirequest.WithUser(context.Background(), &authuser.DefaultInfo{
+		Name: "alice",
+		Extra: map[string][]string{
+			ExtraKeyParentType: {"Project"},
+			ExtraKeyParentName: {"project-123"},
+		},
+	})
+	ctx = apirequest.WithNamespace(ctx, "default")
+
+	event := &corev1.Event{
+		ObjectMeta: metav1.ObjectMeta{Name: "test"},
+	}
+
+	_, err := r.Create(ctx, event, nil, &metav1.CreateOptions{})
+
+	require.Error(t, err)
+	assert.Equal(t, expectedErr, err)
+}
+
+func TestREST_ConvertToTable(t *testing.T) {
+	t.Run("converts event list", func(t *testing.T) {
+		r := NewREST(&mockBackend{})
+
+		eventList := &corev1.EventList{
+			Items: []corev1.Event{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "event-1",
+						Namespace: "default",
+					},
+					Type:   "Normal",
+					Reason: "Started",
+					InvolvedObject: corev1.ObjectReference{
+						Kind: "Pod",
+						Name: "my-pod",
+					},
+					Message:       "Container started",
+					LastTimestamp: metav1.Now(),
+				},
+			},
+		}
+
+		table, err := r.ConvertToTable(context.Background(), eventList, nil)
+
+		require.NoError(t, err)
+		require.NotNil(t, table)
+		assert.Len(t, table.ColumnDefinitions, 5)
+		assert.Len(t, table.Rows, 1)
+		assert.Equal(t, "Normal", table.Rows[0].Cells[1])
+		assert.Equal(t, "Started", table.Rows[0].Cells[2])
+	})
+
+	t.Run("converts single event", func(t *testing.T) {
+		r := NewREST(&mockBackend{})
+
+		event := &corev1.Event{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "event-1",
+				Namespace: "default",
+			},
+			Type:   "Warning",
+			Reason: "Failed",
+			InvolvedObject: corev1.ObjectReference{
+				Kind: "Deployment",
+				Name: "my-deployment",
+			},
+			Message:       "Failed to deploy",
+			LastTimestamp: metav1.Now(),
+		}
+
+		table, err := r.ConvertToTable(context.Background(), event, nil)
+
+		require.NoError(t, err)
+		require.NotNil(t, table)
+		assert.Len(t, table.Rows, 1)
+		assert.Equal(t, "Warning", table.Rows[0].Cells[1])
+		assert.Equal(t, "Failed", table.Rows[0].Cells[2])
+	})
+}
+
+func TestREST_InterfaceImplementation(t *testing.T) {
+	r := NewREST(&mockBackend{})
+
+	// Verify interface implementations
+	var _ rest.Scoper = r
+	var _ rest.Creater = r
+	var _ rest.Getter = r
+	var _ rest.Lister = r
+	var _ rest.Updater = r
+	var _ rest.GracefulDeleter = r
+	var _ rest.Watcher = r
+	var _ rest.Storage = r
+	var _ rest.SingularNameProvider = r
+
+	assert.Equal(t, "event", r.GetSingularName())
+	assert.True(t, r.NamespaceScoped())
+}
+
+// mockUpdatedObjectInfo implements rest.UpdatedObjectInfo for testing.
+type mockUpdatedObjectInfo struct {
+	obj *corev1.Event
+}
+
+func (m *mockUpdatedObjectInfo) Preconditions() *metav1.Preconditions {
+	return nil
+}
+
+func (m *mockUpdatedObjectInfo) UpdatedObject(ctx context.Context, oldObj runtime.Object) (runtime.Object, error) {
+	return m.obj, nil
+}

--- a/internal/apiserver/events/scheme.go
+++ b/internal/apiserver/events/scheme.go
@@ -1,0 +1,34 @@
+package events
+
+import (
+	eventsv1 "k8s.io/api/events/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+)
+
+var (
+	// Scheme is the runtime scheme for events.k8s.io API group.
+	Scheme = runtime.NewScheme()
+	// Codecs provides access to encoding and decoding for the scheme.
+	Codecs = serializer.NewCodecFactory(Scheme)
+	// ParameterCodec handles versioning of objects that are converted to query parameters.
+	ParameterCodec = runtime.NewParameterCodec(Scheme)
+)
+
+func init() {
+	utilruntime.Must(eventsv1.AddToScheme(Scheme))
+
+	metav1.AddToGroupVersion(Scheme, schema.GroupVersion{Version: "v1"})
+
+	unversioned := schema.GroupVersion{Group: "", Version: "v1"}
+	Scheme.AddUnversionedTypes(unversioned,
+		&metav1.Status{},
+		&metav1.APIVersions{},
+		&metav1.APIGroupList{},
+		&metav1.APIGroup{},
+		&metav1.APIResourceList{},
+	)
+}

--- a/internal/apiserver/events/scope.go
+++ b/internal/apiserver/events/scope.go
@@ -1,0 +1,55 @@
+package events
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	apirequest "k8s.io/apiserver/pkg/endpoints/request"
+)
+
+const (
+	// ScopeTypeAnnotation indicates the type of scope (Project, Organization, Platform)
+	ScopeTypeAnnotation = "platform.miloapis.com/scope.type"
+	// ScopeNameAnnotation indicates the name of the scoped resource
+	ScopeNameAnnotation = "platform.miloapis.com/scope.name"
+
+	// ExtraKeyParentType is the user.Extra key containing the parent resource type
+	ExtraKeyParentType = "iam.miloapis.com/parent-type"
+	// ExtraKeyParentName is the user.Extra key containing the parent resource name
+	ExtraKeyParentName = "iam.miloapis.com/parent-name"
+)
+
+// injectScopeAnnotations adds scope annotations to a core/v1 Event based on user context
+func injectScopeAnnotations(ctx context.Context, event *corev1.Event) error {
+	userInfo, ok := apirequest.UserFrom(ctx)
+	if !ok {
+		return fmt.Errorf("no user in context")
+	}
+
+	extras := userInfo.GetExtra()
+
+	parentType := getFirstExtra(extras, ExtraKeyParentType)
+	parentName := getFirstExtra(extras, ExtraKeyParentName)
+
+	// Events without scope context are normal (e.g., system components, platform-level operations)
+	if parentType == "" || parentName == "" {
+		return nil
+	}
+
+	if event.Annotations == nil {
+		event.Annotations = make(map[string]string)
+	}
+
+	event.Annotations[ScopeTypeAnnotation] = parentType
+	event.Annotations[ScopeNameAnnotation] = parentName
+
+	return nil
+}
+
+func getFirstExtra(extras map[string][]string, key string) string {
+	if values, ok := extras[key]; ok && len(values) > 0 {
+		return values[0]
+	}
+	return ""
+}

--- a/internal/apiserver/events/storageprovider.go
+++ b/internal/apiserver/events/storageprovider.go
@@ -1,0 +1,53 @@
+package events
+
+import (
+	"k8s.io/apiserver/pkg/registry/generic"
+	"k8s.io/apiserver/pkg/registry/rest"
+	genericapiserver "k8s.io/apiserver/pkg/server"
+	serverstorage "k8s.io/apiserver/pkg/server/storage"
+	controlplaneapiserver "k8s.io/kubernetes/pkg/controlplane/apiserver"
+)
+
+// CoreProviderWrapper wraps the core storage provider to inject events proxy storage
+type CoreProviderWrapper struct {
+	Inner         controlplaneapiserver.RESTStorageProvider
+	EventsBackend Backend
+}
+
+// NewRESTStorage delegates to the inner provider and injects events proxy storage
+func (w *CoreProviderWrapper) NewRESTStorage(
+	apiResourceConfigSource serverstorage.APIResourceConfigSource,
+	restOptionsGetter generic.RESTOptionsGetter,
+) (genericapiserver.APIGroupInfo, error) {
+	apiGroupInfo, err := w.Inner.NewRESTStorage(apiResourceConfigSource, restOptionsGetter)
+	if err != nil {
+		return apiGroupInfo, err
+	}
+
+	if w.EventsBackend != nil {
+		v1Storage := apiGroupInfo.VersionedResourcesStorageMap["v1"]
+		if v1Storage == nil {
+			v1Storage = make(map[string]rest.Storage)
+			apiGroupInfo.VersionedResourcesStorageMap["v1"] = v1Storage
+		}
+		v1Storage["events"] = NewREST(w.EventsBackend)
+	}
+
+	return apiGroupInfo, nil
+}
+
+// GroupName delegates to the inner provider
+func (w *CoreProviderWrapper) GroupName() string {
+	return w.Inner.GroupName()
+}
+
+// WrapCoreProvider wraps a core storage provider to inject events proxy storage
+func WrapCoreProvider(inner controlplaneapiserver.RESTStorageProvider, backend Backend) controlplaneapiserver.RESTStorageProvider {
+	if backend == nil {
+		return inner
+	}
+	return &CoreProviderWrapper{
+		Inner:         inner,
+		EventsBackend: backend,
+	}
+}

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -1,0 +1,71 @@
+// Package features defines feature gates for the Milo API server.
+//
+// Feature gates follow the Kubernetes pattern for managing feature lifecycle:
+//   - Alpha: Disabled by default, may be removed without notice
+//   - Beta: Enabled by default, API may change
+//   - GA: Enabled by default, stable
+//
+// Usage:
+//
+//	import (
+//	    utilfeature "k8s.io/apiserver/pkg/util/feature"
+//	    "go.miloapis.com/milo/pkg/features"
+//	)
+//
+//	if utilfeature.DefaultFeatureGate.Enabled(features.EventsProxy) {
+//	    // feature is enabled
+//	}
+package features
+
+import (
+	"k8s.io/apimachinery/pkg/util/runtime"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	"k8s.io/component-base/featuregate"
+)
+
+const (
+	// EventsProxy enables forwarding Kubernetes Events (core/v1.Event) to the
+	// Activity service instead of storing them in etcd. This provides multi-tenant
+	// event storage with automatic scope injection.
+	//
+	// owner: @datum-cloud/platform
+	// alpha: v0.1.0
+	EventsProxy featuregate.Feature = "EventsProxy"
+
+	// Sessions enables the identity.miloapis.com/v1alpha1 Session virtual API
+	// that proxies to an external identity provider for session management.
+	//
+	// owner: @datum-cloud/platform
+	// alpha: v0.1.0
+	// ga: v0.2.0
+	Sessions featuregate.Feature = "Sessions"
+
+	// UserIdentities enables the identity.miloapis.com/v1alpha1 UserIdentity
+	// virtual API that proxies to an external identity provider.
+	//
+	// owner: @datum-cloud/platform
+	// alpha: v0.1.0
+	// ga: v0.2.0
+	UserIdentities featuregate.Feature = "UserIdentities"
+)
+
+func init() {
+	runtime.Must(utilfeature.DefaultMutableFeatureGate.Add(defaultFeatureGates))
+}
+
+// defaultFeatureGates defines the default state of Milo feature gates.
+// Features are listed in alphabetical order.
+var defaultFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
+	EventsProxy: {
+		Default:    false,
+		PreRelease: featuregate.Alpha,
+	},
+	Sessions: {
+		Default:    true,
+		PreRelease: featuregate.GA,
+	},
+	UserIdentities: {
+		Default:    true,
+		PreRelease: featuregate.GA,
+	},
+}


### PR DESCRIPTION
## Summary

- Add Events proxy to forward `core/v1` and `events.k8s.io/v1` Events to Activity API server for ClickHouse-backed storage
- Feature-gated behind `EventsProxy=true` (alpha)
- Inject multi-tenant scope annotations based on user context
- Support full CRUD + Watch operations with mTLS authentication
- Share single DynamicProvider between both API versions
- Add Kustomize component for deployment configuration

## Changes

### Events Proxy Implementation
- `internal/apiserver/events/` - REST handlers, storage providers, dynamic provider for proxying events
- `pkg/features/features.go` - Feature gate definitions including `EventsProxy` (alpha)
- `cmd/milo/apiserver/` - Server integration for events proxy
- `config/components/events-proxy/` - Kustomize component for enabling the proxy
- `docs/enhancements/events/activity-events-proxy.md` - Design documentation

## Test plan

- [ ] Unit tests pass (`task test:unit`)
- [ ] E2E tests pass (`task test:end-to-end`)
- [ ] Manual verification with `EventsProxy=true` feature gate enabled

🤖 Generated with [Claude Code](https://claude.ai/claude-code)