### PR TITLE
fix: use PascalCase for audit scope type annotations

### DIFF
--- a/pkg/server/filters/audit_scope.go
+++ b/pkg/server/filters/audit_scope.go
@@ -17,11 +17,13 @@ const (
 	ScopeTypeKey = PlatformNamespace + "scope.type"
 	ScopeNameKey = PlatformNamespace + "scope.name"
 
-	// Scope type values
+	// Scope type values - use PascalCase to match Kubernetes Kind naming convention
+	// and align with how Milo sets parent-type in user.extra.
+	// "global" remains lowercase as it's an internal default, not from user.extra.
 	ScopeTypeGlobal       = "global"
-	ScopeTypeOrganization = "organization"
-	ScopeTypeProject      = "project"
-	ScopeTypeUser         = "user"
+	ScopeTypeOrganization = "Organization"
+	ScopeTypeProject      = "Project"
+	ScopeTypeUser         = "User"
 
 	// User extra keys (from iam.miloapis.com/v1alpha1/doc.go)
 	ParentTypeExtraKey = "iam.miloapis.com/parent-type"


### PR DESCRIPTION
## Summary

Audit log scope annotations were being lowercased before being written, but the activity service queries for PascalCase values. This caused org/project-scoped activity queries to return no results.

## What changed

The `platform.miloapis.com/scope.type` annotation now uses the same casing as the `parent-type` in user.extra:

- `Organization` (was `organization`)
- `Project` (was `project`)  
- `User` (was `user`)
- `global` stays lowercase since it's an internal default

## Background

Milo sets `iam.miloapis.com/parent-type` as `"Project"`, `"Organization"`, etc. (PascalCase). The audit filter was converting these to lowercase when setting the scope annotation, but the activity service expects PascalCase for ClickHouse queries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)