### PR TITLE
chore: add display names and descriptions to system roles

### DIFF
--- a/config/roles/apiextensions-reader.yaml
+++ b/config/roles/apiextensions-reader.yaml
@@ -2,6 +2,9 @@ apiVersion: iam.miloapis.com/v1alpha1
 kind: Role
 metadata:
   name: apiextensions-reader
+  annotations:
+    kubernetes.io/display-name: API Extensions Viewer
+    kubernetes.io/description: View access to custom resource definitions
 spec:
   launchStage: Beta
   includedPermissions:

--- a/config/roles/core-admin.yaml
+++ b/config/roles/core-admin.yaml
@@ -2,6 +2,9 @@ apiVersion: iam.miloapis.com/v1alpha1
 kind: Role
 metadata:
   name: core-admin
+  annotations:
+    kubernetes.io/display-name: Core Admin
+    kubernetes.io/description: Full access to core platform resources including secrets, configmaps, and namespaces
 spec:
   launchStage: Beta
   inheritedRoles:

--- a/config/roles/core-editor.yaml
+++ b/config/roles/core-editor.yaml
@@ -2,6 +2,9 @@ apiVersion: iam.miloapis.com/v1alpha1
 kind: Role
 metadata:
   name: core-editor
+  annotations:
+    kubernetes.io/display-name: Core Editor
+    kubernetes.io/description: Edit access to core platform resources including secrets, configmaps, and namespaces
 spec:
   launchStage: Beta
   inheritedRoles:

--- a/config/roles/core-reader.yaml
+++ b/config/roles/core-reader.yaml
@@ -2,6 +2,9 @@ apiVersion: iam.miloapis.com/v1alpha1
 kind: Role
 metadata:
   name: core-reader
+  annotations:
+    kubernetes.io/display-name: Core Reader
+    kubernetes.io/description: View access to core platform resources including secrets, configmaps, and namespaces
 spec:
   launchStage: Beta
   includedPermissions:

--- a/config/roles/resourcemanager-admin.yaml
+++ b/config/roles/resourcemanager-admin.yaml
@@ -2,6 +2,9 @@ apiVersion: iam.miloapis.com/v1alpha1
 kind: Role
 metadata:
   name: resourcemanager-admin
+  annotations:
+    kubernetes.io/display-name: Resource Manager Admin
+    kubernetes.io/description: Full access to organizations and projects
 spec:
   launchStage: Beta
   inheritedRoles:

--- a/config/roles/resourcemanager-editor.yaml
+++ b/config/roles/resourcemanager-editor.yaml
@@ -2,6 +2,9 @@ apiVersion: iam.miloapis.com/v1alpha1
 kind: Role
 metadata:
   name: resourcemanager-editor
+  annotations:
+    kubernetes.io/display-name: Resource Manager Editor
+    kubernetes.io/description: Edit access to organizations and projects
 spec:
   launchStage: Beta
   inheritedRoles:

--- a/config/roles/resourcemanager-reader.yaml
+++ b/config/roles/resourcemanager-reader.yaml
@@ -2,6 +2,9 @@ apiVersion: iam.miloapis.com/v1alpha1
 kind: Role
 metadata:
   name: resourcemanager-reader
+  annotations:
+    kubernetes.io/display-name: Resource Manager Viewer
+    kubernetes.io/description: View access to organizations and projects
 spec:
   launchStage: Beta
   includedPermissions:

--- a/config/services/quota/iam/roles/organization-quota-manager.yaml
+++ b/config/services/quota/iam/roles/organization-quota-manager.yaml
@@ -3,6 +3,9 @@ kind: Role
 metadata:
   name: quota.miloapis.com-organization-quota-manager
   namespace: milo-system
+  annotations:
+    kubernetes.io/display-name: Organization Quota Manager
+    kubernetes.io/description: View quota usage, grants, and claims across the organization
   labels:
     quota.miloapis.com/role-type: organization-manager
     quota.miloapis.com/service: quota

--- a/config/services/quota/iam/roles/quota-viewer.yaml
+++ b/config/services/quota/iam/roles/quota-viewer.yaml
@@ -3,6 +3,9 @@ kind: Role
 metadata:
   name: quota.miloapis.com-viewer
   namespace: milo-system
+  annotations:
+    kubernetes.io/display-name: Quota Viewer
+    kubernetes.io/description: View access to quota resources including resource registrations, grants, and claims
   labels:
     quota.miloapis.com/role-type: viewer
     quota.miloapis.com/service: quota


### PR DESCRIPTION
## Summary

- Adds `kubernetes.io/display-name` and `kubernetes.io/description` annotations to 9 system roles that were showing raw internal names in the cloud portal UI
- Affected roles: `core-admin`, `core-editor`, `core-reader`, `resourcemanager-admin`, `resourcemanager-editor`, `resourcemanager-reader`, `apiextensions-reader`, `quota.miloapis.com-viewer`, `quota.miloapis.com-organization-quota-manager`

## Test plan

- [ ] Verify roles display friendly names in the cloud portal Add Role screen
- [ ] Confirm annotations are applied correctly after deploy