### PR TITLE
fix: convert internal types to external before unstructured conversion in quota admission

### DIFF
--- a/internal/quota/admission/plugin.go
+++ b/internal/quota/admission/plugin.go
@@ -2,7 +2,6 @@ package admission
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"strings"
 	"sync"
@@ -27,6 +26,8 @@ import (
 	"k8s.io/component-base/metrics"
 	legacyregistry "k8s.io/component-base/metrics/legacyregistry"
 	"k8s.io/klog/v2"
+
+	"k8s.io/kubernetes/pkg/api/legacyscheme"
 
 	"go.miloapis.com/milo/internal/quota/engine"
 	"go.miloapis.com/milo/internal/quota/validation"
@@ -458,18 +459,21 @@ func (p *ResourceQuotaEnforcementPlugin) processResourceWithPolicy(ctx context.C
 		// Already unstructured (CRDs from apiextensions-apiserver)
 		unstructuredObj = v
 	default:
-		// Structured type (native k8s types like Secret, ConfigMap, etc.)
-		// Convert to unstructured via JSON round-trip to ensure field names
-		// match JSON tags (e.g. "metadata") rather than Go field names
-		// (e.g. "objectMeta"). runtime.DefaultUnstructuredConverter.ToUnstructured
-		// uses Go field names, which breaks CEL expressions like trigger.metadata.name.
-		jsonBytes, convErr := json.Marshal(obj)
-		if convErr != nil {
-			return fmt.Errorf("failed to marshal %T to JSON: %w", obj, convErr)
+		// Structured type (native k8s types) — the admission handler decodes
+		// these as internal Go types (e.g. pkg/apis/discovery.EndpointSlice),
+		// not the external versioned types (e.g. api/discovery/v1.EndpointSlice).
+		// Internal types inline ObjectMeta without a "metadata" wrapper, so
+		// both json.Marshal and ToUnstructured produce maps without a "metadata"
+		// key. Convert to the external versioned type first using the scheme,
+		// then use ToUnstructured to get proper Kubernetes JSON structure.
+		toConvert := obj
+		targetGV := schema.GroupVersion{Group: gvk.Group, Version: gvk.Version}
+		if versioned, convErr := legacyscheme.Scheme.ConvertToVersion(obj, targetGV); convErr == nil {
+			toConvert = versioned
 		}
-		var unstructuredMap map[string]interface{}
-		if convErr := json.Unmarshal(jsonBytes, &unstructuredMap); convErr != nil {
-			return fmt.Errorf("failed to unmarshal %T JSON to map: %w", obj, convErr)
+		unstructuredMap, convErr := runtime.DefaultUnstructuredConverter.ToUnstructured(toConvert)
+		if convErr != nil {
+			return fmt.Errorf("failed to convert %T to unstructured: %w", toConvert, convErr)
 		}
 		unstructuredObj = &unstructured.Unstructured{Object: unstructuredMap}
 	}

--- a/test/quota/structured-type-enforcement/01-resource-registration.yaml
+++ b/test/quota/structured-type-enforcement/01-resource-registration.yaml
@@ -1,0 +1,19 @@
+apiVersion: quota.miloapis.com/v1alpha1
+kind: ResourceRegistration
+metadata:
+  name: st-test-endpointslices-per-project
+  labels:
+    test.miloapis.com/quota: "structured-type"
+spec:
+  consumerType:
+    apiGroup: resourcemanager.miloapis.com
+    kind: Project
+  type: "Entity"
+  resourceType: "test.structuredtype.miloapis.com/endpointslices"
+  description: "Test quota for EndpointSlices per project (structured type enforcement)"
+  baseUnit: "endpointslice"
+  displayUnit: "endpointslices"
+  unitConversionFactor: 1
+  claimingResources:
+    - apiGroup: "discovery.k8s.io"
+      kind: EndpointSlice

--- a/test/quota/structured-type-enforcement/02-grant-creation-policy.yaml
+++ b/test/quota/structured-type-enforcement/02-grant-creation-policy.yaml
@@ -1,0 +1,35 @@
+apiVersion: quota.miloapis.com/v1alpha1
+kind: GrantCreationPolicy
+metadata:
+  name: st-test-project-endpointslice-grant-policy
+  labels:
+    test.miloapis.com/quota: "structured-type"
+spec:
+  disabled: false
+  trigger:
+    resource:
+      apiVersion: "resourcemanager.miloapis.com/v1alpha1"
+      kind: "Project"
+    constraints:
+      - expression: 'has(trigger.metadata.labels) && "test.miloapis.com/quota" in trigger.metadata.labels && trigger.metadata.labels["test.miloapis.com/quota"] == "structured-type"'
+  target:
+    parentContext:
+      apiGroup: "resourcemanager.miloapis.com"
+      kind: "Project"
+      nameExpression: "trigger.metadata.name"
+    resourceGrantTemplate:
+      metadata:
+        name: "auto-grant-{{trigger.metadata.name}}"
+        namespace: "milo-system"
+        labels:
+          quota.miloapis.com/auto-created: "true"
+          test.miloapis.com/quota: "structured-type"
+      spec:
+        consumerRef:
+          apiGroup: "resourcemanager.miloapis.com"
+          kind: "Project"
+          name: "{{trigger.metadata.name}}"
+        allowances:
+          - resourceType: "test.structuredtype.miloapis.com/endpointslices"
+            buckets:
+              - amount: 5

--- a/test/quota/structured-type-enforcement/03-test-organization.yaml
+++ b/test/quota/structured-type-enforcement/03-test-organization.yaml
@@ -1,0 +1,8 @@
+apiVersion: resourcemanager.miloapis.com/v1alpha1
+kind: Organization
+metadata:
+  name: st-test-org
+  labels:
+    test.miloapis.com/quota: "structured-type"
+spec:
+  type: Standard

--- a/test/quota/structured-type-enforcement/04-claim-creation-policy.yaml
+++ b/test/quota/structured-type-enforcement/04-claim-creation-policy.yaml
@@ -1,0 +1,28 @@
+apiVersion: quota.miloapis.com/v1alpha1
+kind: ClaimCreationPolicy
+metadata:
+  name: st-test-endpointslice-claim-policy
+  labels:
+    test.miloapis.com/quota: "structured-type"
+spec:
+  disabled: false
+  trigger:
+    resource:
+      apiVersion: "discovery.k8s.io/v1"
+      kind: "EndpointSlice"
+    # No constraints - trigger for all EndpointSlices (matches Secret test pattern)
+  target:
+    resourceClaimTemplate:
+      metadata:
+        # Deterministic claim name using trigger.metadata.name — this is the
+        # pattern that fails when structured types produce "objectMeta" instead
+        # of "metadata" during unstructured conversion.
+        name: "endpointslice-{{ trigger.metadata.name }}"
+        namespace: "{{requestInfo.namespace}}"
+        labels:
+          quota.miloapis.com/test: "true"
+          test.miloapis.com/quota: "structured-type"
+      spec:
+        requests:
+          - resourceType: "test.structuredtype.miloapis.com/endpointslices"
+            amount: 1

--- a/test/quota/structured-type-enforcement/chainsaw-test.yaml
+++ b/test/quota/structured-type-enforcement/chainsaw-test.yaml
@@ -1,0 +1,265 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: structured-type-enforcement
+spec:
+  description: |
+    Tests quota enforcement for EndpointSlice (a structured/native k8s type)
+    in a project control plane.
+
+    EndpointSlice is a native Kubernetes type that arrives at the admission
+    plugin as a Go struct (*discoveryv1.EndpointSlice), not as
+    *unstructured.Unstructured. The admission plugin must convert it to
+    unstructured with correct JSON field names (metadata, not objectMeta)
+    for CEL template expressions like trigger.metadata.name to work.
+
+    This test uses a deterministic claim name template
+    "endpointslice-{{ trigger.metadata.name }}" to verify the CEL
+    evaluation works correctly for structured types.
+
+  clusters:
+    main:
+      kubeconfig: kubeconfig-main
+    org:
+      kubeconfig: kubeconfig-org
+    project1:
+      kubeconfig: kubeconfig-project-1
+
+  steps:
+    - name: setup-resource-registration
+      description: Register EndpointSlice resource type for quota tracking
+      try:
+        - apply:
+            file: 01-resource-registration.yaml
+        - wait:
+            apiVersion: quota.miloapis.com/v1alpha1
+            kind: ResourceRegistration
+            name: st-test-endpointslices-per-project
+            timeout: 30s
+            for:
+              condition:
+                name: Active
+                value: 'True'
+
+    - name: setup-grant-creation-policy
+      description: Create GrantCreationPolicy to grant EndpointSlice quota to projects
+      try:
+        - apply:
+            file: 02-grant-creation-policy.yaml
+        - wait:
+            apiVersion: quota.miloapis.com/v1alpha1
+            kind: GrantCreationPolicy
+            name: st-test-project-endpointslice-grant-policy
+            timeout: 30s
+            for:
+              condition:
+                name: Ready
+                value: 'true'
+
+    - name: setup-test-organization
+      description: Create test organization
+      try:
+        - apply:
+            file: 03-test-organization.yaml
+        - wait:
+            apiVersion: v1
+            kind: Namespace
+            name: organization-st-test-org
+            timeout: 30s
+            for:
+              jsonPath:
+                path: '{.status.phase}'
+                value: Active
+
+    - name: create-project-in-org
+      description: Create project in org control plane
+      cluster: org
+      try:
+        - apply:
+            file: test-data/project-1.yaml
+        - wait:
+            apiVersion: resourcemanager.miloapis.com/v1alpha1
+            kind: Project
+            name: st-test-project-1
+            timeout: 30s
+            for:
+              condition:
+                name: Ready
+                value: 'true'
+
+    - name: verify-grant-for-project
+      description: Confirm grant is created in project control plane
+      cluster: project1
+      try:
+        - wait:
+            apiVersion: quota.miloapis.com/v1alpha1
+            kind: ResourceGrant
+            name: auto-grant-st-test-project-1
+            namespace: milo-system
+            timeout: 30s
+            for:
+              condition:
+                name: Active
+                value: 'True'
+
+    - name: verify-bucket-pre-created
+      description: Verify AllowanceBucket shows 5 available EndpointSlices
+      cluster: project1
+      try:
+        - assert:
+            resource:
+              apiVersion: quota.miloapis.com/v1alpha1
+              kind: AllowanceBucket
+              metadata:
+                namespace: milo-system
+                labels:
+                  quota.miloapis.com/consumer-kind: Project
+                  quota.miloapis.com/consumer-name: st-test-project-1
+              status:
+                limit: 5
+                allocated: 0
+                available: 5
+
+    - name: setup-claim-creation-policy
+      description: Register ClaimCreationPolicy for EndpointSlices with deterministic name
+      cluster: main
+      try:
+        - apply:
+            file: 04-claim-creation-policy.yaml
+        - wait:
+            apiVersion: quota.miloapis.com/v1alpha1
+            kind: ClaimCreationPolicy
+            name: st-test-endpointslice-claim-policy
+            timeout: 30s
+            for:
+              condition:
+                name: Ready
+                value: 'True'
+
+    - name: create-endpointslice-1
+      description: |
+        Create EndpointSlice in project control plane.
+        This is the critical test: EndpointSlice is a native k8s type that
+        arrives as a structured Go type in admission. The CEL template
+        trigger.metadata.name must resolve correctly.
+      cluster: project1
+      try:
+        - sleep:
+            duration: 5s
+        - apply:
+            file: test-data/endpointslice-1.yaml
+      catch:
+        - script:
+            timeout: 10s
+            content: |
+              echo "=== PROJECT CONTROL PLANE ==="
+              echo "--- ResourceClaims ---"
+              kubectl get resourceclaims.quota.miloapis.com -A -o wide 2>&1 || true
+              echo "--- AllowanceBuckets ---"
+              kubectl get allowancebuckets.quota.miloapis.com -A -o wide 2>&1 || true
+              echo "--- ResourceGrants ---"
+              kubectl get resourcegrants.quota.miloapis.com -A -o wide 2>&1 || true
+              echo "--- EndpointSlices ---"
+              kubectl get endpointslices.discovery.k8s.io -A 2>&1 || true
+        - script:
+            timeout: 10s
+            cluster: main
+            content: |
+              echo "=== ROOT CONTROL PLANE ==="
+              echo "--- ResourceClaims (all namespaces) ---"
+              kubectl get resourceclaims.quota.miloapis.com -A -o wide 2>&1 || true
+              echo "--- ClaimCreationPolicies ---"
+              kubectl get claimcreationpolicies.quota.miloapis.com -o wide 2>&1 || true
+
+    - name: verify-claim-for-endpointslice-1
+      description: Confirm ResourceClaim with deterministic name is created and granted
+      cluster: project1
+      try:
+        - wait:
+            apiVersion: quota.miloapis.com/v1alpha1
+            kind: ResourceClaim
+            name: endpointslice-st-test-endpointslice-1
+            namespace: default
+            timeout: 30s
+            for:
+              condition:
+                name: Granted
+                value: 'True'
+
+    - name: verify-bucket-usage-1-of-5
+      description: Verify bucket shows 1 EndpointSlice allocated
+      cluster: project1
+      try:
+        - assert:
+            resource:
+              apiVersion: quota.miloapis.com/v1alpha1
+              kind: AllowanceBucket
+              metadata:
+                namespace: milo-system
+              status:
+                limit: 5
+                allocated: 1
+                available: 4
+
+    - name: create-endpointslice-2
+      description: Create second EndpointSlice
+      cluster: project1
+      try:
+        - apply:
+            file: test-data/endpointslice-2.yaml
+
+    - name: verify-claim-for-endpointslice-2
+      description: Confirm second claim with deterministic name is created and granted
+      cluster: project1
+      try:
+        - wait:
+            apiVersion: quota.miloapis.com/v1alpha1
+            kind: ResourceClaim
+            name: endpointslice-st-test-endpointslice-2
+            namespace: default
+            timeout: 30s
+            for:
+              condition:
+                name: Granted
+                value: 'True'
+
+    - name: verify-bucket-usage-2-of-5
+      description: Verify bucket shows 2 EndpointSlices allocated
+      cluster: project1
+      try:
+        - assert:
+            resource:
+              apiVersion: quota.miloapis.com/v1alpha1
+              kind: AllowanceBucket
+              metadata:
+                namespace: milo-system
+              status:
+                limit: 5
+                allocated: 2
+                available: 3
+
+    - name: delete-endpointslice-1
+      description: Delete first EndpointSlice to free quota
+      cluster: project1
+      try:
+        - delete:
+            ref:
+              apiVersion: discovery.k8s.io/v1
+              kind: EndpointSlice
+              name: st-test-endpointslice-1
+              namespace: default
+
+    - name: verify-bucket-after-deletion
+      description: Verify bucket shows quota freed after deletion
+      cluster: project1
+      try:
+        - assert:
+            resource:
+              apiVersion: quota.miloapis.com/v1alpha1
+              kind: AllowanceBucket
+              metadata:
+                namespace: milo-system
+              status:
+                limit: 5
+                allocated: 1
+                available: 4

--- a/test/quota/structured-type-enforcement/kubeconfig-main
+++ b/test/quota/structured-type-enforcement/kubeconfig-main
@@ -1,0 +1,18 @@
+apiVersion: v1
+clusters:
+- cluster:
+    insecure-skip-tls-verify: true
+    server: https://localhost:30443
+  name: milo-test-infra
+contexts:
+- context:
+    cluster: milo-test-infra
+    user: admin
+  name: milo-test-infra
+current-context: milo-test-infra
+kind: Config
+preferences: {}
+users:
+- name: admin
+  user:
+    token: test-admin-token

--- a/test/quota/structured-type-enforcement/kubeconfig-org
+++ b/test/quota/structured-type-enforcement/kubeconfig-org
@@ -1,0 +1,18 @@
+apiVersion: v1
+clusters:
+- cluster:
+    insecure-skip-tls-verify: true
+    server: https://localhost:30443/apis/resourcemanager.miloapis.com/v1alpha1/organizations/st-test-org/control-plane
+  name: org-st-test-org
+contexts:
+- context:
+    cluster: org-st-test-org
+    user: user-1001
+  name: org-st-test-org
+current-context: org-st-test-org
+kind: Config
+preferences: {}
+users:
+- name: user-1001
+  user:
+    token: test-admin-token

--- a/test/quota/structured-type-enforcement/kubeconfig-project-1
+++ b/test/quota/structured-type-enforcement/kubeconfig-project-1
@@ -1,0 +1,18 @@
+apiVersion: v1
+clusters:
+- cluster:
+    insecure-skip-tls-verify: true
+    server: https://localhost:30443/apis/resourcemanager.miloapis.com/v1alpha1/projects/st-test-project-1/control-plane
+  name: project-st-test-project-1
+contexts:
+- context:
+    cluster: project-st-test-project-1
+    user: user-1001
+  name: project-st-test-project-1
+current-context: project-st-test-project-1
+kind: Config
+preferences: {}
+users:
+- name: user-1001
+  user:
+    token: test-admin-token

--- a/test/quota/structured-type-enforcement/test-data/endpointslice-1.yaml
+++ b/test/quota/structured-type-enforcement/test-data/endpointslice-1.yaml
@@ -1,0 +1,16 @@
+apiVersion: discovery.k8s.io/v1
+kind: EndpointSlice
+metadata:
+  name: st-test-endpointslice-1
+  namespace: default
+  labels:
+    test.miloapis.com/quota: "structured-type"
+addressType: FQDN
+endpoints:
+  - addresses:
+      - "google.com"
+    conditions:
+      ready: true
+ports:
+  - port: 443
+    protocol: TCP

--- a/test/quota/structured-type-enforcement/test-data/endpointslice-2.yaml
+++ b/test/quota/structured-type-enforcement/test-data/endpointslice-2.yaml
@@ -1,0 +1,16 @@
+apiVersion: discovery.k8s.io/v1
+kind: EndpointSlice
+metadata:
+  name: st-test-endpointslice-2
+  namespace: default
+  labels:
+    test.miloapis.com/quota: "structured-type"
+addressType: FQDN
+endpoints:
+  - addresses:
+      - "example.com"
+    conditions:
+      ready: true
+ports:
+  - port: 443
+    protocol: TCP

--- a/test/quota/structured-type-enforcement/test-data/project-1.yaml
+++ b/test/quota/structured-type-enforcement/test-data/project-1.yaml
@@ -1,0 +1,10 @@
+apiVersion: resourcemanager.miloapis.com/v1alpha1
+kind: Project
+metadata:
+  name: st-test-project-1
+  labels:
+    test.miloapis.com/quota: "structured-type"
+spec:
+  ownerRef:
+    kind: Organization
+    name: st-test-org


### PR DESCRIPTION
## Summary

The API server's admission handler decodes native Kubernetes types as **internal** Go types (e.g. `pkg/apis/discovery.EndpointSlice`), not external versioned types (e.g. `api/discovery/v1.EndpointSlice`). Internal types inline `ObjectMeta` without a `metadata` JSON wrapper, so both `json.Marshal` and `runtime.DefaultUnstructuredConverter.ToUnstructured` produce maps without a `metadata` key. This breaks CEL template expressions like `trigger.metadata.name` used in ClaimCreationPolicies.

### Changes

- **Admission plugin**: Use `legacyscheme.Scheme.ConvertToVersion` to convert internal types to their external versioned form before calling `ToUnstructured`. Falls back to direct `ToUnstructured` if the type isn't registered in the scheme (e.g. unit tests with external types).
- **E2E test**: Add chainsaw test for EndpointSlice quota enforcement in a project control plane with deterministic claim names using `trigger.metadata.name` — the exact pattern that fails without this fix.

### Root cause investigation

1. EndpointSlice CREATE in project control plane triggers quota admission
2. Admission plugin receives `*discovery.EndpointSlice` (internal type, not `*discoveryv1.EndpointSlice`)
3. Internal type has `ObjectMeta` with `json:",inline"` — no `metadata` wrapper
4. `ToUnstructured` produces `objectMeta` key; `json.Marshal` flattens metadata fields to top level
5. CEL expression `trigger.metadata.name` fails with `no such key: metadata`
6. Error surfaces as "Insufficient quota resources available"

### Production impact

This blocked EndpointSlice creation in project control planes for the network-services-operator, preventing HTTPProxy resources from being fully programmed (no backend EndpointSlice → gateway controller errors).

## Test plan

- [x] Unit test: `TestStructuredEndpointSliceCELTemplateRendering` — verifies both structured and unstructured objects produce correct CEL evaluation
- [x] E2E test: `structured-type-enforcement` — full quota lifecycle with EndpointSlice in project control plane (passes locally against kind cluster)
- [x] All existing admission unit tests pass
- [x] CI e2e test suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)