### PR TITLE
fix: add default GrantCreationPolicy for core resource quotas

### DIFF
--- a/config/services/quota/grant-policies/default-project-grant-policy.yaml
+++ b/config/services/quota/grant-policies/default-project-grant-policy.yaml
@@ -1,0 +1,38 @@
+apiVersion: quota.miloapis.com/v1alpha1
+kind: GrantCreationPolicy
+metadata:
+  name: default-milo-core-quota-policy
+  labels:
+    app.kubernetes.io/name: milo
+    app.kubernetes.io/component: quota-system
+spec:
+  trigger:
+    resource:
+      apiVersion: resourcemanager.miloapis.com/v1alpha1
+      kind: Project
+  target:
+    parentContext:
+      apiGroup: "resourcemanager.miloapis.com"
+      kind: "Project"
+      nameExpression: "trigger.metadata.name"
+    resourceGrantTemplate:
+      metadata:
+        name: "default-milo-core-quota-{{ trigger.metadata.name }}"
+        namespace: milo-system
+        annotations:
+          kubernetes.io/description: "Default quota allocation for Milo core resources"
+      spec:
+        consumerRef:
+          apiGroup: resourcemanager.miloapis.com
+          kind: Project
+          name: "{{ trigger.metadata.name }}"
+        allowances:
+          - resourceType: notes.miloapis.com/notes
+            buckets:
+              - amount: 100
+          - resourceType: core.miloapis.com/configmaps
+            buckets:
+              - amount: 100
+          - resourceType: core.miloapis.com/secrets
+            buckets:
+              - amount: 100

--- a/config/services/quota/grant-policies/kustomization.yaml
+++ b/config/services/quota/grant-policies/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+sortOptions:
+  order: fifo
+
+resources:
+  - default-project-grant-policy.yaml

--- a/config/services/quota/kustomization.yaml
+++ b/config/services/quota/kustomization.yaml
@@ -6,3 +6,4 @@ components:
   - telemetry/metrics/control-plane
   - registrations
   - claim-policies
+  - grant-policies


### PR DESCRIPTION
## Summary

Add a GrantCreationPolicy that auto-provisions quota for projects when they are created:
- 100 notes (shared between Notes and ClusterNotes)
- 100 configmaps
- 100 secrets

Without this, the ClaimCreationPolicies deployed in PR #528 deny all Note, ConfigMap, and Secret creation with "Insufficient quota" because no grants exist to allocate quota to projects.

**Note:** The CRM `note-contact-lifecycle` test creates Notes in the root control plane (no project context), which will still fail because the GrantCreationPolicy only provisions project-scoped grants. That test needs to be restructured to run in a project control plane, or the admission plugin needs to skip quota enforcement when there's no project context. This will be addressed in a follow-up.

## Test plan

- [x] `kustomize build config/services/` includes the GrantCreationPolicy
- [ ] Project-scoped note/clusternote/configmap tests pass (note-multicluster-subject, clusternote-multicluster-subject)

🤖 Generated with [Claude Code](https://claude.com/claude-code)