### PR TITLE
fix: skip quota enforcement for resources outside project context

### DIFF
--- a/test/notes/clusternote-multicluster-subject/chainsaw-test.yaml
+++ b/test/notes/clusternote-multicluster-subject/chainsaw-test.yaml
@@ -53,6 +53,23 @@ spec:
                 name: Ready
                 value: 'true'
 
+    - name: setup-quota-grant
+      description: Provision quota for the project so resources can be created
+      cluster: project
+      try:
+        - apply:
+            file: test-data/quota-grant.yaml
+        - wait:
+            apiVersion: quota.miloapis.com/v1alpha1
+            kind: ResourceGrant
+            name: test-clusternotes-quota-grant
+            namespace: milo-system
+            timeout: 30s
+            for:
+              condition:
+                name: Active
+                value: 'True'
+
     - name: create-namespace-in-project
       description: Create cluster-scoped Namespace in project control plane
       cluster: project

--- a/test/notes/clusternote-multicluster-subject/test-data/quota-grant.yaml
+++ b/test/notes/clusternote-multicluster-subject/test-data/quota-grant.yaml
@@ -1,0 +1,20 @@
+apiVersion: quota.miloapis.com/v1alpha1
+kind: ResourceGrant
+metadata:
+  name: test-clusternotes-quota-grant
+  namespace: milo-system
+spec:
+  consumerRef:
+    apiGroup: resourcemanager.miloapis.com
+    kind: Project
+    name: cn-mc-test-project-1
+  allowances:
+    - resourceType: notes.miloapis.com/notes
+      buckets:
+        - amount: 100
+    - resourceType: core.miloapis.com/configmaps
+      buckets:
+        - amount: 100
+    - resourceType: core.miloapis.com/secrets
+      buckets:
+        - amount: 100

--- a/test/notes/note-multicluster-subject/chainsaw-test.yaml
+++ b/test/notes/note-multicluster-subject/chainsaw-test.yaml
@@ -52,6 +52,23 @@ spec:
                 name: Ready
                 value: 'true'
 
+    - name: setup-quota-grant
+      description: Provision quota for the project so resources can be created
+      cluster: project
+      try:
+        - apply:
+            file: test-data/quota-grant.yaml
+        - wait:
+            apiVersion: quota.miloapis.com/v1alpha1
+            kind: ResourceGrant
+            name: test-notes-quota-grant
+            namespace: milo-system
+            timeout: 30s
+            for:
+              condition:
+                name: Active
+                value: 'True'
+
     - name: create-configmap-in-project
       description: Create ConfigMap resource in project control plane
       cluster: project

--- a/test/notes/note-multicluster-subject/test-data/quota-grant.yaml
+++ b/test/notes/note-multicluster-subject/test-data/quota-grant.yaml
@@ -1,0 +1,20 @@
+apiVersion: quota.miloapis.com/v1alpha1
+kind: ResourceGrant
+metadata:
+  name: test-notes-quota-grant
+  namespace: milo-system
+spec:
+  consumerRef:
+    apiGroup: resourcemanager.miloapis.com
+    kind: Project
+    name: note-mc-test-project-1
+  allowances:
+    - resourceType: notes.miloapis.com/notes
+      buckets:
+        - amount: 100
+    - resourceType: core.miloapis.com/configmaps
+      buckets:
+        - amount: 100
+    - resourceType: core.miloapis.com/secrets
+      buckets:
+        - amount: 100


### PR DESCRIPTION
## Summary

Two fixes for quota enforcement breaking existing e2e tests after ClaimCreationPolicies were deployed in PR #528:

### 1. Skip quota in root control plane

The admission plugin now skips ResourceClaim creation when no consumer (project) context can be determined. Resources created in the root control plane (e.g. CRM notes test) are not subject to per-project quota.

Previously, creating Notes, ConfigMaps, or Secrets outside a project control plane failed with "Insufficient quota" because the claim had no consumerRef and couldn't match any AllowanceBucket.

### 2. Add test-specific grants for project-scoped tests

Add ResourceGrant setup steps to `note-multicluster-subject` and `clusternote-multicluster-subject` e2e tests so their projects have quota allocated. These tests create resources in project control planes which now require quota grants.

## Test plan

- [x] Unit tests pass
- [ ] `crm-note-contact-lifecycle` passes (root-scoped Notes skip quota)
- [ ] `note-multicluster-subject` passes (project-scoped with test grant)
- [ ] `clusternote-multicluster-subject` passes (project-scoped with test grant)

🤖 Generated with [Claude Code](https://claude.com/claude-code)