### PR TITLE
feat: add organization-scoped IAM roles

### DIFF
--- a/config/roles/iam-organization-admin.yaml
+++ b/config/roles/iam-organization-admin.yaml
@@ -1,0 +1,11 @@
+apiVersion: iam.miloapis.com/v1alpha1
+kind: Role
+metadata:
+  name: iam-organization-admin
+  annotations:
+    kubernetes.io/display-name: IAM Organization Admin
+    kubernetes.io/description: "Full access to organization-scoped IAM resources"
+spec:
+  launchStage: Beta
+  inheritedRoles:
+    - name: iam-organization-editor

--- a/config/roles/iam-organization-editor.yaml
+++ b/config/roles/iam-organization-editor.yaml
@@ -1,0 +1,28 @@
+apiVersion: iam.miloapis.com/v1alpha1
+kind: Role
+metadata:
+  name: iam-organization-editor
+  annotations:
+    kubernetes.io/display-name: IAM Organization Editor
+    kubernetes.io/description: "Edit organization-scoped IAM resources"
+spec:
+  launchStage: Beta
+  inheritedRoles:
+    - name: iam-organization-viewer
+  includedPermissions:
+    - iam.miloapis.com/groups.create
+    - iam.miloapis.com/groups.update
+    - iam.miloapis.com/groups.patch
+    - iam.miloapis.com/groups.delete
+    - iam.miloapis.com/groupmemberships.create
+    - iam.miloapis.com/groupmemberships.update
+    - iam.miloapis.com/groupmemberships.patch
+    - iam.miloapis.com/groupmemberships.delete
+    - iam.miloapis.com/userinvitations.create
+    - iam.miloapis.com/userinvitations.update
+    - iam.miloapis.com/userinvitations.patch
+    - iam.miloapis.com/userinvitations.delete
+    - iam.miloapis.com/policybindings.create
+    - iam.miloapis.com/policybindings.update
+    - iam.miloapis.com/policybindings.patch
+    - iam.miloapis.com/policybindings.delete

--- a/config/roles/iam-organization-viewer.yaml
+++ b/config/roles/iam-organization-viewer.yaml
@@ -1,0 +1,22 @@
+apiVersion: iam.miloapis.com/v1alpha1
+kind: Role
+metadata:
+  name: iam-organization-viewer
+  annotations:
+    kubernetes.io/display-name: IAM Organization Viewer
+    kubernetes.io/description: "View organization-scoped IAM resources"
+spec:
+  launchStage: Beta
+  includedPermissions:
+    - iam.miloapis.com/groups.get
+    - iam.miloapis.com/groups.list
+    - iam.miloapis.com/groups.watch
+    - iam.miloapis.com/groupmemberships.get
+    - iam.miloapis.com/groupmemberships.list
+    - iam.miloapis.com/groupmemberships.watch
+    - iam.miloapis.com/userinvitations.get
+    - iam.miloapis.com/userinvitations.list
+    - iam.miloapis.com/userinvitations.watch
+    - iam.miloapis.com/policybindings.get
+    - iam.miloapis.com/policybindings.list
+    - iam.miloapis.com/policybindings.watch

--- a/config/roles/kustomization.yaml
+++ b/config/roles/kustomization.yaml
@@ -7,6 +7,9 @@ resources:
   - iam-viewer.yaml
   - iam-editor.yaml
   - iam-admin.yaml
+  - iam-organization-viewer.yaml
+  - iam-organization-editor.yaml
+  - iam-organization-admin.yaml
   - resourcemanager-reader.yaml
   - resourcemanager-editor.yaml
   - resourcemanager-admin.yaml


### PR DESCRIPTION
## Summary

The platform `iam-admin` role includes permissions for platform-level resources — `protectedresources` and `users` — that have no Organization parent and don't belong in the Organization resource hierarchy. When this role is granted at the organization level it gives access to platform-wide resources, which is broader than intended.

This PR introduces three new roles scoped strictly to resources that have `Organization` as a parent:

- **`iam-organization-viewer`**: Read access to `groups`, `groupmemberships`, `userinvitations`, and `policybindings`
- **`iam-organization-editor`**: Inherits viewer; adds create/update/patch/delete on the same resources
- **`iam-organization-admin`**: Inherits editor; acts as the org-level IAM admin role

These roles intentionally exclude:
- `iam.miloapis.com/users.*` — platform resource (no org parent)
- `iam.miloapis.com/protectedresources.*` — platform resource (no org parent)
- `iam.miloapis.com/roles.*` — scoped to `Service`, not `Organization`

## Test plan

- [ ] Apply the new Role manifests to a dev cluster and verify they are accepted
- [ ] Assign `iam-organization-admin` to a user on an organization and confirm they can manage groups/policybindings but cannot access platform-level IAM resources
- [ ] Confirm `iam-organization-viewer` grants read-only access as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)