### PR TITLE
fix: remove project label from projectstorage metrics to reduce cardinality

### DIFF
--- a/internal/apiserver/storage/project/mux.go
+++ b/internal/apiserver/storage/project/mux.go
@@ -35,10 +35,10 @@ var (
 	childCreations = k8smetrics.NewCounterVec(
 		&k8smetrics.CounterOpts{
 			Name:           "projectstorage_child_creations_total",
-			Help:           "Per-project child storage creations",
+			Help:           "Child storage creations by resource type",
 			StabilityLevel: k8smetrics.ALPHA,
 		},
-		[]string{"project", "resource_group", "resource_kind"},
+		[]string{"resource_group", "resource_kind"},
 	)
 
 	firstReady = k8smetrics.NewHistogramVec(
@@ -48,7 +48,7 @@ var (
 			Buckets:        []float64{0.02, 0.05, 0.1, 0.25, 0.5, 1, 2, 5, 10},
 			StabilityLevel: k8smetrics.ALPHA,
 		},
-		[]string{"project", "resource_group", "resource_kind"},
+		[]string{"resource_group", "resource_kind"},
 	)
 
 	reinitErrors = k8smetrics.NewCounterVec(
@@ -57,7 +57,7 @@ var (
 			Help:           "Ops that hit 'storage is (re)initializing'",
 			StabilityLevel: k8smetrics.ALPHA,
 		},
-		[]string{"project", "resource_group", "resource_kind", "verb"},
+		[]string{"resource_group", "resource_kind", "verb"},
 	)
 )
 
@@ -69,13 +69,13 @@ func isReinitErr(err error) bool {
 	return err != nil && strings.Contains(err.Error(), "storage is (re)initializing")
 }
 
-func incrReinit(project, group, kind, verb string) {
-	reinitErrors.WithLabelValues(project, group, kind, verb).Inc()
+func incrReinit(group, kind, verb string) {
+	reinitErrors.WithLabelValues(group, kind, verb).Inc()
 }
 
-func recordFirstReady(c *child, project, group, kind string) {
+func recordFirstReady(c *child, group, kind string) {
 	c.readyOnce.Do(func() {
-		firstReady.WithLabelValues(project, group, kind).
+		firstReady.WithLabelValues(group, kind).
 			Observe(time.Since(c.created).Seconds())
 	})
 }
@@ -107,9 +107,8 @@ type decoratorArgs struct {
 
 // instrumentedStorage wraps a storage.Interface to emit metrics once per child
 type instrumentedStorage struct {
-	inner   storage.Interface
-	child   *child
-	project string
+	inner storage.Interface
+	child *child
 
 	// normalized labels
 	group string // API group ("" => "core" when you query; we keep "" here)
@@ -117,11 +116,11 @@ type instrumentedStorage struct {
 }
 
 func (i *instrumentedStorage) markSuccess() {
-	recordFirstReady(i.child, i.project, i.group, i.kind)
+	recordFirstReady(i.child, i.group, i.kind)
 }
 func (i *instrumentedStorage) markReinit(verb string, err error) error {
 	if isReinitErr(err) {
-		incrReinit(i.project, i.group, i.kind, verb)
+		incrReinit(i.group, i.kind, verb)
 	}
 	return err
 }
@@ -239,16 +238,15 @@ func (m *projectMux) childForProject(project string) (storage.Interface, error) 
 	// Wrap the child once with instrumentation.
 	c := &child{s: s, destroy: destroy, created: time.Now()}
 	wrapped := &instrumentedStorage{
-		inner:   s,
-		child:   c,
-		project: project,
-		group:   m.args.resourceGroup,
-		kind:    m.args.resourceKind,
+		inner: s,
+		child: c,
+		group: m.args.resourceGroup,
+		kind:  m.args.resourceKind,
 	}
 	c.s = wrapped
 
 	m.children[project] = c
-	childCreations.WithLabelValues(project, m.args.resourceGroup, m.args.resourceKind).Inc()
+	childCreations.WithLabelValues(m.args.resourceGroup, m.args.resourceKind).Inc()
 
 	// Bootstrap system namespace synchronously to prevent resource creation failures
 	if project != "" && m.loopbackConfig != nil {


### PR DESCRIPTION
## Summary
- Remove the `project` label from all three `projectstorage_*` metrics

## Problem
The `project` label creates cardinality explosion in VictoriaMetrics production storage (datum-cloud/infra#2113). PVCs are at 93% capacity.

| Metric | Before (per pod) | After (per pod) |
|--------|-----------------|-----------------|
| `projectstorage_first_ready_seconds` | 414 × 82 × 12 = 407K series | 82 × 12 = 984 series |
| `projectstorage_child_creations_total` | 414 × 82 = 34K series | 82 series |
| `projectstorage_reinitializing_errors_total` | 414 × 82 × 7 = 237K series | 82 × 7 = 574 series |
| **Total** | **~678K / pod, ~6.1M across 9 pods** | **~1.6K / pod, ~14K across 9 pods** |

**~430x reduction in cardinality.**

## What changed
- Removed `project` from label dimensions on all three metrics
- Removed `project` field from `instrumentedStorage` struct
- Updated `recordFirstReady`, `incrReinit`, and `childCreations.WithLabelValues` call sites

The distribution by `resource_group` and `resource_kind` is the useful signal for understanding storage init performance. Per-project granularity is not actionable and is the source of the cardinality problem.

## Test plan
- [ ] `go build ./internal/apiserver/storage/project/` passes
- [ ] Deploy to staging, verify metrics still emit with reduced labels
- [ ] Confirm VictoriaMetrics series count drops after old series expire