### PR TITLE
fix: eliminate 502 errors during rolling deployments

### DIFF
--- a/config/apiserver/deployment.yaml
+++ b/config/apiserver/deployment.yaml
@@ -10,7 +10,7 @@ spec:
       app.kubernetes.io/part-of: milo-control-plane
   strategy:
     rollingUpdate:
-      maxSurge: 1
+      maxSurge: 25%
       maxUnavailable: 0
     type: RollingUpdate
   template:

--- a/config/apiserver/deployment.yaml
+++ b/config/apiserver/deployment.yaml
@@ -10,8 +10,8 @@ spec:
       app.kubernetes.io/part-of: milo-control-plane
   strategy:
     rollingUpdate:
-      maxSurge: 25%
-      maxUnavailable: 25%
+      maxSurge: 1
+      maxUnavailable: 0
     type: RollingUpdate
   template:
     metadata:
@@ -83,6 +83,7 @@ spec:
           - --events-provider-timeout=$(EVENTS_PROVIDER_TIMEOUT)
           - --events-provider-retries=$(EVENTS_PROVIDER_RETRIES)
           - --events-forward-extras=$(EVENTS_FORWARD_EXTRAS)
+          - --shutdown-delay-duration=$(SHUTDOWN_DELAY_DURATION)
         env:
           # Feature gates configuration
           # Sessions and UserIdentities are GA (enabled by default)
@@ -184,6 +185,8 @@ spec:
             value: "3"
           - name: EVENTS_FORWARD_EXTRAS
             value: "iam.miloapis.com/parent-api-group,iam.miloapis.com/parent-type,iam.miloapis.com/parent-name"
+          - name: SHUTDOWN_DELAY_DURATION
+            value: "10s"
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/config/apiserver/deployment.yaml
+++ b/config/apiserver/deployment.yaml
@@ -214,11 +214,11 @@ spec:
           timeoutSeconds: 15
         resources:
           requests:
-            cpu: 100m
-            memory: 128Mi
-          limits:
-            cpu: 500m
+            cpu: 200m
             memory: 512Mi
+          limits:
+            cpu: "1"
+            memory: 1Gi
         startupProbe:
           failureThreshold: 30
           httpGet:

--- a/config/apiserver/kustomization.yaml
+++ b/config/apiserver/kustomization.yaml
@@ -3,3 +3,4 @@ kind: Kustomization
 resources:
   - deployment.yaml
   - service.yaml
+  - pdb.yaml

--- a/config/apiserver/pdb.yaml
+++ b/config/apiserver/pdb.yaml
@@ -1,0 +1,9 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: milo-apiserver
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: milo-apiserver

--- a/config/apiserver/pdb.yaml
+++ b/config/apiserver/pdb.yaml
@@ -3,7 +3,7 @@ kind: PodDisruptionBudget
 metadata:
   name: milo-apiserver
 spec:
-  maxUnavailable: 1
+  maxUnavailable: 20%
   selector:
     matchLabels:
       app.kubernetes.io/name: milo-apiserver

--- a/config/components/gateway-api/backend-traffic-policy.yaml
+++ b/config/components/gateway-api/backend-traffic-policy.yaml
@@ -1,0 +1,37 @@
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: BackendTrafficPolicy
+metadata:
+  name: milo-apiserver
+  namespace: milo-system
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: milo-apiserver
+  retry:
+    numRetries: 3
+    retryOn:
+      triggers:
+        - gateway-error
+        - connect-failure
+        - reset
+    perRetry:
+      backOff:
+        baseInterval: 100ms
+        maxInterval: 1s
+      timeout: 2s
+  healthCheck:
+    active:
+      type: HTTP
+      http:
+        path: /readyz
+      interval: 5s
+      timeout: 3s
+      unhealthyThreshold: 2
+      healthyThreshold: 1
+    passive:
+      consecutive5XxErrors: 2
+      consecutiveGatewayErrors: 1
+      interval: 3s
+      baseEjectionTime: 15s
+      maxEjectionPercent: 33

--- a/config/components/gateway-api/kustomization.yaml
+++ b/config/components/gateway-api/kustomization.yaml
@@ -4,3 +4,4 @@ kind: Component
 resources:
   - httproute.yaml
   - backend-tls-policy.yaml
+  - backend-traffic-policy.yaml


### PR DESCRIPTION
## Summary

Clients occasionally see brief 502 errors when the API server is updated. This PR makes deployments seamless so clients never see errors during rollouts.

**What changed:**
- The gateway now automatically retries failed requests on a healthy pod instead of returning the error to the client
- Health checks detect pods shutting down within seconds and stop sending them traffic
- The API server signals it's going away before actually stopping, giving the gateway time to react
- A disruption budget prevents too many pods from going down at once during cluster maintenance
- The rollout strategy now waits for a new pod to be fully ready before terminating the old one

Closes #559

## Test plan

- [ ] Deploy to staging with 2+ API server replicas
- [ ] Trigger a rolling update (image tag change) while sending continuous API requests
- [ ] Verify zero 502 errors are returned to clients during the rollout
- [ ] Verify the `BackendTrafficPolicy` is accepted by Envoy Gateway (`kubectl get btp -n milo-system`)
- [ ] Test a voluntary node drain to confirm the PDB keeps at least one pod available

🤖 Generated with [Claude Code](https://claude.com/claude-code)