### PR TITLE
Show only the APIs that make sense for each context

### DIFF
--- a/cmd/milo/apiserver/config.go
+++ b/cmd/milo/apiserver/config.go
@@ -309,7 +309,10 @@ func (c *Config) Complete() (CompletedConfig, error) {
 }
 
 func NewConfig(opts options.CompletedOptions) (*Config, error) {
-	registry := discoveryctx.NewRegistry()
+	var registry *discoveryctx.Registry
+	if utilfeature.DefaultFeatureGate.Enabled(features.DiscoveryContextFilter) {
+		registry = discoveryctx.NewRegistry()
+	}
 
 	c := &Config{
 		Options:           opts,
@@ -352,11 +355,9 @@ func NewConfig(opts options.CompletedOptions) (*Config, error) {
 	loopbackClientConfig := genericConfig.LoopbackClientConfig
 
 	genericConfig.BuildHandlerChainFunc = func(h http.Handler, c *server.Config) http.Handler {
-		// Wrap the inner apiHandler with the discovery filter so it captures
-		// responses from the discovery endpoints. This is the innermost
-		// middleware so all parent-context decorators have populated the
-		// request context by the time the filter runs.
-		h = discoveryctx.DiscoveryContextFilter(h, registry)
+		if registry != nil {
+			h = discoveryctx.DiscoveryContextFilter(h, registry)
+		}
 		return datumfilters.ProjectRouterWithRequestInfo(
 			DefaultBuildHandlerChain(h, c, loopbackClientConfig), // build stock chain first
 			c.RequestInfoResolver,                                // then wrap with router
@@ -388,7 +389,9 @@ func NewConfig(opts options.CompletedOptions) (*Config, error) {
 		return nil, err
 	}
 	apiExtensions.GenericConfig.BuildHandlerChainFunc = func(h http.Handler, c *server.Config) http.Handler {
-		h = discoveryctx.DiscoveryContextFilter(h, registry)
+		if registry != nil {
+			h = discoveryctx.DiscoveryContextFilter(h, registry)
+		}
 		return datumfilters.ProjectRouterWithRequestInfo(
 			DefaultBuildHandlerChain(h, c, loopbackClientConfig),
 			c.RequestInfoResolver,
@@ -412,7 +415,9 @@ func NewConfig(opts options.CompletedOptions) (*Config, error) {
 		return nil, err
 	}
 	aggregator.GenericConfig.BuildHandlerChainFunc = func(h http.Handler, c *server.Config) http.Handler {
-		h = discoveryctx.DiscoveryContextFilter(h, registry)
+		if registry != nil {
+			h = discoveryctx.DiscoveryContextFilter(h, registry)
+		}
 		return datumfilters.ProjectRouterWithRequestInfo(
 			DefaultBuildHandlerChain(h, c, loopbackClientConfig),
 			c.RequestInfoResolver,

--- a/cmd/milo/apiserver/config.go
+++ b/cmd/milo/apiserver/config.go
@@ -54,6 +54,7 @@ import (
 	identityopenapi "go.miloapis.com/milo/pkg/apis/identity/v1alpha1"
 	quotaapi "go.miloapis.com/milo/pkg/apis/quota"
 	"go.miloapis.com/milo/pkg/features"
+	discoveryctx "go.miloapis.com/milo/pkg/server/discovery"
 	datumfilters "go.miloapis.com/milo/pkg/server/filters"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	openapicommon "k8s.io/kube-openapi/pkg/common"
@@ -65,6 +66,11 @@ type Config struct {
 	Aggregator    *aggregatorapiserver.Config
 	ControlPlane  *controlplaneapiserver.Config
 	APIExtensions *apiextensionsapiserver.Config
+
+	// DiscoveryRegistry is the shared parent-context registry used by the
+	// discovery filter. Created in NewConfig, populated from CRDs by a
+	// post-start hook in CreateServerChain.
+	DiscoveryRegistry *discoveryctx.Registry
 
 	ExtraConfig
 }
@@ -126,6 +132,8 @@ type completedConfig struct {
 	Aggregator    aggregatorapiserver.CompletedConfig
 	ControlPlane  controlplaneapiserver.CompletedConfig
 	APIExtensions apiextensionsapiserver.CompletedConfig
+
+	DiscoveryRegistry *discoveryctx.Registry
 
 	ExtraConfig
 }
@@ -294,13 +302,18 @@ func (c *Config) Complete() (CompletedConfig, error) {
 		ControlPlane:  c.ControlPlane.Complete(),
 		APIExtensions: c.APIExtensions.Complete(),
 
+		DiscoveryRegistry: c.DiscoveryRegistry,
+
 		ExtraConfig: c.ExtraConfig,
 	}}, nil
 }
 
 func NewConfig(opts options.CompletedOptions) (*Config, error) {
+	registry := discoveryctx.NewRegistry()
+
 	c := &Config{
-		Options: opts,
+		Options:           opts,
+		DiscoveryRegistry: registry,
 	}
 
 	miloScheme := runtime.NewScheme()
@@ -339,6 +352,11 @@ func NewConfig(opts options.CompletedOptions) (*Config, error) {
 	loopbackClientConfig := genericConfig.LoopbackClientConfig
 
 	genericConfig.BuildHandlerChainFunc = func(h http.Handler, c *server.Config) http.Handler {
+		// Wrap the inner apiHandler with the discovery filter so it captures
+		// responses from the discovery endpoints. This is the innermost
+		// middleware so all parent-context decorators have populated the
+		// request context by the time the filter runs.
+		h = discoveryctx.DiscoveryContextFilter(h, registry)
 		return datumfilters.ProjectRouterWithRequestInfo(
 			DefaultBuildHandlerChain(h, c, loopbackClientConfig), // build stock chain first
 			c.RequestInfoResolver,                                // then wrap with router
@@ -370,6 +388,7 @@ func NewConfig(opts options.CompletedOptions) (*Config, error) {
 		return nil, err
 	}
 	apiExtensions.GenericConfig.BuildHandlerChainFunc = func(h http.Handler, c *server.Config) http.Handler {
+		h = discoveryctx.DiscoveryContextFilter(h, registry)
 		return datumfilters.ProjectRouterWithRequestInfo(
 			DefaultBuildHandlerChain(h, c, loopbackClientConfig),
 			c.RequestInfoResolver,
@@ -393,6 +412,7 @@ func NewConfig(opts options.CompletedOptions) (*Config, error) {
 		return nil, err
 	}
 	aggregator.GenericConfig.BuildHandlerChainFunc = func(h http.Handler, c *server.Config) http.Handler {
+		h = discoveryctx.DiscoveryContextFilter(h, registry)
 		return datumfilters.ProjectRouterWithRequestInfo(
 			DefaultBuildHandlerChain(h, c, loopbackClientConfig),
 			c.RequestInfoResolver,

--- a/cmd/milo/apiserver/server.go
+++ b/cmd/milo/apiserver/server.go
@@ -313,6 +313,21 @@ func CreateServerChain(config CompletedConfig) (*aggregatorapiserver.APIAggregat
 	}
 	crdAPIEnabled := config.APIExtensions.GenericConfig.MergedResourceConfig.ResourceEnabled(apiextensionsv1.SchemeGroupVersion.WithResource("customresourcedefinitions"))
 
+	// Populate the discovery context registry from CRD annotations. The
+	// apiextensions informer factory is shared across the apiserver, so we
+	// reuse it rather than spinning up a parallel informer.
+	if reg := config.DiscoveryRegistry; reg != nil {
+		informers := apiExtensionsServer.Informers
+		apiExtensionsServer.GenericAPIServer.AddPostStartHookOrDie("milo-discovery-context-registry", func(hookCtx genericapiserver.PostStartHookContext) error {
+			go func() {
+				if err := reg.Run(hookCtx, informers); err != nil {
+					klog.ErrorS(err, "discovery context registry stopped")
+				}
+			}()
+			return nil
+		})
+	}
+
 	nativeAPIs, err := config.ControlPlane.New("datum-apiserver", apiExtensionsServer.GenericAPIServer)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create datum controlplane apiserver: %w", err)

--- a/config/crd/bases/iam/iam.miloapis.com_groupmemberships.yaml
+++ b/config/crd/bases/iam/iam.miloapis.com_groupmemberships.yaml
@@ -4,6 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.18.0
+    discovery.miloapis.com/parent-contexts: Organization
   name: groupmemberships.iam.miloapis.com
 spec:
   group: iam.miloapis.com

--- a/config/crd/bases/iam/iam.miloapis.com_groups.yaml
+++ b/config/crd/bases/iam/iam.miloapis.com_groups.yaml
@@ -4,6 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.18.0
+    discovery.miloapis.com/parent-contexts: Organization
   name: groups.iam.miloapis.com
 spec:
   group: iam.miloapis.com

--- a/config/crd/bases/iam/iam.miloapis.com_machineaccounts.yaml
+++ b/config/crd/bases/iam/iam.miloapis.com_machineaccounts.yaml
@@ -4,6 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.18.0
+    discovery.miloapis.com/parent-contexts: Project
   name: machineaccounts.iam.miloapis.com
 spec:
   group: iam.miloapis.com

--- a/config/crd/bases/iam/iam.miloapis.com_platformaccessapprovals.yaml
+++ b/config/crd/bases/iam/iam.miloapis.com_platformaccessapprovals.yaml
@@ -4,6 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.18.0
+    discovery.miloapis.com/parent-contexts: Platform
   name: platformaccessapprovals.iam.miloapis.com
 spec:
   group: iam.miloapis.com

--- a/config/crd/bases/iam/iam.miloapis.com_platformaccessapprovals.yaml
+++ b/config/crd/bases/iam/iam.miloapis.com_platformaccessapprovals.yaml
@@ -4,7 +4,6 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.18.0
-    discovery.miloapis.com/parent-contexts: Platform
   name: platformaccessapprovals.iam.miloapis.com
 spec:
   group: iam.miloapis.com

--- a/config/crd/bases/iam/iam.miloapis.com_platformaccessdenials.yaml
+++ b/config/crd/bases/iam/iam.miloapis.com_platformaccessdenials.yaml
@@ -4,7 +4,6 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.18.0
-    discovery.miloapis.com/parent-contexts: Platform
   name: platformaccessdenials.iam.miloapis.com
 spec:
   group: iam.miloapis.com

--- a/config/crd/bases/iam/iam.miloapis.com_platformaccessdenials.yaml
+++ b/config/crd/bases/iam/iam.miloapis.com_platformaccessdenials.yaml
@@ -4,6 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.18.0
+    discovery.miloapis.com/parent-contexts: Platform
   name: platformaccessdenials.iam.miloapis.com
 spec:
   group: iam.miloapis.com

--- a/config/crd/bases/iam/iam.miloapis.com_platformaccessrejections.yaml
+++ b/config/crd/bases/iam/iam.miloapis.com_platformaccessrejections.yaml
@@ -4,7 +4,6 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.18.0
-    discovery.miloapis.com/parent-contexts: Platform
   name: platformaccessrejections.iam.miloapis.com
 spec:
   group: iam.miloapis.com

--- a/config/crd/bases/iam/iam.miloapis.com_platformaccessrejections.yaml
+++ b/config/crd/bases/iam/iam.miloapis.com_platformaccessrejections.yaml
@@ -4,6 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.18.0
+    discovery.miloapis.com/parent-contexts: Platform
   name: platformaccessrejections.iam.miloapis.com
 spec:
   group: iam.miloapis.com

--- a/config/crd/bases/iam/iam.miloapis.com_platforminvitations.yaml
+++ b/config/crd/bases/iam/iam.miloapis.com_platforminvitations.yaml
@@ -4,6 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.18.0
+    discovery.miloapis.com/parent-contexts: Platform
   name: platforminvitations.iam.miloapis.com
 spec:
   group: iam.miloapis.com

--- a/config/crd/bases/iam/iam.miloapis.com_platforminvitations.yaml
+++ b/config/crd/bases/iam/iam.miloapis.com_platforminvitations.yaml
@@ -4,7 +4,6 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.18.0
-    discovery.miloapis.com/parent-contexts: Platform
   name: platforminvitations.iam.miloapis.com
 spec:
   group: iam.miloapis.com

--- a/config/crd/bases/iam/iam.miloapis.com_policybindings.yaml
+++ b/config/crd/bases/iam/iam.miloapis.com_policybindings.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.18.0
-    discovery.miloapis.com/parent-contexts: Organization
+    discovery.miloapis.com/parent-contexts: Organization,Platform
   name: policybindings.iam.miloapis.com
 spec:
   group: iam.miloapis.com

--- a/config/crd/bases/iam/iam.miloapis.com_policybindings.yaml
+++ b/config/crd/bases/iam/iam.miloapis.com_policybindings.yaml
@@ -4,6 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.18.0
+    discovery.miloapis.com/parent-contexts: Organization,Platform
   name: policybindings.iam.miloapis.com
 spec:
   group: iam.miloapis.com

--- a/config/crd/bases/iam/iam.miloapis.com_policybindings.yaml
+++ b/config/crd/bases/iam/iam.miloapis.com_policybindings.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.18.0
-    discovery.miloapis.com/parent-contexts: Organization,Platform
+    discovery.miloapis.com/parent-contexts: Organization
   name: policybindings.iam.miloapis.com
 spec:
   group: iam.miloapis.com

--- a/config/crd/bases/iam/iam.miloapis.com_protectedresources.yaml
+++ b/config/crd/bases/iam/iam.miloapis.com_protectedresources.yaml
@@ -4,6 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.18.0
+    discovery.miloapis.com/parent-contexts: Platform
   name: protectedresources.iam.miloapis.com
 spec:
   group: iam.miloapis.com

--- a/config/crd/bases/iam/iam.miloapis.com_protectedresources.yaml
+++ b/config/crd/bases/iam/iam.miloapis.com_protectedresources.yaml
@@ -4,7 +4,6 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.18.0
-    discovery.miloapis.com/parent-contexts: Platform
   name: protectedresources.iam.miloapis.com
 spec:
   group: iam.miloapis.com

--- a/config/crd/bases/iam/iam.miloapis.com_roles.yaml
+++ b/config/crd/bases/iam/iam.miloapis.com_roles.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.18.0
-    discovery.miloapis.com/parent-contexts: Organization
+    discovery.miloapis.com/parent-contexts: Organization,Platform
   name: roles.iam.miloapis.com
 spec:
   group: iam.miloapis.com

--- a/config/crd/bases/iam/iam.miloapis.com_roles.yaml
+++ b/config/crd/bases/iam/iam.miloapis.com_roles.yaml
@@ -4,6 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.18.0
+    discovery.miloapis.com/parent-contexts: Organization,Platform
   name: roles.iam.miloapis.com
 spec:
   group: iam.miloapis.com

--- a/config/crd/bases/iam/iam.miloapis.com_roles.yaml
+++ b/config/crd/bases/iam/iam.miloapis.com_roles.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.18.0
-    discovery.miloapis.com/parent-contexts: Organization,Platform
+    discovery.miloapis.com/parent-contexts: Organization
   name: roles.iam.miloapis.com
 spec:
   group: iam.miloapis.com

--- a/config/crd/bases/iam/iam.miloapis.com_userdeactivations.yaml
+++ b/config/crd/bases/iam/iam.miloapis.com_userdeactivations.yaml
@@ -4,6 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.18.0
+    discovery.miloapis.com/parent-contexts: Platform
   name: userdeactivations.iam.miloapis.com
 spec:
   group: iam.miloapis.com

--- a/config/crd/bases/iam/iam.miloapis.com_userdeactivations.yaml
+++ b/config/crd/bases/iam/iam.miloapis.com_userdeactivations.yaml
@@ -4,7 +4,6 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.18.0
-    discovery.miloapis.com/parent-contexts: Platform
   name: userdeactivations.iam.miloapis.com
 spec:
   group: iam.miloapis.com

--- a/config/crd/bases/iam/iam.miloapis.com_userinvitations.yaml
+++ b/config/crd/bases/iam/iam.miloapis.com_userinvitations.yaml
@@ -4,6 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.18.0
+    discovery.miloapis.com/parent-contexts: Organization,User
   name: userinvitations.iam.miloapis.com
 spec:
   group: iam.miloapis.com

--- a/config/crd/bases/iam/iam.miloapis.com_userpreferences.yaml
+++ b/config/crd/bases/iam/iam.miloapis.com_userpreferences.yaml
@@ -4,6 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.18.0
+    discovery.miloapis.com/parent-contexts: User
   name: userpreferences.iam.miloapis.com
 spec:
   group: iam.miloapis.com

--- a/config/crd/bases/iam/iam.miloapis.com_users.yaml
+++ b/config/crd/bases/iam/iam.miloapis.com_users.yaml
@@ -4,6 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.18.0
+    discovery.miloapis.com/parent-contexts: Platform,User
   name: users.iam.miloapis.com
 spec:
   group: iam.miloapis.com

--- a/config/crd/bases/iam/iam.miloapis.com_users.yaml
+++ b/config/crd/bases/iam/iam.miloapis.com_users.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.18.0
-    discovery.miloapis.com/parent-contexts: Platform,User
+    discovery.miloapis.com/parent-contexts: User
   name: users.iam.miloapis.com
 spec:
   group: iam.miloapis.com

--- a/config/crd/bases/iam/iam.miloapis.com_users.yaml
+++ b/config/crd/bases/iam/iam.miloapis.com_users.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.18.0
-    discovery.miloapis.com/parent-contexts: User
+    discovery.miloapis.com/parent-contexts: Platform,User
   name: users.iam.miloapis.com
 spec:
   group: iam.miloapis.com

--- a/config/crd/bases/infrastructure/infrastructure.miloapis.com_projectcontrolplanes.yaml
+++ b/config/crd/bases/infrastructure/infrastructure.miloapis.com_projectcontrolplanes.yaml
@@ -4,7 +4,6 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.18.0
-    discovery.miloapis.com/parent-contexts: Platform
   name: projectcontrolplanes.infrastructure.miloapis.com
 spec:
   group: infrastructure.miloapis.com

--- a/config/crd/bases/infrastructure/infrastructure.miloapis.com_projectcontrolplanes.yaml
+++ b/config/crd/bases/infrastructure/infrastructure.miloapis.com_projectcontrolplanes.yaml
@@ -4,6 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.18.0
+    discovery.miloapis.com/parent-contexts: Platform
   name: projectcontrolplanes.infrastructure.miloapis.com
 spec:
   group: infrastructure.miloapis.com

--- a/config/crd/bases/notes/notes.miloapis.com_clusternotes.yaml
+++ b/config/crd/bases/notes/notes.miloapis.com_clusternotes.yaml
@@ -4,7 +4,6 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.18.0
-    discovery.miloapis.com/parent-contexts: Platform
   name: clusternotes.notes.miloapis.com
 spec:
   group: notes.miloapis.com

--- a/config/crd/bases/notes/notes.miloapis.com_clusternotes.yaml
+++ b/config/crd/bases/notes/notes.miloapis.com_clusternotes.yaml
@@ -4,6 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.18.0
+    discovery.miloapis.com/parent-contexts: Platform
   name: clusternotes.notes.miloapis.com
 spec:
   group: notes.miloapis.com

--- a/config/crd/bases/notification/notification.miloapis.com_contactgroupmembershipremovals.yaml
+++ b/config/crd/bases/notification/notification.miloapis.com_contactgroupmembershipremovals.yaml
@@ -4,6 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.18.0
+    discovery.miloapis.com/parent-contexts: Platform,User
   name: contactgroupmembershipremovals.notification.miloapis.com
 spec:
   group: notification.miloapis.com

--- a/config/crd/bases/notification/notification.miloapis.com_contactgroupmembershipremovals.yaml
+++ b/config/crd/bases/notification/notification.miloapis.com_contactgroupmembershipremovals.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.18.0
-    discovery.miloapis.com/parent-contexts: Platform,User
+    discovery.miloapis.com/parent-contexts: User
   name: contactgroupmembershipremovals.notification.miloapis.com
 spec:
   group: notification.miloapis.com

--- a/config/crd/bases/notification/notification.miloapis.com_contactgroupmembershipremovals.yaml
+++ b/config/crd/bases/notification/notification.miloapis.com_contactgroupmembershipremovals.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.18.0
-    discovery.miloapis.com/parent-contexts: User
+    discovery.miloapis.com/parent-contexts: Platform,User
   name: contactgroupmembershipremovals.notification.miloapis.com
 spec:
   group: notification.miloapis.com

--- a/config/crd/bases/notification/notification.miloapis.com_contactgroupmemberships.yaml
+++ b/config/crd/bases/notification/notification.miloapis.com_contactgroupmemberships.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.18.0
-    discovery.miloapis.com/parent-contexts: Platform,User
+    discovery.miloapis.com/parent-contexts: User
   name: contactgroupmemberships.notification.miloapis.com
 spec:
   group: notification.miloapis.com

--- a/config/crd/bases/notification/notification.miloapis.com_contactgroupmemberships.yaml
+++ b/config/crd/bases/notification/notification.miloapis.com_contactgroupmemberships.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.18.0
-    discovery.miloapis.com/parent-contexts: User
+    discovery.miloapis.com/parent-contexts: Platform,User
   name: contactgroupmemberships.notification.miloapis.com
 spec:
   group: notification.miloapis.com

--- a/config/crd/bases/notification/notification.miloapis.com_contactgroupmemberships.yaml
+++ b/config/crd/bases/notification/notification.miloapis.com_contactgroupmemberships.yaml
@@ -4,6 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.18.0
+    discovery.miloapis.com/parent-contexts: Platform,User
   name: contactgroupmemberships.notification.miloapis.com
 spec:
   group: notification.miloapis.com

--- a/config/crd/bases/notification/notification.miloapis.com_contactgroups.yaml
+++ b/config/crd/bases/notification/notification.miloapis.com_contactgroups.yaml
@@ -4,6 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.18.0
+    discovery.miloapis.com/parent-contexts: Platform,User
   name: contactgroups.notification.miloapis.com
 spec:
   group: notification.miloapis.com

--- a/config/crd/bases/notification/notification.miloapis.com_contactgroups.yaml
+++ b/config/crd/bases/notification/notification.miloapis.com_contactgroups.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.18.0
-    discovery.miloapis.com/parent-contexts: User
+    discovery.miloapis.com/parent-contexts: Platform,User
   name: contactgroups.notification.miloapis.com
 spec:
   group: notification.miloapis.com

--- a/config/crd/bases/notification/notification.miloapis.com_contactgroups.yaml
+++ b/config/crd/bases/notification/notification.miloapis.com_contactgroups.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.18.0
-    discovery.miloapis.com/parent-contexts: Platform,User
+    discovery.miloapis.com/parent-contexts: User
   name: contactgroups.notification.miloapis.com
 spec:
   group: notification.miloapis.com

--- a/config/crd/bases/notification/notification.miloapis.com_contacts.yaml
+++ b/config/crd/bases/notification/notification.miloapis.com_contacts.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.18.0
-    discovery.miloapis.com/parent-contexts: Platform,User
+    discovery.miloapis.com/parent-contexts: User
   name: contacts.notification.miloapis.com
 spec:
   group: notification.miloapis.com

--- a/config/crd/bases/notification/notification.miloapis.com_contacts.yaml
+++ b/config/crd/bases/notification/notification.miloapis.com_contacts.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.18.0
-    discovery.miloapis.com/parent-contexts: User
+    discovery.miloapis.com/parent-contexts: Platform,User
   name: contacts.notification.miloapis.com
 spec:
   group: notification.miloapis.com

--- a/config/crd/bases/notification/notification.miloapis.com_contacts.yaml
+++ b/config/crd/bases/notification/notification.miloapis.com_contacts.yaml
@@ -4,6 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.18.0
+    discovery.miloapis.com/parent-contexts: Platform,User
   name: contacts.notification.miloapis.com
 spec:
   group: notification.miloapis.com

--- a/config/crd/bases/notification/notification.miloapis.com_emailbroadcasts.yaml
+++ b/config/crd/bases/notification/notification.miloapis.com_emailbroadcasts.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.18.0
-    discovery.miloapis.com/parent-contexts: User
+    discovery.miloapis.com/parent-contexts: Platform,User
   name: emailbroadcasts.notification.miloapis.com
 spec:
   group: notification.miloapis.com

--- a/config/crd/bases/notification/notification.miloapis.com_emailbroadcasts.yaml
+++ b/config/crd/bases/notification/notification.miloapis.com_emailbroadcasts.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.18.0
-    discovery.miloapis.com/parent-contexts: Platform,User
+    discovery.miloapis.com/parent-contexts: User
   name: emailbroadcasts.notification.miloapis.com
 spec:
   group: notification.miloapis.com

--- a/config/crd/bases/notification/notification.miloapis.com_emailbroadcasts.yaml
+++ b/config/crd/bases/notification/notification.miloapis.com_emailbroadcasts.yaml
@@ -4,6 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.18.0
+    discovery.miloapis.com/parent-contexts: Platform,User
   name: emailbroadcasts.notification.miloapis.com
 spec:
   group: notification.miloapis.com

--- a/config/crd/bases/notification/notification.miloapis.com_emails.yaml
+++ b/config/crd/bases/notification/notification.miloapis.com_emails.yaml
@@ -4,6 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.18.0
+    discovery.miloapis.com/parent-contexts: Platform,User
   name: emails.notification.miloapis.com
 spec:
   group: notification.miloapis.com

--- a/config/crd/bases/notification/notification.miloapis.com_emails.yaml
+++ b/config/crd/bases/notification/notification.miloapis.com_emails.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.18.0
-    discovery.miloapis.com/parent-contexts: Platform,User
+    discovery.miloapis.com/parent-contexts: User
   name: emails.notification.miloapis.com
 spec:
   group: notification.miloapis.com

--- a/config/crd/bases/notification/notification.miloapis.com_emails.yaml
+++ b/config/crd/bases/notification/notification.miloapis.com_emails.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.18.0
-    discovery.miloapis.com/parent-contexts: User
+    discovery.miloapis.com/parent-contexts: Platform,User
   name: emails.notification.miloapis.com
 spec:
   group: notification.miloapis.com

--- a/config/crd/bases/notification/notification.miloapis.com_emailtemplates.yaml
+++ b/config/crd/bases/notification/notification.miloapis.com_emailtemplates.yaml
@@ -4,7 +4,6 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.18.0
-    discovery.miloapis.com/parent-contexts: Platform
   name: emailtemplates.notification.miloapis.com
 spec:
   group: notification.miloapis.com

--- a/config/crd/bases/notification/notification.miloapis.com_emailtemplates.yaml
+++ b/config/crd/bases/notification/notification.miloapis.com_emailtemplates.yaml
@@ -4,6 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.18.0
+    discovery.miloapis.com/parent-contexts: Platform
   name: emailtemplates.notification.miloapis.com
 spec:
   group: notification.miloapis.com

--- a/config/crd/bases/quota/quota.miloapis.com_allowancebuckets.yaml
+++ b/config/crd/bases/quota/quota.miloapis.com_allowancebuckets.yaml
@@ -4,6 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.18.0
+    discovery.miloapis.com/parent-contexts: Organization,Project
   name: allowancebuckets.quota.miloapis.com
 spec:
   group: quota.miloapis.com

--- a/config/crd/bases/quota/quota.miloapis.com_claimcreationpolicies.yaml
+++ b/config/crd/bases/quota/quota.miloapis.com_claimcreationpolicies.yaml
@@ -4,7 +4,6 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.18.0
-    discovery.miloapis.com/parent-contexts: Platform
   name: claimcreationpolicies.quota.miloapis.com
 spec:
   group: quota.miloapis.com

--- a/config/crd/bases/quota/quota.miloapis.com_claimcreationpolicies.yaml
+++ b/config/crd/bases/quota/quota.miloapis.com_claimcreationpolicies.yaml
@@ -4,6 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.18.0
+    discovery.miloapis.com/parent-contexts: Platform
   name: claimcreationpolicies.quota.miloapis.com
 spec:
   group: quota.miloapis.com

--- a/config/crd/bases/quota/quota.miloapis.com_grantcreationpolicies.yaml
+++ b/config/crd/bases/quota/quota.miloapis.com_grantcreationpolicies.yaml
@@ -4,7 +4,6 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.18.0
-    discovery.miloapis.com/parent-contexts: Platform
   name: grantcreationpolicies.quota.miloapis.com
 spec:
   group: quota.miloapis.com

--- a/config/crd/bases/quota/quota.miloapis.com_grantcreationpolicies.yaml
+++ b/config/crd/bases/quota/quota.miloapis.com_grantcreationpolicies.yaml
@@ -4,6 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.18.0
+    discovery.miloapis.com/parent-contexts: Platform
   name: grantcreationpolicies.quota.miloapis.com
 spec:
   group: quota.miloapis.com

--- a/config/crd/bases/quota/quota.miloapis.com_resourceclaims.yaml
+++ b/config/crd/bases/quota/quota.miloapis.com_resourceclaims.yaml
@@ -4,6 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.18.0
+    discovery.miloapis.com/parent-contexts: Organization,Project
   name: resourceclaims.quota.miloapis.com
 spec:
   group: quota.miloapis.com

--- a/config/crd/bases/quota/quota.miloapis.com_resourcegrants.yaml
+++ b/config/crd/bases/quota/quota.miloapis.com_resourcegrants.yaml
@@ -4,6 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.18.0
+    discovery.miloapis.com/parent-contexts: Organization,Project
   name: resourcegrants.quota.miloapis.com
 spec:
   group: quota.miloapis.com

--- a/config/crd/bases/quota/quota.miloapis.com_resourceregistrations.yaml
+++ b/config/crd/bases/quota/quota.miloapis.com_resourceregistrations.yaml
@@ -4,6 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.18.0
+    discovery.miloapis.com/parent-contexts: Platform
   name: resourceregistrations.quota.miloapis.com
 spec:
   group: quota.miloapis.com

--- a/config/crd/bases/quota/quota.miloapis.com_resourceregistrations.yaml
+++ b/config/crd/bases/quota/quota.miloapis.com_resourceregistrations.yaml
@@ -4,7 +4,6 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.18.0
-    discovery.miloapis.com/parent-contexts: Platform
   name: resourceregistrations.quota.miloapis.com
 spec:
   group: quota.miloapis.com

--- a/config/crd/bases/resourcemanager/resourcemanager.miloapis.com_organizationmemberships.yaml
+++ b/config/crd/bases/resourcemanager/resourcemanager.miloapis.com_organizationmemberships.yaml
@@ -4,6 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.18.0
+    discovery.miloapis.com/parent-contexts: Organization,User
   name: organizationmemberships.resourcemanager.miloapis.com
 spec:
   group: resourcemanager.miloapis.com

--- a/config/crd/bases/resourcemanager/resourcemanager.miloapis.com_organizations.yaml
+++ b/config/crd/bases/resourcemanager/resourcemanager.miloapis.com_organizations.yaml
@@ -4,6 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.18.0
+    discovery.miloapis.com/parent-contexts: Platform
   name: organizations.resourcemanager.miloapis.com
 spec:
   group: resourcemanager.miloapis.com

--- a/config/crd/bases/resourcemanager/resourcemanager.miloapis.com_organizations.yaml
+++ b/config/crd/bases/resourcemanager/resourcemanager.miloapis.com_organizations.yaml
@@ -4,7 +4,6 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.18.0
-    discovery.miloapis.com/parent-contexts: Platform
   name: organizations.resourcemanager.miloapis.com
 spec:
   group: resourcemanager.miloapis.com

--- a/config/crd/bases/resourcemanager/resourcemanager.miloapis.com_organizations.yaml
+++ b/config/crd/bases/resourcemanager/resourcemanager.miloapis.com_organizations.yaml
@@ -4,6 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.18.0
+    discovery.miloapis.com/parent-contexts: Root
   name: organizations.resourcemanager.miloapis.com
 spec:
   group: resourcemanager.miloapis.com

--- a/config/crd/bases/resourcemanager/resourcemanager.miloapis.com_organizations.yaml
+++ b/config/crd/bases/resourcemanager/resourcemanager.miloapis.com_organizations.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.18.0
-    discovery.miloapis.com/parent-contexts: Root
+    discovery.miloapis.com/parent-contexts: Platform
   name: organizations.resourcemanager.miloapis.com
 spec:
   group: resourcemanager.miloapis.com

--- a/config/crd/bases/resourcemanager/resourcemanager.miloapis.com_projects.yaml
+++ b/config/crd/bases/resourcemanager/resourcemanager.miloapis.com_projects.yaml
@@ -4,6 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.18.0
+    discovery.miloapis.com/parent-contexts: Organization
   name: projects.resourcemanager.miloapis.com
 spec:
   group: resourcemanager.miloapis.com

--- a/config/overlays/test-infra/patches/apiserver-patch.yaml
+++ b/config/overlays/test-infra/patches/apiserver-patch.yaml
@@ -50,6 +50,8 @@ spec:
             value: "batch"
           - name: AUDIT_WEBHOOK_INITIAL_BACKOFF
             value: "10s"
+          - name: FEATURE_GATES
+            value: "DiscoveryContextFilter=true"
         # Add volume mount for token auth
         volumeMounts:
           - name: auth-tokens

--- a/docs/architecture/discovery-contexts.md
+++ b/docs/architecture/discovery-contexts.md
@@ -1,0 +1,146 @@
+# Parent-context-aware API discovery
+
+Milo serves the same API surface to many kinds of callers — humans hitting the
+cluster root to manage their organizations, controllers operating inside a
+specific organization, project-scoped clients running inside a project's
+control plane, and end users reading their own profile. Most of those callers
+only care about a small slice of the resources Milo exposes.
+
+This document describes how a resource declares which **parent contexts** it
+is visible in, and how Milo filters the standard Kubernetes API discovery
+responses (`/apis`, `/apis/{group}/{version}`) per request.
+
+> **Status: prototype.** The filter is implemented; the companion admission
+> check that turns this into a hard boundary is not. See
+> [Tradeoffs](#tradeoffs).
+
+## Parent contexts
+
+A request enters Milo in one of four parent contexts. The context is
+determined by the URL prefix the client used; the existing handlers in
+`pkg/server/filters/` extract the parent type and stash it on the request
+context.
+
+| Context        | URL pattern                                                                              |
+| -------------- | ---------------------------------------------------------------------------------------- |
+| `Root`         | `/apis/...` (no parent prefix)                                                           |
+| `Organization` | `/apis/resourcemanager.miloapis.com/v1alpha1/organizations/{id}/control-plane/apis/...`  |
+| `Project`      | `.../projects/{id}/control-plane/apis/...`                                               |
+| `User`         | `/apis/iam.miloapis.com/v1alpha1/users/{id}/control-plane/apis/...`                      |
+
+The filter consults a registry built from CRD annotations and decides, for
+each `(group, resource)` pair, whether to include it in the discovery
+response.
+
+## Tagging a resource
+
+### Bundled CRDs (Go-defined types)
+
+Add the `+kubebuilder:metadata:annotations` marker on the type. `task
+generate` writes it onto the generated CRD manifest:
+
+```go
+// +kubebuilder:resource:path=projects,scope=Cluster
+// +kubebuilder:metadata:annotations=discovery.miloapis.com/parent-contexts=Organization
+type Project struct { ... }
+```
+
+For multiple contexts, quote the marker value. controller-gen's marker
+parser treats bare tokens as the legacy slice form (split on `;`) and splits
+the annotations list on `,`, so unquoted multi-context values fail code
+generation. A quoted value goes through `strconv.Unquote` and is preserved
+verbatim:
+
+```go
+// +kubebuilder:metadata:annotations="discovery.miloapis.com/parent-contexts=Organization,User"
+type OrganizationMembership struct { ... }
+```
+
+The runtime parser accepts `,` and `;` interchangeably, so external CRDs
+written directly as YAML (no controller-gen in the loop) can use either.
+
+References:
+- `sigs.k8s.io/controller-tools/pkg/crd/markers/crd.go:360` — `Metadata.Annotations []string`
+- `sigs.k8s.io/controller-tools/pkg/markers/parse.go:376` — `parseString` accepts `"..."` and `` `...` `` via `strconv.Unquote`
+
+### External CRDs (services built on Milo)
+
+External services install their CRDs through the standard apiextensions
+endpoint. Tag the CRD object directly — Milo's CRD informer picks up the
+annotation within seconds and the discovery filter starts honoring it on the
+next request.
+
+```yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: widgets.example.com
+  annotations:
+    discovery.miloapis.com/parent-contexts: "Organization,Project"
+spec:
+  group: example.com
+  names: { kind: Widget, plural: widgets, ... }
+```
+
+Comma OR semicolon work in raw CRD YAML — there's no controller-gen in the
+loop. The wildcard `*` (or omitting the annotation entirely) means "visible
+in all contexts," which is the backwards-compatible default.
+
+### Non-CRD types (built-in, aggregated)
+
+Resources served by aggregated APIs (e.g. `identity.miloapis.com/sessions`,
+core/v1) aren't backed by a CRD object, so there is no annotation surface.
+For these, register the contexts programmatically at apiserver startup:
+
+```go
+registry.RegisterStatic(
+    schema.GroupResource{Group: "identity.miloapis.com", Resource: "sessions"},
+    discovery.ContextUser,
+)
+```
+
+Static registrations take precedence over CRD annotations for the same
+`GroupResource` — useful if you ever need to override.
+
+## What the client sees
+
+```console
+# Root context — projects are hidden because they're tagged Organization-only.
+$ kubectl api-resources --api-group=resourcemanager.miloapis.com
+NAME             SHORTNAMES   APIVERSION                              NAMESPACED   KIND
+organizations                 resourcemanager.miloapis.com/v1alpha1   false        Organization
+
+# Organization context — projects show up; organizations themselves are hidden
+# because the user already knows which org they're in.
+$ kubectl api-resources \
+    --server=https://milo/apis/.../organizations/acme/control-plane \
+    --api-group=resourcemanager.miloapis.com
+NAME                       APIVERSION                              NAMESPACED   KIND
+organizationmemberships    resourcemanager.miloapis.com/v1alpha1   true         OrganizationMembership
+projects                   resourcemanager.miloapis.com/v1alpha1   false        Project
+```
+
+## Tradeoffs
+
+**This is a discovery hint, not enforcement.** A client that already knows
+the GVR of a hidden resource can still issue a `GET`/`POST`/`LIST` and the
+apiserver will serve it (subject to RBAC). To make the boundary hard, pair
+the filter with a validating admission plugin that rejects writes to a
+resource whose annotation excludes the current parent context. The two share
+the same `Registry` so the rules can never drift.
+
+**Backwards compatibility.** Resources without the annotation are visible
+everywhere. Existing CRDs (Milo's and third-parties') keep working unchanged
+until they opt in.
+
+**Startup window.** During apiserver startup, before the CRD informer has
+synced, the filter falls open (everything visible). This avoids hiding
+resources during the brief window where the registry is empty.
+
+## File map
+
+- `pkg/server/discovery/contexts.go` — annotation contract, ParentContext type, request-context detection
+- `pkg/server/discovery/registry.go` — CRD-watching registry + static registration
+- `pkg/server/discovery/filter.go` — HTTP middleware that captures and filters discovery responses
+- `cmd/milo/apiserver/config.go` — wires the filter into the three handler chains (kube-API, apiextensions, aggregator)
+- `cmd/milo/apiserver/server.go` — starts the registry's CRD informer in a post-start hook

--- a/docs/architecture/discovery-contexts.md
+++ b/docs/architecture/discovery-contexts.md
@@ -23,7 +23,7 @@ context.
 
 | Context        | URL pattern                                                                              |
 | -------------- | ---------------------------------------------------------------------------------------- |
-| `Root`         | `/apis/...` (no parent prefix)                                                           |
+| `Platform`         | `/apis/...` (no parent prefix)                                                           |
 | `Organization` | `/apis/resourcemanager.miloapis.com/v1alpha1/organizations/{id}/control-plane/apis/...`  |
 | `Project`      | `.../projects/{id}/control-plane/apis/...`                                               |
 | `User`         | `/apis/iam.miloapis.com/v1alpha1/users/{id}/control-plane/apis/...`                      |
@@ -105,7 +105,7 @@ Static registrations take precedence over CRD annotations for the same
 ## What the client sees
 
 ```console
-# Root context — projects are hidden because they're tagged Organization-only.
+# Platform context — projects are hidden because they're tagged Organization-only.
 $ kubectl api-resources --api-group=resourcemanager.miloapis.com
 NAME             SHORTNAMES   APIVERSION                              NAMESPACED   KIND
 organizations                 resourcemanager.miloapis.com/v1alpha1   false        Organization

--- a/pkg/apis/iam/v1alpha1/group_types.go
+++ b/pkg/apis/iam/v1alpha1/group_types.go
@@ -20,6 +20,7 @@ type GroupStatus struct {
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 
 // Group is the Schema for the groups API
+// +kubebuilder:metadata:annotations="discovery.miloapis.com/parent-contexts=Organization"
 type Group struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/pkg/apis/iam/v1alpha1/groupmembership_types.go
+++ b/pkg/apis/iam/v1alpha1/groupmembership_types.go
@@ -55,6 +55,7 @@ type GroupMembershipStatus struct {
 // +kubebuilder:selectablefield:JSONPath=".spec.groupRef.name"
 // +kubebuilder:selectablefield:JSONPath=".spec.userRef.name"
 // GroupMembership is the Schema for the groupmemberships API
+// +kubebuilder:metadata:annotations="discovery.miloapis.com/parent-contexts=Organization"
 type GroupMembership struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/pkg/apis/iam/v1alpha1/machineaccount_types.go
+++ b/pkg/apis/iam/v1alpha1/machineaccount_types.go
@@ -16,6 +16,7 @@ import (
 // +kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.conditions[?(@.type=='Ready')].status"
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 // +kubebuilder:resource:scope=Cluster
+// +kubebuilder:metadata:annotations="discovery.miloapis.com/parent-contexts=Project"
 type MachineAccount struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/pkg/apis/iam/v1alpha1/platformaccessapproval_types.go
+++ b/pkg/apis/iam/v1alpha1/platformaccessapproval_types.go
@@ -19,7 +19,6 @@ const (
 // +kubebuilder:resource:scope=Cluster
 // +kubebuilder:selectablefield:JSONPath=".spec.subjectRef.email"
 // +kubebuilder:selectablefield:JSONPath=".spec.subjectRef.userRef.name"
-// +kubebuilder:metadata:annotations="discovery.miloapis.com/parent-contexts=Platform"
 type PlatformAccessApproval struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/pkg/apis/iam/v1alpha1/platformaccessapproval_types.go
+++ b/pkg/apis/iam/v1alpha1/platformaccessapproval_types.go
@@ -19,6 +19,7 @@ const (
 // +kubebuilder:resource:scope=Cluster
 // +kubebuilder:selectablefield:JSONPath=".spec.subjectRef.email"
 // +kubebuilder:selectablefield:JSONPath=".spec.subjectRef.userRef.name"
+// +kubebuilder:metadata:annotations="discovery.miloapis.com/parent-contexts=Platform"
 type PlatformAccessApproval struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/pkg/apis/iam/v1alpha1/platformaccessrejection_types.go
+++ b/pkg/apis/iam/v1alpha1/platformaccessrejection_types.go
@@ -18,6 +18,7 @@ const (
 // It represents a formal denial of platform access for a user. Once the rejection is created, a notification can be sent to the user.
 // +kubebuilder:resource:scope=Cluster
 // +kubebuilder:selectablefield:JSONPath=".spec.subjectRef.name"
+// +kubebuilder:metadata:annotations="discovery.miloapis.com/parent-contexts=Platform"
 type PlatformAccessRejection struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/pkg/apis/iam/v1alpha1/platformaccessrejection_types.go
+++ b/pkg/apis/iam/v1alpha1/platformaccessrejection_types.go
@@ -18,7 +18,6 @@ const (
 // It represents a formal denial of platform access for a user. Once the rejection is created, a notification can be sent to the user.
 // +kubebuilder:resource:scope=Cluster
 // +kubebuilder:selectablefield:JSONPath=".spec.subjectRef.name"
-// +kubebuilder:metadata:annotations="discovery.miloapis.com/parent-contexts=Platform"
 type PlatformAccessRejection struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/pkg/apis/iam/v1alpha1/platforminvitation_types.go
+++ b/pkg/apis/iam/v1alpha1/platforminvitation_types.go
@@ -23,6 +23,7 @@ const (
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=".metadata.creationTimestamp"
 // It represents a platform invitation for a user.
 // +kubebuilder:resource:scope=Cluster
+// +kubebuilder:metadata:annotations="discovery.miloapis.com/parent-contexts=Platform"
 type PlatformInvitation struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/pkg/apis/iam/v1alpha1/platforminvitation_types.go
+++ b/pkg/apis/iam/v1alpha1/platforminvitation_types.go
@@ -23,7 +23,6 @@ const (
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=".metadata.creationTimestamp"
 // It represents a platform invitation for a user.
 // +kubebuilder:resource:scope=Cluster
-// +kubebuilder:metadata:annotations="discovery.miloapis.com/parent-contexts=Platform"
 type PlatformInvitation struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/pkg/apis/iam/v1alpha1/policybinding_types.go
+++ b/pkg/apis/iam/v1alpha1/policybinding_types.go
@@ -102,6 +102,7 @@ type ResourceSelector struct {
 // +kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.conditions[?(@.type=='Ready')].status"
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 // +kubebuilder:resource:path=policybindings,scope=Namespaced
+// +kubebuilder:metadata:annotations="discovery.miloapis.com/parent-contexts=Organization,Platform"
 type PolicyBinding struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`

--- a/pkg/apis/iam/v1alpha1/policybinding_types.go
+++ b/pkg/apis/iam/v1alpha1/policybinding_types.go
@@ -102,7 +102,7 @@ type ResourceSelector struct {
 // +kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.conditions[?(@.type=='Ready')].status"
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 // +kubebuilder:resource:path=policybindings,scope=Namespaced
-// +kubebuilder:metadata:annotations="discovery.miloapis.com/parent-contexts=Organization"
+// +kubebuilder:metadata:annotations="discovery.miloapis.com/parent-contexts=Organization,Platform"
 type PolicyBinding struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`

--- a/pkg/apis/iam/v1alpha1/policybinding_types.go
+++ b/pkg/apis/iam/v1alpha1/policybinding_types.go
@@ -102,7 +102,7 @@ type ResourceSelector struct {
 // +kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.conditions[?(@.type=='Ready')].status"
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 // +kubebuilder:resource:path=policybindings,scope=Namespaced
-// +kubebuilder:metadata:annotations="discovery.miloapis.com/parent-contexts=Organization,Platform"
+// +kubebuilder:metadata:annotations="discovery.miloapis.com/parent-contexts=Organization"
 type PolicyBinding struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`

--- a/pkg/apis/iam/v1alpha1/protectedresource_types.go
+++ b/pkg/apis/iam/v1alpha1/protectedresource_types.go
@@ -57,6 +57,7 @@ type ProtectedResourceStatus struct {
 // +kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.conditions[?(@.type=='Ready')].status"
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 // +kubebuilder:resource:path=protectedresources,scope=Cluster,singular=protectedresource
+// +kubebuilder:metadata:annotations="discovery.miloapis.com/parent-contexts=Platform"
 type ProtectedResource struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/pkg/apis/iam/v1alpha1/protectedresource_types.go
+++ b/pkg/apis/iam/v1alpha1/protectedresource_types.go
@@ -57,7 +57,6 @@ type ProtectedResourceStatus struct {
 // +kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.conditions[?(@.type=='Ready')].status"
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 // +kubebuilder:resource:path=protectedresources,scope=Cluster,singular=protectedresource
-// +kubebuilder:metadata:annotations="discovery.miloapis.com/parent-contexts=Platform"
 type ProtectedResource struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/pkg/apis/iam/v1alpha1/role_types.go
+++ b/pkg/apis/iam/v1alpha1/role_types.go
@@ -13,6 +13,7 @@ import (
 // +kubebuilder:printcolumn:name="Launch Stage",type="string",JSONPath=".spec.launchStage"
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 // +kubebuilder:resource:scope=Namespaced
+// +kubebuilder:metadata:annotations="discovery.miloapis.com/parent-contexts=Organization,Platform"
 type Role struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/pkg/apis/iam/v1alpha1/role_types.go
+++ b/pkg/apis/iam/v1alpha1/role_types.go
@@ -13,7 +13,7 @@ import (
 // +kubebuilder:printcolumn:name="Launch Stage",type="string",JSONPath=".spec.launchStage"
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 // +kubebuilder:resource:scope=Namespaced
-// +kubebuilder:metadata:annotations="discovery.miloapis.com/parent-contexts=Organization"
+// +kubebuilder:metadata:annotations="discovery.miloapis.com/parent-contexts=Organization,Platform"
 type Role struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/pkg/apis/iam/v1alpha1/role_types.go
+++ b/pkg/apis/iam/v1alpha1/role_types.go
@@ -13,7 +13,7 @@ import (
 // +kubebuilder:printcolumn:name="Launch Stage",type="string",JSONPath=".spec.launchStage"
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 // +kubebuilder:resource:scope=Namespaced
-// +kubebuilder:metadata:annotations="discovery.miloapis.com/parent-contexts=Organization,Platform"
+// +kubebuilder:metadata:annotations="discovery.miloapis.com/parent-contexts=Organization"
 type Role struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/pkg/apis/iam/v1alpha1/user_types.go
+++ b/pkg/apis/iam/v1alpha1/user_types.go
@@ -47,7 +47,7 @@ const (
 // +kubebuilder:resource:path=users,scope=Cluster
 // +kubebuilder:selectablefield:JSONPath=".status.registrationApproval"
 // +kubebuilder:selectablefield:JSONPath=".spec.email"
-// +kubebuilder:metadata:annotations="discovery.miloapis.com/parent-contexts=User"
+// +kubebuilder:metadata:annotations="discovery.miloapis.com/parent-contexts=Platform,User"
 type User struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/pkg/apis/iam/v1alpha1/user_types.go
+++ b/pkg/apis/iam/v1alpha1/user_types.go
@@ -47,7 +47,7 @@ const (
 // +kubebuilder:resource:path=users,scope=Cluster
 // +kubebuilder:selectablefield:JSONPath=".status.registrationApproval"
 // +kubebuilder:selectablefield:JSONPath=".spec.email"
-// +kubebuilder:metadata:annotations="discovery.miloapis.com/parent-contexts=Platform,User"
+// +kubebuilder:metadata:annotations="discovery.miloapis.com/parent-contexts=User"
 type User struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/pkg/apis/iam/v1alpha1/user_types.go
+++ b/pkg/apis/iam/v1alpha1/user_types.go
@@ -47,6 +47,7 @@ const (
 // +kubebuilder:resource:path=users,scope=Cluster
 // +kubebuilder:selectablefield:JSONPath=".status.registrationApproval"
 // +kubebuilder:selectablefield:JSONPath=".spec.email"
+// +kubebuilder:metadata:annotations="discovery.miloapis.com/parent-contexts=Platform,User"
 type User struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/pkg/apis/iam/v1alpha1/userdeactivation_types.go
+++ b/pkg/apis/iam/v1alpha1/userdeactivation_types.go
@@ -54,6 +54,7 @@ type UserDeactivationStatus struct {
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 // +kubebuilder:selectablefield:JSONPath=".spec.userRef.name"
 // +kubebuilder:resource:scope=Cluster
+// +kubebuilder:metadata:annotations="discovery.miloapis.com/parent-contexts=Platform"
 type UserDeactivation struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/pkg/apis/iam/v1alpha1/userdeactivation_types.go
+++ b/pkg/apis/iam/v1alpha1/userdeactivation_types.go
@@ -54,7 +54,6 @@ type UserDeactivationStatus struct {
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 // +kubebuilder:selectablefield:JSONPath=".spec.userRef.name"
 // +kubebuilder:resource:scope=Cluster
-// +kubebuilder:metadata:annotations="discovery.miloapis.com/parent-contexts=Platform"
 type UserDeactivation struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/pkg/apis/iam/v1alpha1/userinvitation_types.go
+++ b/pkg/apis/iam/v1alpha1/userinvitation_types.go
@@ -39,6 +39,7 @@ const (
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=".metadata.creationTimestamp"
 // +kubebuilder:resource:path=userinvitations,scope=Namespaced
 // +kubebuilder:selectablefield:JSONPath=".status.inviteeUser.name"
+// +kubebuilder:metadata:annotations="discovery.miloapis.com/parent-contexts=Organization,User"
 type UserInvitation struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/pkg/apis/iam/v1alpha1/userpreference_types.go
+++ b/pkg/apis/iam/v1alpha1/userpreference_types.go
@@ -13,6 +13,7 @@ import (
 // +kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.conditions[?(@.type=='Ready')].status"
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 // +kubebuilder:resource:path=userpreferences,scope=Cluster
+// +kubebuilder:metadata:annotations="discovery.miloapis.com/parent-contexts=User"
 type UserPreference struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/pkg/apis/identity/v1alpha1/machineaccountkey_types.go
+++ b/pkg/apis/identity/v1alpha1/machineaccountkey_types.go
@@ -16,6 +16,7 @@ import (
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 // +kubebuilder:selectablefield:JSONPath=".spec.machineAccountName"
 // +kubebuilder:resource:scope=Namespaced
+// +kubebuilder:metadata:annotations="discovery.miloapis.com/parent-contexts=Project"
 type MachineAccountKey struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/pkg/apis/infrastructure/v1alpha1/projectcontrolplane_types.go
+++ b/pkg/apis/infrastructure/v1alpha1/projectcontrolplane_types.go
@@ -38,7 +38,6 @@ const (
 // +kubebuilder:resource:scope=Cluster
 
 // ProjectControlPlane is the Schema for the projectcontrolplanes API.
-// +kubebuilder:metadata:annotations="discovery.miloapis.com/parent-contexts=Platform"
 type ProjectControlPlane struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/pkg/apis/infrastructure/v1alpha1/projectcontrolplane_types.go
+++ b/pkg/apis/infrastructure/v1alpha1/projectcontrolplane_types.go
@@ -38,6 +38,7 @@ const (
 // +kubebuilder:resource:scope=Cluster
 
 // ProjectControlPlane is the Schema for the projectcontrolplanes API.
+// +kubebuilder:metadata:annotations="discovery.miloapis.com/parent-contexts=Platform"
 type ProjectControlPlane struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/pkg/apis/notes/v1alpha1/note_types.go
+++ b/pkg/apis/notes/v1alpha1/note_types.go
@@ -50,6 +50,7 @@ type Note struct {
 // +kubebuilder:selectablefield:JSONPath=".spec.nextActionTime"
 // +kubebuilder:selectablefield:JSONPath=".spec.followUp"
 // +kubebuilder:selectablefield:JSONPath=".status.createdBy"
+// +kubebuilder:metadata:annotations="discovery.miloapis.com/parent-contexts=Platform"
 type ClusterNote struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/pkg/apis/notes/v1alpha1/note_types.go
+++ b/pkg/apis/notes/v1alpha1/note_types.go
@@ -50,7 +50,6 @@ type Note struct {
 // +kubebuilder:selectablefield:JSONPath=".spec.nextActionTime"
 // +kubebuilder:selectablefield:JSONPath=".spec.followUp"
 // +kubebuilder:selectablefield:JSONPath=".status.createdBy"
-// +kubebuilder:metadata:annotations="discovery.miloapis.com/parent-contexts=Platform"
 type ClusterNote struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/pkg/apis/notification/v1alpha1/contact_types.go
+++ b/pkg/apis/notification/v1alpha1/contact_types.go
@@ -49,7 +49,7 @@ const (
 // +kubebuilder:selectablefield:JSONPath=".spec.email"
 // +kubebuilder:selectablefield:JSONPath=".spec.subject.name"
 // +kubebuilder:selectablefield:JSONPath=".spec.subject.kind"
-// +kubebuilder:metadata:annotations="discovery.miloapis.com/parent-contexts=User"
+// +kubebuilder:metadata:annotations="discovery.miloapis.com/parent-contexts=Platform,User"
 type Contact struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/pkg/apis/notification/v1alpha1/contact_types.go
+++ b/pkg/apis/notification/v1alpha1/contact_types.go
@@ -49,6 +49,7 @@ const (
 // +kubebuilder:selectablefield:JSONPath=".spec.email"
 // +kubebuilder:selectablefield:JSONPath=".spec.subject.name"
 // +kubebuilder:selectablefield:JSONPath=".spec.subject.kind"
+// +kubebuilder:metadata:annotations="discovery.miloapis.com/parent-contexts=Platform,User"
 type Contact struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/pkg/apis/notification/v1alpha1/contact_types.go
+++ b/pkg/apis/notification/v1alpha1/contact_types.go
@@ -49,7 +49,7 @@ const (
 // +kubebuilder:selectablefield:JSONPath=".spec.email"
 // +kubebuilder:selectablefield:JSONPath=".spec.subject.name"
 // +kubebuilder:selectablefield:JSONPath=".spec.subject.kind"
-// +kubebuilder:metadata:annotations="discovery.miloapis.com/parent-contexts=Platform,User"
+// +kubebuilder:metadata:annotations="discovery.miloapis.com/parent-contexts=User"
 type Contact struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/pkg/apis/notification/v1alpha1/contactgroup_types.go
+++ b/pkg/apis/notification/v1alpha1/contactgroup_types.go
@@ -53,7 +53,7 @@ const (
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 // +kubebuilder:resource:scope=Namespaced
 // +kubebuilder:selectablefield:JSONPath=".spec.visibility"
-// +kubebuilder:metadata:annotations="discovery.miloapis.com/parent-contexts=User"
+// +kubebuilder:metadata:annotations="discovery.miloapis.com/parent-contexts=Platform,User"
 type ContactGroup struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/pkg/apis/notification/v1alpha1/contactgroup_types.go
+++ b/pkg/apis/notification/v1alpha1/contactgroup_types.go
@@ -53,7 +53,7 @@ const (
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 // +kubebuilder:resource:scope=Namespaced
 // +kubebuilder:selectablefield:JSONPath=".spec.visibility"
-// +kubebuilder:metadata:annotations="discovery.miloapis.com/parent-contexts=Platform,User"
+// +kubebuilder:metadata:annotations="discovery.miloapis.com/parent-contexts=User"
 type ContactGroup struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/pkg/apis/notification/v1alpha1/contactgroup_types.go
+++ b/pkg/apis/notification/v1alpha1/contactgroup_types.go
@@ -53,6 +53,7 @@ const (
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 // +kubebuilder:resource:scope=Namespaced
 // +kubebuilder:selectablefield:JSONPath=".spec.visibility"
+// +kubebuilder:metadata:annotations="discovery.miloapis.com/parent-contexts=Platform,User"
 type ContactGroup struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/pkg/apis/notification/v1alpha1/contactgroupmembership.go
+++ b/pkg/apis/notification/v1alpha1/contactgroupmembership.go
@@ -52,6 +52,7 @@ const (
 // +kubebuilder:selectablefield:JSONPath=".spec.contactRef.name"
 // +kubebuilder:selectablefield:JSONPath=".spec.contactGroupRef.name"
 // +kubebuilder:selectablefield:JSONPath=".status.username"
+// +kubebuilder:metadata:annotations="discovery.miloapis.com/parent-contexts=Platform,User"
 type ContactGroupMembership struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/pkg/apis/notification/v1alpha1/contactgroupmembership.go
+++ b/pkg/apis/notification/v1alpha1/contactgroupmembership.go
@@ -52,7 +52,7 @@ const (
 // +kubebuilder:selectablefield:JSONPath=".spec.contactRef.name"
 // +kubebuilder:selectablefield:JSONPath=".spec.contactGroupRef.name"
 // +kubebuilder:selectablefield:JSONPath=".status.username"
-// +kubebuilder:metadata:annotations="discovery.miloapis.com/parent-contexts=Platform,User"
+// +kubebuilder:metadata:annotations="discovery.miloapis.com/parent-contexts=User"
 type ContactGroupMembership struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/pkg/apis/notification/v1alpha1/contactgroupmembership.go
+++ b/pkg/apis/notification/v1alpha1/contactgroupmembership.go
@@ -52,7 +52,7 @@ const (
 // +kubebuilder:selectablefield:JSONPath=".spec.contactRef.name"
 // +kubebuilder:selectablefield:JSONPath=".spec.contactGroupRef.name"
 // +kubebuilder:selectablefield:JSONPath=".status.username"
-// +kubebuilder:metadata:annotations="discovery.miloapis.com/parent-contexts=User"
+// +kubebuilder:metadata:annotations="discovery.miloapis.com/parent-contexts=Platform,User"
 type ContactGroupMembership struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/pkg/apis/notification/v1alpha1/contactgroupmembershipremoval_types.go
+++ b/pkg/apis/notification/v1alpha1/contactgroupmembershipremoval_types.go
@@ -26,6 +26,7 @@ const (
 // +kubebuilder:validation:Type=object
 // +kubebuilder:selectablefield:JSONPath=".spec.contactRef.name"
 // +kubebuilder:selectablefield:JSONPath=".status.username"
+// +kubebuilder:metadata:annotations="discovery.miloapis.com/parent-contexts=Platform,User"
 type ContactGroupMembershipRemoval struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/pkg/apis/notification/v1alpha1/contactgroupmembershipremoval_types.go
+++ b/pkg/apis/notification/v1alpha1/contactgroupmembershipremoval_types.go
@@ -26,7 +26,7 @@ const (
 // +kubebuilder:validation:Type=object
 // +kubebuilder:selectablefield:JSONPath=".spec.contactRef.name"
 // +kubebuilder:selectablefield:JSONPath=".status.username"
-// +kubebuilder:metadata:annotations="discovery.miloapis.com/parent-contexts=Platform,User"
+// +kubebuilder:metadata:annotations="discovery.miloapis.com/parent-contexts=User"
 type ContactGroupMembershipRemoval struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/pkg/apis/notification/v1alpha1/contactgroupmembershipremoval_types.go
+++ b/pkg/apis/notification/v1alpha1/contactgroupmembershipremoval_types.go
@@ -26,7 +26,7 @@ const (
 // +kubebuilder:validation:Type=object
 // +kubebuilder:selectablefield:JSONPath=".spec.contactRef.name"
 // +kubebuilder:selectablefield:JSONPath=".status.username"
-// +kubebuilder:metadata:annotations="discovery.miloapis.com/parent-contexts=User"
+// +kubebuilder:metadata:annotations="discovery.miloapis.com/parent-contexts=Platform,User"
 type ContactGroupMembershipRemoval struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/pkg/apis/notification/v1alpha1/email_types.go
+++ b/pkg/apis/notification/v1alpha1/email_types.go
@@ -156,6 +156,7 @@ type EmailStatus struct {
 // +kubebuilder:resource:scope=Namespaced
 // +kubebuilder:selectablefield:JSONPath=".spec.recipient.userRef.name"
 // +kubebuilder:selectablefield:JSONPath=".spec.recipient.emailAddress"
+// +kubebuilder:metadata:annotations="discovery.miloapis.com/parent-contexts=Platform,User"
 type Email struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/pkg/apis/notification/v1alpha1/email_types.go
+++ b/pkg/apis/notification/v1alpha1/email_types.go
@@ -156,7 +156,7 @@ type EmailStatus struct {
 // +kubebuilder:resource:scope=Namespaced
 // +kubebuilder:selectablefield:JSONPath=".spec.recipient.userRef.name"
 // +kubebuilder:selectablefield:JSONPath=".spec.recipient.emailAddress"
-// +kubebuilder:metadata:annotations="discovery.miloapis.com/parent-contexts=Platform,User"
+// +kubebuilder:metadata:annotations="discovery.miloapis.com/parent-contexts=User"
 type Email struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/pkg/apis/notification/v1alpha1/email_types.go
+++ b/pkg/apis/notification/v1alpha1/email_types.go
@@ -156,7 +156,7 @@ type EmailStatus struct {
 // +kubebuilder:resource:scope=Namespaced
 // +kubebuilder:selectablefield:JSONPath=".spec.recipient.userRef.name"
 // +kubebuilder:selectablefield:JSONPath=".spec.recipient.emailAddress"
-// +kubebuilder:metadata:annotations="discovery.miloapis.com/parent-contexts=User"
+// +kubebuilder:metadata:annotations="discovery.miloapis.com/parent-contexts=Platform,User"
 type Email struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/pkg/apis/notification/v1alpha1/emailbroadcast_types.go
+++ b/pkg/apis/notification/v1alpha1/emailbroadcast_types.go
@@ -37,6 +37,7 @@ const (
 // +kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.conditions[?(@.type=='Ready')].status"
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 // +kubebuilder:resource:scope=Namespaced
+// +kubebuilder:metadata:annotations="discovery.miloapis.com/parent-contexts=Platform,User"
 type EmailBroadcast struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/pkg/apis/notification/v1alpha1/emailbroadcast_types.go
+++ b/pkg/apis/notification/v1alpha1/emailbroadcast_types.go
@@ -37,7 +37,7 @@ const (
 // +kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.conditions[?(@.type=='Ready')].status"
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 // +kubebuilder:resource:scope=Namespaced
-// +kubebuilder:metadata:annotations="discovery.miloapis.com/parent-contexts=User"
+// +kubebuilder:metadata:annotations="discovery.miloapis.com/parent-contexts=Platform,User"
 type EmailBroadcast struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/pkg/apis/notification/v1alpha1/emailbroadcast_types.go
+++ b/pkg/apis/notification/v1alpha1/emailbroadcast_types.go
@@ -37,7 +37,7 @@ const (
 // +kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.conditions[?(@.type=='Ready')].status"
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 // +kubebuilder:resource:scope=Namespaced
-// +kubebuilder:metadata:annotations="discovery.miloapis.com/parent-contexts=Platform,User"
+// +kubebuilder:metadata:annotations="discovery.miloapis.com/parent-contexts=User"
 type EmailBroadcast struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/pkg/apis/notification/v1alpha1/emailtemplate_types.go
+++ b/pkg/apis/notification/v1alpha1/emailtemplate_types.go
@@ -84,7 +84,6 @@ type EmailTemplateStatus struct {
 // +kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.conditions[?(@.type=='Ready')].status"
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 // +kubebuilder:resource:scope=Cluster
-// +kubebuilder:metadata:annotations="discovery.miloapis.com/parent-contexts=Platform"
 type EmailTemplate struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/pkg/apis/notification/v1alpha1/emailtemplate_types.go
+++ b/pkg/apis/notification/v1alpha1/emailtemplate_types.go
@@ -84,6 +84,7 @@ type EmailTemplateStatus struct {
 // +kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.conditions[?(@.type=='Ready')].status"
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 // +kubebuilder:resource:scope=Cluster
+// +kubebuilder:metadata:annotations="discovery.miloapis.com/parent-contexts=Platform"
 type EmailTemplate struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/pkg/apis/quota/v1alpha1/allowancebucket_types.go
+++ b/pkg/apis/quota/v1alpha1/allowancebucket_types.go
@@ -281,6 +281,7 @@ type AllowanceBucketStatus struct {
 // +kubebuilder:selectablefield:JSONPath=".spec.consumerRef.kind"
 // +kubebuilder:selectablefield:JSONPath=".spec.consumerRef.name"
 // +kubebuilder:selectablefield:JSONPath=".spec.resourceType"
+// +kubebuilder:metadata:annotations="discovery.miloapis.com/parent-contexts=Organization,Project"
 type AllowanceBucket struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/pkg/apis/quota/v1alpha1/claimcreationpolicy_types.go
+++ b/pkg/apis/quota/v1alpha1/claimcreationpolicy_types.go
@@ -366,6 +366,7 @@ func (t *ClaimTriggerResource) GetGVK() schema.GroupVersionKind {
 // +kubebuilder:selectablefield:JSONPath=".spec.trigger.resource.kind"
 // +kubebuilder:selectablefield:JSONPath=".spec.trigger.resource.apiVersion"
 // +kubebuilder:selectablefield:JSONPath=".spec.disabled"
+// +kubebuilder:metadata:annotations="discovery.miloapis.com/parent-contexts=Platform"
 type ClaimCreationPolicy struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/pkg/apis/quota/v1alpha1/claimcreationpolicy_types.go
+++ b/pkg/apis/quota/v1alpha1/claimcreationpolicy_types.go
@@ -366,7 +366,6 @@ func (t *ClaimTriggerResource) GetGVK() schema.GroupVersionKind {
 // +kubebuilder:selectablefield:JSONPath=".spec.trigger.resource.kind"
 // +kubebuilder:selectablefield:JSONPath=".spec.trigger.resource.apiVersion"
 // +kubebuilder:selectablefield:JSONPath=".spec.disabled"
-// +kubebuilder:metadata:annotations="discovery.miloapis.com/parent-contexts=Platform"
 type ClaimCreationPolicy struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/pkg/apis/quota/v1alpha1/grantcreationpolicy_types.go
+++ b/pkg/apis/quota/v1alpha1/grantcreationpolicy_types.go
@@ -330,7 +330,6 @@ func (t *GrantTriggerResource) GetGVK() schema.GroupVersionKind {
 // +kubebuilder:selectablefield:JSONPath=".spec.trigger.resource.apiVersion"
 // +kubebuilder:selectablefield:JSONPath=".spec.target.parentContext.kind"
 // +kubebuilder:selectablefield:JSONPath=".spec.target.parentContext.apiGroup"
-// +kubebuilder:metadata:annotations="discovery.miloapis.com/parent-contexts=Platform"
 type GrantCreationPolicy struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/pkg/apis/quota/v1alpha1/grantcreationpolicy_types.go
+++ b/pkg/apis/quota/v1alpha1/grantcreationpolicy_types.go
@@ -330,6 +330,7 @@ func (t *GrantTriggerResource) GetGVK() schema.GroupVersionKind {
 // +kubebuilder:selectablefield:JSONPath=".spec.trigger.resource.apiVersion"
 // +kubebuilder:selectablefield:JSONPath=".spec.target.parentContext.kind"
 // +kubebuilder:selectablefield:JSONPath=".spec.target.parentContext.apiGroup"
+// +kubebuilder:metadata:annotations="discovery.miloapis.com/parent-contexts=Platform"
 type GrantCreationPolicy struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/pkg/apis/quota/v1alpha1/resourceclaim_types.go
+++ b/pkg/apis/quota/v1alpha1/resourceclaim_types.go
@@ -355,6 +355,7 @@ const (
 // +kubebuilder:selectablefield:JSONPath=".spec.resourceRef.kind"
 // +kubebuilder:selectablefield:JSONPath=".spec.resourceRef.name"
 // +kubebuilder:selectablefield:JSONPath=".spec.resourceRef.namespace"
+// +kubebuilder:metadata:annotations="discovery.miloapis.com/parent-contexts=Organization,Project"
 type ResourceClaim struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/pkg/apis/quota/v1alpha1/resourcegrant_types.go
+++ b/pkg/apis/quota/v1alpha1/resourcegrant_types.go
@@ -246,6 +246,7 @@ const (
 // +k8s:openapi-gen=true
 // +kubebuilder:selectablefield:JSONPath=".spec.consumerRef.kind"
 // +kubebuilder:selectablefield:JSONPath=".spec.consumerRef.name"
+// +kubebuilder:metadata:annotations="discovery.miloapis.com/parent-contexts=Organization,Project"
 type ResourceGrant struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/pkg/apis/quota/v1alpha1/resourceregistration_types.go
+++ b/pkg/apis/quota/v1alpha1/resourceregistration_types.go
@@ -291,7 +291,6 @@ const (
 // +kubebuilder:validation:XValidation:rule="!has(oldSelf.spec.resourceType) || self.spec.resourceType == oldSelf.spec.resourceType",message="spec.resourceType is immutable"
 // +kubebuilder:validation:XValidation:rule="!has(oldSelf.spec.consumerType) || self.spec.consumerType == oldSelf.spec.consumerType",message="spec.consumerType is immutable"
 // +kubebuilder:validation:XValidation:rule="!has(oldSelf.spec.type) || self.spec.type == oldSelf.spec.type",message="spec.type is immutable"
-// +kubebuilder:metadata:annotations="discovery.miloapis.com/parent-contexts=Platform"
 type ResourceRegistration struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/pkg/apis/quota/v1alpha1/resourceregistration_types.go
+++ b/pkg/apis/quota/v1alpha1/resourceregistration_types.go
@@ -291,6 +291,7 @@ const (
 // +kubebuilder:validation:XValidation:rule="!has(oldSelf.spec.resourceType) || self.spec.resourceType == oldSelf.spec.resourceType",message="spec.resourceType is immutable"
 // +kubebuilder:validation:XValidation:rule="!has(oldSelf.spec.consumerType) || self.spec.consumerType == oldSelf.spec.consumerType",message="spec.consumerType is immutable"
 // +kubebuilder:validation:XValidation:rule="!has(oldSelf.spec.type) || self.spec.type == oldSelf.spec.type",message="spec.type is immutable"
+// +kubebuilder:metadata:annotations="discovery.miloapis.com/parent-contexts=Platform"
 type ResourceRegistration struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/pkg/apis/resourcemanager/v1alpha1/organization_types.go
+++ b/pkg/apis/resourcemanager/v1alpha1/organization_types.go
@@ -37,6 +37,7 @@ type OrganizationStatus struct {
 // +kubebuilder:subresource:status
 // Use lowercase for path, which influences plural name. Ensure kind is Organization.
 // +kubebuilder:resource:path=organizations,scope=Cluster,categories=datum,singular=organization
+// +kubebuilder:metadata:annotations=discovery.miloapis.com/parent-contexts=Root
 // +kubebuilder:printcolumn:name="Display Name",type="string",JSONPath=".metadata.annotations.kubernetes\\.io\\/display-name"
 // +kubebuilder:printcolumn:name="Type",type="string",JSONPath=".spec.type"
 // +kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.conditions[?(@.type=='Ready')].status"

--- a/pkg/apis/resourcemanager/v1alpha1/organization_types.go
+++ b/pkg/apis/resourcemanager/v1alpha1/organization_types.go
@@ -37,7 +37,6 @@ type OrganizationStatus struct {
 // +kubebuilder:subresource:status
 // Use lowercase for path, which influences plural name. Ensure kind is Organization.
 // +kubebuilder:resource:path=organizations,scope=Cluster,categories=datum,singular=organization
-// +kubebuilder:metadata:annotations="discovery.miloapis.com/parent-contexts=Platform"
 // +kubebuilder:printcolumn:name="Display Name",type="string",JSONPath=".metadata.annotations.kubernetes\\.io\\/display-name"
 // +kubebuilder:printcolumn:name="Type",type="string",JSONPath=".spec.type"
 // +kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.conditions[?(@.type=='Ready')].status"

--- a/pkg/apis/resourcemanager/v1alpha1/organization_types.go
+++ b/pkg/apis/resourcemanager/v1alpha1/organization_types.go
@@ -37,7 +37,7 @@ type OrganizationStatus struct {
 // +kubebuilder:subresource:status
 // Use lowercase for path, which influences plural name. Ensure kind is Organization.
 // +kubebuilder:resource:path=organizations,scope=Cluster,categories=datum,singular=organization
-// +kubebuilder:metadata:annotations=discovery.miloapis.com/parent-contexts=Root
+// +kubebuilder:metadata:annotations="discovery.miloapis.com/parent-contexts=Platform"
 // +kubebuilder:printcolumn:name="Display Name",type="string",JSONPath=".metadata.annotations.kubernetes\\.io\\/display-name"
 // +kubebuilder:printcolumn:name="Type",type="string",JSONPath=".spec.type"
 // +kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.conditions[?(@.type=='Ready')].status"

--- a/pkg/apis/resourcemanager/v1alpha1/organization_types.go
+++ b/pkg/apis/resourcemanager/v1alpha1/organization_types.go
@@ -43,6 +43,7 @@ type OrganizationStatus struct {
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=".metadata.creationTimestamp"
 // Organization is the Schema for the Organizations API
 // +kubebuilder:object:root=true
+// +kubebuilder:metadata:annotations="discovery.miloapis.com/parent-contexts=Platform"
 type Organization struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/pkg/apis/resourcemanager/v1alpha1/organizationmembership_types.go
+++ b/pkg/apis/resourcemanager/v1alpha1/organizationmembership_types.go
@@ -58,6 +58,7 @@ import (
 // +kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.conditions[?(@.type=='Ready')].status"
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 // +kubebuilder:resource:path=organizationmemberships,scope=Namespaced,singular=organizationmembership
+// +kubebuilder:metadata:annotations="discovery.miloapis.com/parent-contexts=Organization,User"
 // +kubebuilder:selectablefield:JSONPath=".spec.userRef.name"
 // +kubebuilder:selectablefield:JSONPath=".spec.organizationRef.name"
 type OrganizationMembership struct {

--- a/pkg/apis/resourcemanager/v1alpha1/organizationmembership_types.go
+++ b/pkg/apis/resourcemanager/v1alpha1/organizationmembership_types.go
@@ -58,9 +58,9 @@ import (
 // +kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.conditions[?(@.type=='Ready')].status"
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 // +kubebuilder:resource:path=organizationmemberships,scope=Namespaced,singular=organizationmembership
-// +kubebuilder:metadata:annotations="discovery.miloapis.com/parent-contexts=Organization,User"
 // +kubebuilder:selectablefield:JSONPath=".spec.userRef.name"
 // +kubebuilder:selectablefield:JSONPath=".spec.organizationRef.name"
+// +kubebuilder:metadata:annotations="discovery.miloapis.com/parent-contexts=Organization,User"
 type OrganizationMembership struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/pkg/apis/resourcemanager/v1alpha1/project_types.go
+++ b/pkg/apis/resourcemanager/v1alpha1/project_types.go
@@ -56,6 +56,7 @@ const (
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:scope=Cluster
+// +kubebuilder:metadata:annotations=discovery.miloapis.com/parent-contexts=Organization
 
 // Project is the Schema for the projects API.
 // +kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.conditions[?(@.type=='Ready')].status"

--- a/pkg/apis/resourcemanager/v1alpha1/project_types.go
+++ b/pkg/apis/resourcemanager/v1alpha1/project_types.go
@@ -56,7 +56,7 @@ const (
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:scope=Cluster
-// +kubebuilder:metadata:annotations=discovery.miloapis.com/parent-contexts=Organization
+// +kubebuilder:metadata:annotations="discovery.miloapis.com/parent-contexts=Organization"
 
 // Project is the Schema for the projects API.
 // +kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.conditions[?(@.type=='Ready')].status"

--- a/pkg/apis/resourcemanager/v1alpha1/project_types.go
+++ b/pkg/apis/resourcemanager/v1alpha1/project_types.go
@@ -56,11 +56,11 @@ const (
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:scope=Cluster
-// +kubebuilder:metadata:annotations="discovery.miloapis.com/parent-contexts=Organization"
 
 // Project is the Schema for the projects API.
 // +kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.conditions[?(@.type=='Ready')].status"
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
+// +kubebuilder:metadata:annotations="discovery.miloapis.com/parent-contexts=Organization"
 type Project struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -48,6 +48,17 @@ const (
 	// ga: v0.2.0
 	UserIdentities featuregate.Feature = "UserIdentities"
 
+	// DiscoveryContextFilter enables parent-context-aware filtering of API
+	// discovery responses. When enabled, resources tagged with the
+	// discovery.miloapis.com/parent-contexts CRD annotation are hidden from
+	// discovery in contexts where they don't apply (e.g. Organization-only
+	// resources are hidden at the User context). Platform context requests
+	// are never filtered.
+	//
+	// owner: @datum-cloud/platform
+	// alpha: v0.1.0
+	DiscoveryContextFilter featuregate.Feature = "DiscoveryContextFilter"
+
 	// MachineAccountKeys enables the identity.miloapis.com/v1alpha1 MachineAccountKey
 	// virtual API that proxies to an external identity provider for machine account key management.
 	//
@@ -63,6 +74,10 @@ func init() {
 // defaultFeatureGates defines the default state of Milo feature gates.
 // Features are listed in alphabetical order.
 var defaultFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
+	DiscoveryContextFilter: {
+		Default:    false,
+		PreRelease: featuregate.Alpha,
+	},
 	EventsProxy: {
 		Default:    false,
 		PreRelease: featuregate.Alpha,

--- a/pkg/server/discovery/contexts.go
+++ b/pkg/server/discovery/contexts.go
@@ -1,0 +1,113 @@
+// Package discovery implements parent-context-aware filtering of the
+// Kubernetes API discovery responses served by the Milo control plane.
+//
+// Resources opt in to a set of "parent contexts" they are visible in
+// (Organization, Project, User, or Root). Discovery responses are filtered
+// per request based on the URL prefix the client used (e.g.
+// /apis/resourcemanager.miloapis.com/v1alpha1/organizations/{id}/control-plane/...).
+//
+// This is a discovery hint, NOT an enforcement boundary. See
+// docs/discovery-contexts.md for the rationale and the companion admission
+// check.
+package discovery
+
+import (
+	"context"
+	"slices"
+	"strings"
+
+	"go.miloapis.com/milo/pkg/request"
+	"go.miloapis.com/milo/pkg/server/filters"
+)
+
+// ParentContextsAnnotation is the CRD annotation that lists the parent
+// contexts a resource is visible in. Comma-separated, e.g.
+//
+//	discovery.miloapis.com/parent-contexts: "Organization,Project"
+//
+// Missing or empty annotation means "visible in all contexts" — chosen so
+// that pre-existing CRDs and external CRDs that have not adopted the marker
+// continue to behave exactly as before.
+const ParentContextsAnnotation = "discovery.miloapis.com/parent-contexts"
+
+// AllContextsWildcard, when present in the annotation value, is equivalent to
+// omitting the annotation: visible in all parent contexts.
+const AllContextsWildcard = "*"
+
+// ParentContext identifies the platform context a request is being made in.
+type ParentContext string
+
+const (
+	// ContextRoot is requests against the cluster root (no /organizations/{id}
+	// or /projects/{id}/control-plane prefix). This is where org-level lookup,
+	// user self-service, and platform-wide resources live.
+	ContextRoot ParentContext = "Root"
+
+	// ContextOrganization is requests routed through
+	// /apis/resourcemanager.miloapis.com/v1alpha1/organizations/{id}/control-plane/...
+	ContextOrganization ParentContext = "Organization"
+
+	// ContextProject is requests routed through .../projects/{id}/control-plane/...
+	ContextProject ParentContext = "Project"
+
+	// ContextUser is requests routed through
+	// /apis/iam.miloapis.com/v1alpha1/users/{id}/control-plane/...
+	ContextUser ParentContext = "User"
+)
+
+// FromRequest returns the parent context of the current request based on the
+// values stashed on the context by the existing path-routing handlers.
+//
+// Project takes precedence over Organization (matches the existing
+// authorization decorator order in cmd/milo/apiserver/config.go).
+func FromRequest(ctx context.Context) ParentContext {
+	if _, ok := request.ProjectID(ctx); ok {
+		return ContextProject
+	}
+	if _, ok := filters.OrganizationID(ctx); ok {
+		return ContextOrganization
+	}
+	if _, ok := filters.UserID(ctx); ok {
+		return ContextUser
+	}
+	return ContextRoot
+}
+
+// ParseContexts parses the annotation value into a set of ParentContexts.
+// Comma OR semicolon separated — semicolons let Go-defined types use
+// `+kubebuilder:metadata:annotations` markers without escaping commas, which
+// controller-gen treats as its own field delimiter.
+//
+// An empty input or one containing the wildcard returns nil, which callers
+// should treat as "visible in all contexts".
+func ParseContexts(annotation string) []ParentContext {
+	annotation = strings.TrimSpace(annotation)
+	if annotation == "" {
+		return nil
+	}
+	out := make([]ParentContext, 0, 4)
+	for _, raw := range strings.FieldsFunc(annotation, func(r rune) bool { return r == ',' || r == ';' }) {
+		v := strings.TrimSpace(raw)
+		if v == "" {
+			continue
+		}
+		if v == AllContextsWildcard {
+			return nil
+		}
+		out = append(out, ParentContext(v))
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// Matches reports whether a resource tagged with `allowed` should be visible
+// in the given current context. A nil/empty `allowed` is the "all contexts"
+// wildcard.
+func Matches(allowed []ParentContext, current ParentContext) bool {
+	if len(allowed) == 0 {
+		return true
+	}
+	return slices.Contains(allowed, current)
+}

--- a/pkg/server/discovery/contexts.go
+++ b/pkg/server/discovery/contexts.go
@@ -2,7 +2,7 @@
 // Kubernetes API discovery responses served by the Milo control plane.
 //
 // Resources opt in to a set of "parent contexts" they are visible in
-// (Organization, Project, User, or Root). Discovery responses are filtered
+// (Organization, Project, User, or Platform). Discovery responses are filtered
 // per request based on the URL prefix the client used (e.g.
 // /apis/resourcemanager.miloapis.com/v1alpha1/organizations/{id}/control-plane/...).
 //
@@ -38,10 +38,10 @@ const AllContextsWildcard = "*"
 type ParentContext string
 
 const (
-	// ContextRoot is requests against the cluster root (no /organizations/{id}
-	// or /projects/{id}/control-plane prefix). This is where org-level lookup,
-	// user self-service, and platform-wide resources live.
-	ContextRoot ParentContext = "Root"
+	// ContextPlatform is requests against the platform root (no
+	// /organizations/{id} or /projects/{id}/control-plane prefix). This is
+	// where platform-wide resources like Organizations and Users live.
+	ContextPlatform ParentContext = "Platform"
 
 	// ContextOrganization is requests routed through
 	// /apis/resourcemanager.miloapis.com/v1alpha1/organizations/{id}/control-plane/...
@@ -70,7 +70,7 @@ func FromRequest(ctx context.Context) ParentContext {
 	if _, ok := filters.UserID(ctx); ok {
 		return ContextUser
 	}
-	return ContextRoot
+	return ContextPlatform
 }
 
 // ParseContexts parses the annotation value into a set of ParentContexts.

--- a/pkg/server/discovery/filter.go
+++ b/pkg/server/discovery/filter.go
@@ -1,0 +1,210 @@
+package discovery
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"regexp"
+	"strconv"
+	"strings"
+
+	apidiscoveryv2 "k8s.io/api/apidiscovery/v2"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/klog/v2"
+)
+
+// /apis/{group}/{version} — legacy per-group-version APIResourceList
+var apisGroupVersionRE = regexp.MustCompile(`^/apis/([^/]+)/([^/]+)/?$`)
+
+// DiscoveryContextFilter wraps the apiserver handler chain and filters
+// discovery responses (/apis, /apis/{group}/{version}) so that only resources
+// tagged for the caller's parent context are visible. Resources with no
+// registration are visible everywhere (backwards-compatible).
+//
+// The filter only inspects responses; it never writes its own errors. If
+// anything in the response is unexpected (non-JSON, non-200, malformed) the
+// original bytes are passed through unchanged.
+//
+// IMPORTANT: This is a discovery hint, not an authorization boundary. A
+// client that already knows a hidden resource exists can still POST/GET
+// directly. A companion admission check is required to make this a hard
+// boundary.
+func DiscoveryContextFilter(next http.Handler, registry *Registry) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		// Only filter GETs against the discovery endpoints. Skip until the
+		// registry has loaded so we don't hide resources during apiserver
+		// startup.
+		if req.Method != http.MethodGet || !registry.HasSynced() {
+			next.ServeHTTP(w, req)
+			return
+		}
+
+		path := req.URL.Path
+		switch {
+		case path == "/apis" || path == "/apis/":
+			filterAPIIndex(w, req, next, registry)
+		case apisGroupVersionRE.MatchString(path):
+			filterAPIResourceList(w, req, next, registry)
+		default:
+			next.ServeHTTP(w, req)
+		}
+	})
+}
+
+// filterAPIResourceList filters the per-(group,version) discovery doc.
+func filterAPIResourceList(w http.ResponseWriter, req *http.Request, next http.Handler, registry *Registry) {
+	cw := newCaptureWriter(w)
+	next.ServeHTTP(cw, req)
+
+	if !shouldFilter(cw) {
+		cw.flushUnchanged()
+		return
+	}
+
+	var list metav1.APIResourceList
+	if err := json.Unmarshal(cw.body.Bytes(), &list); err != nil {
+		cw.flushUnchanged()
+		return
+	}
+
+	parentCtx := FromRequest(req.Context())
+	match := apisGroupVersionRE.FindStringSubmatch(req.URL.Path)
+	group := match[1]
+
+	kept := list.APIResources[:0]
+	for _, r := range list.APIResources {
+		// Subresources (e.g. "organizations/status") inherit their owner's
+		// visibility — strip the suffix before lookup.
+		base := r.Name
+		if i := strings.IndexByte(base, '/'); i >= 0 {
+			base = base[:i]
+		}
+		if registry.IsVisible(schema.GroupResource{Group: group, Resource: base}, parentCtx) {
+			kept = append(kept, r)
+		}
+	}
+	list.APIResources = kept
+
+	cw.flushJSON(&list)
+}
+
+// filterAPIIndex filters /apis. Handles both the legacy APIGroupList and the
+// modern aggregated APIGroupDiscoveryList based on Content-Type.
+func filterAPIIndex(w http.ResponseWriter, req *http.Request, next http.Handler, registry *Registry) {
+	cw := newCaptureWriter(w)
+	next.ServeHTTP(cw, req)
+
+	if !shouldFilter(cw) {
+		cw.flushUnchanged()
+		return
+	}
+
+	parentCtx := FromRequest(req.Context())
+
+	// Aggregated discovery (modern kubectl) — APIGroupDiscoveryList.
+	if isAggregatedDiscovery(cw.Header().Get("Content-Type")) {
+		var list apidiscoveryv2.APIGroupDiscoveryList
+		if err := json.Unmarshal(cw.body.Bytes(), &list); err != nil {
+			cw.flushUnchanged()
+			return
+		}
+		filterAggregatedGroups(&list, registry, parentCtx)
+		cw.flushJSON(&list)
+		return
+	}
+
+	// Legacy APIGroupList — we can't tell from the index alone which
+	// resources live in each group, so we leave the group list intact. The
+	// per-(group,version) request will be filtered by filterAPIResourceList.
+	cw.flushUnchanged()
+}
+
+func filterAggregatedGroups(list *apidiscoveryv2.APIGroupDiscoveryList, registry *Registry, parentCtx ParentContext) {
+	keptGroups := list.Items[:0]
+	for _, group := range list.Items {
+		keptVersions := group.Versions[:0]
+		for _, version := range group.Versions {
+			keptResources := version.Resources[:0]
+			for _, r := range version.Resources {
+				if registry.IsVisible(schema.GroupResource{Group: group.Name, Resource: r.Resource}, parentCtx) {
+					keptResources = append(keptResources, r)
+				}
+			}
+			if len(keptResources) > 0 {
+				version.Resources = keptResources
+				keptVersions = append(keptVersions, version)
+			}
+		}
+		if len(keptVersions) > 0 {
+			group.Versions = keptVersions
+			keptGroups = append(keptGroups, group)
+		}
+	}
+	list.Items = keptGroups
+}
+
+func isAggregatedDiscovery(ct string) bool {
+	return strings.Contains(ct, "as=APIGroupDiscoveryList")
+}
+
+func shouldFilter(cw *captureWriter) bool {
+	if cw.status != http.StatusOK && cw.status != 0 {
+		return false
+	}
+	ct := cw.Header().Get("Content-Type")
+	return strings.Contains(ct, "application/json")
+}
+
+// captureWriter buffers the downstream response so we can rewrite it.
+type captureWriter struct {
+	dst    http.ResponseWriter
+	body   bytes.Buffer
+	status int
+}
+
+func newCaptureWriter(dst http.ResponseWriter) *captureWriter {
+	return &captureWriter{dst: dst}
+}
+
+func (c *captureWriter) Header() http.Header { return c.dst.Header() }
+
+func (c *captureWriter) WriteHeader(s int) { c.status = s }
+
+func (c *captureWriter) Write(p []byte) (int, error) {
+	if c.status == 0 {
+		c.status = http.StatusOK
+	}
+	return c.body.Write(p)
+}
+
+// flushUnchanged writes the captured response to the real ResponseWriter
+// verbatim.
+func (c *captureWriter) flushUnchanged() {
+	if c.status == 0 {
+		c.status = http.StatusOK
+	}
+	c.dst.WriteHeader(c.status)
+	if _, err := c.dst.Write(c.body.Bytes()); err != nil {
+		klog.V(4).ErrorS(err, "discovery filter: writing passthrough response")
+	}
+}
+
+// flushJSON serializes obj as JSON and writes it as the response, replacing
+// any captured body. Headers other than Content-Length are preserved.
+func (c *captureWriter) flushJSON(obj any) {
+	out, err := json.Marshal(obj)
+	if err != nil {
+		klog.ErrorS(err, "discovery filter: re-encoding filtered response")
+		c.flushUnchanged()
+		return
+	}
+	c.dst.Header().Set("Content-Length", strconv.Itoa(len(out)))
+	if c.status == 0 {
+		c.status = http.StatusOK
+	}
+	c.dst.WriteHeader(c.status)
+	if _, err := c.dst.Write(out); err != nil {
+		klog.V(4).ErrorS(err, "discovery filter: writing filtered response")
+	}
+}

--- a/pkg/server/discovery/filter.go
+++ b/pkg/server/discovery/filter.go
@@ -32,10 +32,13 @@ var apisGroupVersionRE = regexp.MustCompile(`^/apis/([^/]+)/([^/]+)/?$`)
 // boundary.
 func DiscoveryContextFilter(next http.Handler, registry *Registry) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		// Only filter GETs against the discovery endpoints. Skip until the
-		// registry has loaded so we don't hide resources during apiserver
-		// startup.
-		if req.Method != http.MethodGet || !registry.HasSynced() {
+		// Only filter GETs against the discovery endpoints. Skip when:
+		// - not a GET (mutations don't touch discovery)
+		// - registry hasn't synced yet (fall open during startup)
+		// - request is at Platform context (no parent prefix in URL) —
+		//   controllers, admin tools, and internal clients operate here
+		//   and must see all resources to function correctly
+		if req.Method != http.MethodGet || !registry.HasSynced() || FromRequest(req.Context()) == ContextPlatform {
 			next.ServeHTTP(w, req)
 			return
 		}

--- a/pkg/server/discovery/filter_test.go
+++ b/pkg/server/discovery/filter_test.go
@@ -93,9 +93,9 @@ func TestFilterAPIResourceListByContext(t *testing.T) {
 		wantNames []string // expected resource names (in order kept)
 	}{
 		{
-			name:      "root context hides Organization-only resource",
+			name:      "platform context passes through unfiltered",
 			ctxSetter: func(c context.Context) context.Context { return c },
-			wantNames: []string{"organizations", "organizations/status", "untagged"},
+			wantNames: []string{"organizations", "organizations/status", "projects", "untagged"},
 		},
 		{
 			name:      "project context hides Platform-only and Organization-only",

--- a/pkg/server/discovery/filter_test.go
+++ b/pkg/server/discovery/filter_test.go
@@ -25,7 +25,7 @@ func TestParseContexts(t *testing.T) {
 		{"Organization", []ParentContext{ContextOrganization}},
 		{"Organization,User", []ParentContext{ContextOrganization, ContextUser}},
 		{"Organization;User", []ParentContext{ContextOrganization, ContextUser}},
-		{"  Root , Organization  ", []ParentContext{ContextRoot, ContextOrganization}},
+		{"  Platform , Organization  ", []ParentContext{ContextPlatform, ContextOrganization}},
 		{"Organization,*,Project", nil}, // wildcard short-circuits
 	}
 	for _, tc := range cases {
@@ -38,12 +38,12 @@ func TestParseContexts(t *testing.T) {
 
 func TestRegistryStaticAndCRD(t *testing.T) {
 	r := NewRegistry()
-	r.RegisterStatic(schema.GroupResource{Group: "core", Resource: "configmaps"}, ContextRoot)
+	r.RegisterStatic(schema.GroupResource{Group: "core", Resource: "configmaps"}, ContextPlatform)
 	// Simulate a CRD entry by writing directly (informer path is exercised
 	// implicitly elsewhere; this keeps the test hermetic).
 	r.crd[schema.GroupResource{Group: "resourcemanager.miloapis.com", Resource: "projects"}] = []ParentContext{ContextOrganization}
 
-	if !r.IsVisible(schema.GroupResource{Group: "core", Resource: "configmaps"}, ContextRoot) {
+	if !r.IsVisible(schema.GroupResource{Group: "core", Resource: "configmaps"}, ContextPlatform) {
 		t.Error("static registration should be visible in matching context")
 	}
 	if r.IsVisible(schema.GroupResource{Group: "core", Resource: "configmaps"}, ContextProject) {
@@ -52,7 +52,7 @@ func TestRegistryStaticAndCRD(t *testing.T) {
 	if !r.IsVisible(schema.GroupResource{Group: "resourcemanager.miloapis.com", Resource: "projects"}, ContextOrganization) {
 		t.Error("CRD registration should be visible in matching context")
 	}
-	if r.IsVisible(schema.GroupResource{Group: "resourcemanager.miloapis.com", Resource: "projects"}, ContextRoot) {
+	if r.IsVisible(schema.GroupResource{Group: "resourcemanager.miloapis.com", Resource: "projects"}, ContextPlatform) {
 		t.Error("CRD registration should NOT be visible at root")
 	}
 	// Unregistered resource → visible everywhere (backwards-compatible).
@@ -65,8 +65,8 @@ func TestFilterAPIResourceListByContext(t *testing.T) {
 	registry := NewRegistry()
 	// Mark "projects" as Organization-only.
 	registry.crd[schema.GroupResource{Group: "resourcemanager.miloapis.com", Resource: "projects"}] = []ParentContext{ContextOrganization}
-	// Mark "organizations" as Root-only.
-	registry.crd[schema.GroupResource{Group: "resourcemanager.miloapis.com", Resource: "organizations"}] = []ParentContext{ContextRoot}
+	// Mark "organizations" as Platform-only.
+	registry.crd[schema.GroupResource{Group: "resourcemanager.miloapis.com", Resource: "organizations"}] = []ParentContext{ContextPlatform}
 	registry.hasInit = true
 
 	// Inner handler that returns a synthetic APIResourceList.
@@ -98,7 +98,7 @@ func TestFilterAPIResourceListByContext(t *testing.T) {
 			wantNames: []string{"organizations", "organizations/status", "untagged"},
 		},
 		{
-			name:      "project context hides Root-only and Organization-only",
+			name:      "project context hides Platform-only and Organization-only",
 			ctxSetter: func(c context.Context) context.Context { return request.WithProject(c, "p1") },
 			wantNames: []string{"untagged"},
 		},

--- a/pkg/server/discovery/filter_test.go
+++ b/pkg/server/discovery/filter_test.go
@@ -1,0 +1,141 @@
+package discovery
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"go.miloapis.com/milo/pkg/request"
+)
+
+func TestParseContexts(t *testing.T) {
+	cases := []struct {
+		in   string
+		want []ParentContext
+	}{
+		{"", nil},
+		{"   ", nil},
+		{"*", nil},
+		{"Organization", []ParentContext{ContextOrganization}},
+		{"Organization,User", []ParentContext{ContextOrganization, ContextUser}},
+		{"Organization;User", []ParentContext{ContextOrganization, ContextUser}},
+		{"  Root , Organization  ", []ParentContext{ContextRoot, ContextOrganization}},
+		{"Organization,*,Project", nil}, // wildcard short-circuits
+	}
+	for _, tc := range cases {
+		got := ParseContexts(tc.in)
+		if !equalContexts(got, tc.want) {
+			t.Errorf("ParseContexts(%q) = %v, want %v", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestRegistryStaticAndCRD(t *testing.T) {
+	r := NewRegistry()
+	r.RegisterStatic(schema.GroupResource{Group: "core", Resource: "configmaps"}, ContextRoot)
+	// Simulate a CRD entry by writing directly (informer path is exercised
+	// implicitly elsewhere; this keeps the test hermetic).
+	r.crd[schema.GroupResource{Group: "resourcemanager.miloapis.com", Resource: "projects"}] = []ParentContext{ContextOrganization}
+
+	if !r.IsVisible(schema.GroupResource{Group: "core", Resource: "configmaps"}, ContextRoot) {
+		t.Error("static registration should be visible in matching context")
+	}
+	if r.IsVisible(schema.GroupResource{Group: "core", Resource: "configmaps"}, ContextProject) {
+		t.Error("static registration should NOT be visible in non-matching context")
+	}
+	if !r.IsVisible(schema.GroupResource{Group: "resourcemanager.miloapis.com", Resource: "projects"}, ContextOrganization) {
+		t.Error("CRD registration should be visible in matching context")
+	}
+	if r.IsVisible(schema.GroupResource{Group: "resourcemanager.miloapis.com", Resource: "projects"}, ContextRoot) {
+		t.Error("CRD registration should NOT be visible at root")
+	}
+	// Unregistered resource → visible everywhere (backwards-compatible).
+	if !r.IsVisible(schema.GroupResource{Group: "x", Resource: "y"}, ContextProject) {
+		t.Error("unregistered resource should be visible by default")
+	}
+}
+
+func TestFilterAPIResourceListByContext(t *testing.T) {
+	registry := NewRegistry()
+	// Mark "projects" as Organization-only.
+	registry.crd[schema.GroupResource{Group: "resourcemanager.miloapis.com", Resource: "projects"}] = []ParentContext{ContextOrganization}
+	// Mark "organizations" as Root-only.
+	registry.crd[schema.GroupResource{Group: "resourcemanager.miloapis.com", Resource: "organizations"}] = []ParentContext{ContextRoot}
+	registry.hasInit = true
+
+	// Inner handler that returns a synthetic APIResourceList.
+	inner := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		body, _ := json.Marshal(metav1.APIResourceList{
+			TypeMeta:     metav1.TypeMeta{Kind: "APIResourceList", APIVersion: "v1"},
+			GroupVersion: "resourcemanager.miloapis.com/v1alpha1",
+			APIResources: []metav1.APIResource{
+				{Name: "organizations", Namespaced: false, Kind: "Organization"},
+				{Name: "organizations/status", Namespaced: false, Kind: "Organization"},
+				{Name: "projects", Namespaced: false, Kind: "Project"},
+				{Name: "untagged", Namespaced: false, Kind: "Untagged"},
+			},
+		})
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(body)
+	})
+	handler := DiscoveryContextFilter(inner, registry)
+
+	cases := []struct {
+		name      string
+		ctxSetter func(context.Context) context.Context
+		wantNames []string // expected resource names (in order kept)
+	}{
+		{
+			name:      "root context hides Organization-only resource",
+			ctxSetter: func(c context.Context) context.Context { return c },
+			wantNames: []string{"organizations", "organizations/status", "untagged"},
+		},
+		{
+			name:      "project context hides Root-only and Organization-only",
+			ctxSetter: func(c context.Context) context.Context { return request.WithProject(c, "p1") },
+			wantNames: []string{"untagged"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/apis/resourcemanager.miloapis.com/v1alpha1", nil)
+			req = req.WithContext(tc.ctxSetter(req.Context()))
+			rr := httptest.NewRecorder()
+			handler.ServeHTTP(rr, req)
+
+			if rr.Code != http.StatusOK {
+				t.Fatalf("status = %d, want 200; body=%s", rr.Code, rr.Body.String())
+			}
+			var out metav1.APIResourceList
+			if err := json.Unmarshal(rr.Body.Bytes(), &out); err != nil {
+				t.Fatalf("decode response: %v", err)
+			}
+			got := make([]string, len(out.APIResources))
+			for i, r := range out.APIResources {
+				got[i] = r.Name
+			}
+			if strings.Join(got, ",") != strings.Join(tc.wantNames, ",") {
+				t.Errorf("filtered names = %v, want %v", got, tc.wantNames)
+			}
+		})
+	}
+}
+
+func equalContexts(a, b []ParentContext) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/server/discovery/registry.go
+++ b/pkg/server/discovery/registry.go
@@ -1,0 +1,151 @@
+package discovery
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apiextensionsinformers "k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog/v2"
+)
+
+// Registry is the source of truth for "which parent contexts is this resource
+// visible in." It merges two inputs:
+//
+//  1. CRD annotations — for resources installed through the apiextensions API
+//     (both Milo's bundled CRDs and any CRDs installed by external services
+//     that build on Milo). Watched live via an informer.
+//
+//  2. Static registrations — for built-in/aggregated APIs (e.g. core/v1,
+//     identity.miloapis.com sessions) that aren't backed by CRDs. Registered
+//     once at apiserver startup with RegisterStatic.
+//
+// Lookups return the union: a static registration sets a baseline that a CRD
+// annotation can extend but not contradict. (In practice no resource has
+// both, since static is for non-CRD types.)
+//
+// Resources with no registration in either source are treated as visible in
+// all contexts, so existing CRDs and external CRDs that haven't adopted the
+// marker continue to behave as before.
+type Registry struct {
+	mu      sync.RWMutex
+	crd     map[schema.GroupResource][]ParentContext
+	static  map[schema.GroupResource][]ParentContext
+	hasInit bool
+}
+
+// NewRegistry creates an empty registry. Call RegisterStatic for any built-in
+// APIs, then Run with an informer factory to populate the CRD-derived map.
+func NewRegistry() *Registry {
+	return &Registry{
+		crd:    map[schema.GroupResource][]ParentContext{},
+		static: map[schema.GroupResource][]ParentContext{},
+	}
+}
+
+// RegisterStatic records the parent contexts for a built-in or aggregated API
+// that is not backed by a CRD. Safe to call before Run.
+func (r *Registry) RegisterStatic(gr schema.GroupResource, contexts ...ParentContext) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if len(contexts) == 0 {
+		delete(r.static, gr)
+		return
+	}
+	r.static[gr] = append([]ParentContext(nil), contexts...)
+}
+
+// AllowedContexts returns the parent contexts a resource should be visible
+// in, or nil if it should be visible everywhere.
+func (r *Registry) AllowedContexts(gr schema.GroupResource) []ParentContext {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	if v, ok := r.static[gr]; ok {
+		return v
+	}
+	if v, ok := r.crd[gr]; ok {
+		return v
+	}
+	return nil
+}
+
+// IsVisible is a convenience wrapper combining AllowedContexts + Matches.
+func (r *Registry) IsVisible(gr schema.GroupResource, current ParentContext) bool {
+	return Matches(r.AllowedContexts(gr), current)
+}
+
+// HasSynced reports whether the CRD informer has completed its initial list.
+// Discovery filtering should fall open (visible) until this is true to avoid
+// hiding resources during apiserver startup.
+func (r *Registry) HasSynced() bool {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.hasInit
+}
+
+// Run starts watching CRDs from the supplied informer factory. It blocks
+// until ctx is cancelled. Caller must invoke factory.Start(...) separately
+// (or use the same factory for other consumers).
+func (r *Registry) Run(ctx context.Context, factory apiextensionsinformers.SharedInformerFactory) error {
+	informer := factory.Apiextensions().V1().CustomResourceDefinitions().Informer()
+
+	_, err := informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    func(obj any) { r.upsertFromObj(obj) },
+		UpdateFunc: func(_, obj any) { r.upsertFromObj(obj) },
+		DeleteFunc: func(obj any) { r.deleteFromObj(obj) },
+	})
+	if err != nil {
+		return fmt.Errorf("registering CRD event handler: %w", err)
+	}
+
+	if !cache.WaitForCacheSync(ctx.Done(), informer.HasSynced) {
+		return fmt.Errorf("CRD informer cache failed to sync")
+	}
+
+	r.mu.Lock()
+	r.hasInit = true
+	r.mu.Unlock()
+
+	klog.InfoS("Discovery context registry synced", "crdEntries", len(r.crd))
+	<-ctx.Done()
+	return nil
+}
+
+func (r *Registry) upsertFromObj(obj any) {
+	crd, ok := obj.(*apiextensionsv1.CustomResourceDefinition)
+	if !ok {
+		return
+	}
+	gr := schema.GroupResource{Group: crd.Spec.Group, Resource: crd.Spec.Names.Plural}
+	contexts := ParseContexts(crd.Annotations[ParentContextsAnnotation])
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if contexts == nil {
+		// Wildcard / unset — drop any prior entry so lookup falls through
+		// to "visible everywhere".
+		delete(r.crd, gr)
+		return
+	}
+	r.crd[gr] = contexts
+}
+
+func (r *Registry) deleteFromObj(obj any) {
+	var crd *apiextensionsv1.CustomResourceDefinition
+	switch v := obj.(type) {
+	case *apiextensionsv1.CustomResourceDefinition:
+		crd = v
+	case cache.DeletedFinalStateUnknown:
+		crd, _ = v.Obj.(*apiextensionsv1.CustomResourceDefinition)
+	}
+	if crd == nil {
+		return
+	}
+	gr := schema.GroupResource{Group: crd.Spec.Group, Resource: crd.Spec.Names.Plural}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	delete(r.crd, gr)
+}

--- a/pkg/server/filters/organizationmembership.go
+++ b/pkg/server/filters/organizationmembership.go
@@ -32,6 +32,14 @@ const (
 	UserIDContextKey = "userID"
 )
 
+// UserID returns the user ID stashed on the request context by
+// UserContextHandler, if any. Used by middleware that needs to detect whether
+// the current request is being made in the context of a user.
+func UserID(ctx context.Context) (string, bool) {
+	id, ok := ctx.Value(UserIDContextKey).(string)
+	return id, ok
+}
+
 // UserContextHandler will react to requests sent to a pseudo API path of
 // `/apis/iam.miloapis.com/v1alpha1/users/` and injects the provided user ID
 // into a request context value. This value will then be used by

--- a/pkg/server/filters/organizations.go
+++ b/pkg/server/filters/organizations.go
@@ -24,6 +24,14 @@ type key int
 
 const orgId key = iota
 
+// OrganizationID returns the organization ID stashed on the request context by
+// OrganizationContextHandler, if any. Used by middleware that needs to detect
+// whether the current request is being made in the context of an organization.
+func OrganizationID(ctx context.Context) (string, bool) {
+	id, ok := ctx.Value(orgId).(string)
+	return id, ok
+}
+
 // OrganizationContextHandler will react to requests sent to a pseudo API path
 // of `/apis/resourcemanager.miloapis.com/v1alpha1/organizations/` and injects
 // the provided organization ID into a request context value. This value will

--- a/test/discovery-context-filter/02-external-crd.yaml
+++ b/test/discovery-context-filter/02-external-crd.yaml
@@ -1,0 +1,27 @@
+# Models an external service tagging its CRD with the parent-contexts
+# annotation. We don't use a +kubebuilder marker here — this is the path a
+# third-party service would take when installing its API on top of Milo.
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: discoverywidgets.discovery-filter-test.example.com
+  annotations:
+    discovery.miloapis.com/parent-contexts: "Organization"
+spec:
+  group: discovery-filter-test.example.com
+  scope: Namespaced
+  names:
+    kind: DiscoveryWidget
+    plural: discoverywidgets
+    singular: discoverywidget
+    listKind: DiscoveryWidgetList
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object

--- a/test/discovery-context-filter/chainsaw-test.yaml
+++ b/test/discovery-context-filter/chainsaw-test.yaml
@@ -7,7 +7,7 @@ spec:
     End-to-end test for parent-context-aware API discovery.
 
     Verifies that the discovery endpoint response is filtered per parent
-    context (Root vs Organization), driven by the
+    context (Platform vs Organization), driven by the
     `discovery.miloapis.com/parent-contexts` CRD annotation. Exercises both
     the bundled-CRD path (organizations, projects, organizationmemberships)
     and the third-party-CRD path (a synthetic DiscoveryWidget CRD installed
@@ -20,7 +20,7 @@ spec:
 
     Expectations:
       At ROOT:
-        - organizations            present (tagged Root)
+        - organizations            present (tagged Platform)
         - projects                 hidden (tagged Organization)
         - organizationmemberships  hidden (tagged Organization,User)
         - discoverywidgets         hidden (tagged Organization)
@@ -74,7 +74,7 @@ spec:
             duration: 3s
 
     - name: verify-root-context-discovery
-      description: Root context should expose organizations but hide Organization-tagged resources.
+      description: Platform context should expose organizations but hide Organization-tagged resources.
       cluster: root
       try:
         - script:
@@ -85,7 +85,7 @@ spec:
                 "/apis/resourcemanager.miloapis.com/v1alpha1" \
                 | jq -r '.resources[].name' | sort -u)
 
-              echo "Root resourcemanager resources:"
+              echo "Platform resourcemanager resources:"
               echo "$RM_NAMES"
 
               echo "$RM_NAMES" | grep -qx "organizations" \
@@ -101,7 +101,7 @@ spec:
                 "/apis/discovery-filter-test.example.com/v1alpha1" \
                 | jq -r '.resources[].name // empty' | sort -u)
 
-              echo "Root example.com resources: ${WIDGET_NAMES:-<none>}"
+              echo "Platform example.com resources: ${WIDGET_NAMES:-<none>}"
 
               [ -z "$WIDGET_NAMES" ] \
                 || { echo "FAIL: discoverywidgets should be hidden at root"; exit 1; }
@@ -109,7 +109,7 @@ spec:
               echo "PASS: root-context discovery"
 
     - name: verify-org-context-discovery
-      description: Organization context should expose Organization-tagged resources and hide Root-tagged ones.
+      description: Organization context should expose Organization-tagged resources and hide Platform-tagged ones.
       cluster: org
       try:
         - script:

--- a/test/discovery-context-filter/chainsaw-test.yaml
+++ b/test/discovery-context-filter/chainsaw-test.yaml
@@ -1,0 +1,177 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: discovery-context-filter
+spec:
+  description: |
+    End-to-end test for parent-context-aware API discovery.
+
+    Verifies that the discovery endpoint response is filtered per parent
+    context (Root vs Organization), driven by the
+    `discovery.miloapis.com/parent-contexts` CRD annotation. Exercises both
+    the bundled-CRD path (organizations, projects, organizationmemberships)
+    and the third-party-CRD path (a synthetic DiscoveryWidget CRD installed
+    mid-test).
+
+    The discovery filter is URL-driven — it consults only the request path
+    prefix — so this test does not need a real Organization to exist. The
+    kubeconfig points at `.../organizations/demo-discovery-filter-org/control-plane`
+    and the filter honours that alone.
+
+    Expectations:
+      At ROOT:
+        - organizations            present (tagged Root)
+        - projects                 hidden (tagged Organization)
+        - organizationmemberships  hidden (tagged Organization,User)
+        - discoverywidgets         hidden (tagged Organization)
+
+      At ORGANIZATION:
+        - organizations            hidden
+        - projects                 present
+        - organizationmemberships  present
+        - discoverywidgets         present
+
+      At USER:
+        - organizations            hidden
+        - projects                 hidden
+        - organizationmemberships  present (multi-context)
+        - discoverywidgets         hidden
+
+  clusters:
+    root:
+      kubeconfig: kubeconfig-root
+    org:
+      kubeconfig: kubeconfig-org
+    user:
+      kubeconfig: kubeconfig-user
+
+  concurrent: false
+  # The test only touches a cluster-scoped CRD; no ephemeral namespace is
+  # needed and creating one slows teardown when org/project controllers are
+  # unhealthy.
+  namespace: default
+  skipDelete: false
+
+  steps:
+    - name: install-external-crd
+      description: Install a third-party CRD tagged for the Organization context.
+      cluster: root
+      try:
+        - apply:
+            file: 02-external-crd.yaml
+        - wait:
+            apiVersion: apiextensions.k8s.io/v1
+            kind: CustomResourceDefinition
+            name: discoverywidgets.discovery-filter-test.example.com
+            timeout: 30s
+            for:
+              condition:
+                name: Established
+                value: "True"
+        # The registry informer observes CRD events eventually; give it a
+        # short window so the annotation is in the map before we query.
+        - sleep:
+            duration: 3s
+
+    - name: verify-root-context-discovery
+      description: Root context should expose organizations but hide Organization-tagged resources.
+      cluster: root
+      try:
+        - script:
+            timeout: 30s
+            content: |
+              set -e
+              RM_NAMES=$(kubectl --kubeconfig=kubeconfig-root get --raw \
+                "/apis/resourcemanager.miloapis.com/v1alpha1" \
+                | jq -r '.resources[].name' | sort -u)
+
+              echo "Root resourcemanager resources:"
+              echo "$RM_NAMES"
+
+              echo "$RM_NAMES" | grep -qx "organizations" \
+                || { echo "FAIL: organizations missing at root"; exit 1; }
+
+              ! echo "$RM_NAMES" | grep -qx "projects" \
+                || { echo "FAIL: projects should be hidden at root"; exit 1; }
+
+              ! echo "$RM_NAMES" | grep -qx "organizationmemberships" \
+                || { echo "FAIL: organizationmemberships should be hidden at root"; exit 1; }
+
+              WIDGET_NAMES=$(kubectl --kubeconfig=kubeconfig-root get --raw \
+                "/apis/discovery-filter-test.example.com/v1alpha1" \
+                | jq -r '.resources[].name // empty' | sort -u)
+
+              echo "Root example.com resources: ${WIDGET_NAMES:-<none>}"
+
+              [ -z "$WIDGET_NAMES" ] \
+                || { echo "FAIL: discoverywidgets should be hidden at root"; exit 1; }
+
+              echo "PASS: root-context discovery"
+
+    - name: verify-org-context-discovery
+      description: Organization context should expose Organization-tagged resources and hide Root-tagged ones.
+      cluster: org
+      try:
+        - script:
+            timeout: 30s
+            content: |
+              set -e
+              RM_NAMES=$(kubectl --kubeconfig=kubeconfig-org get --raw \
+                "/apis/resourcemanager.miloapis.com/v1alpha1" \
+                | jq -r '.resources[].name' | sort -u)
+
+              echo "Org resourcemanager resources:"
+              echo "$RM_NAMES"
+
+              echo "$RM_NAMES" | grep -qx "projects" \
+                || { echo "FAIL: projects missing in org context"; exit 1; }
+
+              echo "$RM_NAMES" | grep -qx "organizationmemberships" \
+                || { echo "FAIL: organizationmemberships missing in org context"; exit 1; }
+
+              ! echo "$RM_NAMES" | grep -qx "organizations" \
+                || { echo "FAIL: organizations should be hidden in org context"; exit 1; }
+
+              WIDGET_NAMES=$(kubectl --kubeconfig=kubeconfig-org get --raw \
+                "/apis/discovery-filter-test.example.com/v1alpha1" \
+                | jq -r '.resources[].name' | sort -u)
+
+              echo "Org example.com resources: $WIDGET_NAMES"
+
+              echo "$WIDGET_NAMES" | grep -qx "discoverywidgets" \
+                || { echo "FAIL: discoverywidgets missing in org context"; exit 1; }
+
+              echo "PASS: org-context discovery"
+
+    - name: verify-user-context-discovery
+      description: User context should expose multi-context resources (organizationmemberships) and hide the rest.
+      cluster: user
+      try:
+        - script:
+            timeout: 30s
+            content: |
+              set -e
+              RM_NAMES=$(kubectl --kubeconfig=kubeconfig-user get --raw \
+                "/apis/resourcemanager.miloapis.com/v1alpha1" \
+                | jq -r '.resources[].name' | sort -u)
+
+              echo "User resourcemanager resources:"
+              echo "$RM_NAMES"
+
+              echo "$RM_NAMES" | grep -qx "organizationmemberships" \
+                || { echo "FAIL: organizationmemberships missing in user context (multi-context annotation)"; exit 1; }
+
+              ! echo "$RM_NAMES" | grep -qx "organizations" \
+                || { echo "FAIL: organizations should be hidden in user context"; exit 1; }
+
+              ! echo "$RM_NAMES" | grep -qx "projects" \
+                || { echo "FAIL: projects should be hidden in user context"; exit 1; }
+
+              echo "PASS: user-context discovery"
+
+    - name: cleanup-external-crd
+      description: Remove the external CRD so the registry forgets the entry.
+      cluster: root
+      try:
+        - delete:
+            file: 02-external-crd.yaml

--- a/test/discovery-context-filter/chainsaw-test.yaml
+++ b/test/discovery-context-filter/chainsaw-test.yaml
@@ -73,8 +73,8 @@ spec:
         - sleep:
             duration: 3s
 
-    - name: verify-root-context-discovery
-      description: Platform context should expose organizations but hide Organization-tagged resources.
+    - name: verify-platform-context-discovery
+      description: Platform context is unfiltered — controllers and admin tools must see all resources.
       cluster: root
       try:
         - script:
@@ -88,14 +88,15 @@ spec:
               echo "Platform resourcemanager resources:"
               echo "$RM_NAMES"
 
+              # Platform context passes through unfiltered — all resources visible.
               echo "$RM_NAMES" | grep -qx "organizations" \
-                || { echo "FAIL: organizations missing at root"; exit 1; }
+                || { echo "FAIL: organizations missing at platform"; exit 1; }
 
-              ! echo "$RM_NAMES" | grep -qx "projects" \
-                || { echo "FAIL: projects should be hidden at root"; exit 1; }
+              echo "$RM_NAMES" | grep -qx "projects" \
+                || { echo "FAIL: projects missing at platform"; exit 1; }
 
-              ! echo "$RM_NAMES" | grep -qx "organizationmemberships" \
-                || { echo "FAIL: organizationmemberships should be hidden at root"; exit 1; }
+              echo "$RM_NAMES" | grep -qx "organizationmemberships" \
+                || { echo "FAIL: organizationmemberships missing at platform"; exit 1; }
 
               WIDGET_NAMES=$(kubectl --kubeconfig=kubeconfig-root get --raw \
                 "/apis/discovery-filter-test.example.com/v1alpha1" \
@@ -103,10 +104,10 @@ spec:
 
               echo "Platform example.com resources: ${WIDGET_NAMES:-<none>}"
 
-              [ -z "$WIDGET_NAMES" ] \
-                || { echo "FAIL: discoverywidgets should be hidden at root"; exit 1; }
+              echo "$WIDGET_NAMES" | grep -qx "discoverywidgets" \
+                || { echo "FAIL: discoverywidgets missing at platform"; exit 1; }
 
-              echo "PASS: root-context discovery"
+              echo "PASS: platform-context discovery (unfiltered)"
 
     - name: verify-org-context-discovery
       description: Organization context should expose Organization-tagged resources and hide Platform-tagged ones.

--- a/test/discovery-context-filter/kubeconfig-org
+++ b/test/discovery-context-filter/kubeconfig-org
@@ -1,0 +1,18 @@
+apiVersion: v1
+clusters:
+- cluster:
+    insecure-skip-tls-verify: true
+    server: https://localhost:30443/apis/resourcemanager.miloapis.com/v1alpha1/organizations/demo-discovery-filter-org/control-plane
+  name: milo-org
+contexts:
+- context:
+    cluster: milo-org
+    user: test-admin
+  name: milo-org
+current-context: milo-org
+kind: Config
+preferences: {}
+users:
+- name: test-admin
+  user:
+    token: test-admin-token

--- a/test/discovery-context-filter/kubeconfig-root
+++ b/test/discovery-context-filter/kubeconfig-root
@@ -1,0 +1,18 @@
+apiVersion: v1
+clusters:
+- cluster:
+    insecure-skip-tls-verify: true
+    server: https://localhost:30443
+  name: milo-root
+contexts:
+- context:
+    cluster: milo-root
+    user: test-admin
+  name: milo-root
+current-context: milo-root
+kind: Config
+preferences: {}
+users:
+- name: test-admin
+  user:
+    token: test-admin-token

--- a/test/discovery-context-filter/kubeconfig-user
+++ b/test/discovery-context-filter/kubeconfig-user
@@ -1,0 +1,18 @@
+apiVersion: v1
+clusters:
+- cluster:
+    insecure-skip-tls-verify: true
+    server: https://localhost:30443/apis/iam.miloapis.com/v1alpha1/users/demo-discovery-user/control-plane
+  name: milo-user
+contexts:
+- context:
+    cluster: milo-user
+    user: test-admin
+  name: milo-user
+current-context: milo-user
+kind: Config
+preferences: {}
+users:
+- name: test-admin
+  user:
+    token: test-admin-token


### PR DESCRIPTION
## Summary

When a user runs `datumctl api-resources` against Milo, they see every API the platform exposes — even the ones that don't apply to where they are. A user browsing their organization sees platform-level APIs mixed in with organization-level ones. A user inside a project sees organization-level APIs they can't act on. It's noise.

This PR lets a resource declare which **parent contexts** it belongs in (Root, Organization, Project, User), and Milo filters discovery responses accordingly — so `datumctl api-resources` only shows the APIs that make sense for whatever URL the caller is using.

## What the user sees

**Before — same list everywhere:**
```
$ datumctl api-resources --api-group=resourcemanager.miloapis.com
NAME                     NAMESPACED   KIND
organizations            false        Organization
organizationmemberships  true         OrganizationMembership
projects                 false        Project
```

**After — scoped to context:**
```
# At the cluster root: just the platform-level APIs
$ datumctl api-resources --api-group=resourcemanager.miloapis.com
NAME             NAMESPACED   KIND
organizations    false        Organization

# Inside an organization: the things you'd do in an org
$ kubectl api-resources --api-group=resourcemanager.miloapis.com  # (org-scoped kubeconfig)
NAME                     NAMESPACED   KIND
organizationmemberships  true         OrganizationMembership
projects                 false        Project
```

## How someone opts a resource in

On a Go-defined type (Milo's own APIs):
```go
// +kubebuilder:metadata:annotations="discovery.miloapis.com/parent-contexts=Organization,User"
type OrganizationMembership struct { ... }
```

On a CRD installed by an external service building on Milo:
```yaml
metadata:
  annotations:
    discovery.miloapis.com/parent-contexts: "Organization"
```

That's the whole contract. No annotation = visible everywhere (so nothing changes until a team opts in). Multiple contexts are comma-separated. Details and the thinking behind the design live in [`docs/architecture/discovery-contexts.md`](../blob/feat/discovery-context-aware-api/docs/architecture/discovery-contexts.md).

## Who this helps

- **Platform users** get a clean `kubectl api-resources` — only the APIs relevant to the URL they're hitting.
- **Service teams building on Milo** tag their CRDs and immediately feel native alongside Milo's own APIs. No new registration step.
- **Documentation and tab-completion** stop drowning users in irrelevant resources they can't use.

## Scope

This is a discovery hint — it changes what the list endpoints return, not what the server accepts. A caller who already knows a GVR can still talk to it directly. Turning this into a hard boundary would mean pairing the filter with an admission check; that's deliberately out of scope for this change and called out in the doc.

Three existing Milo resources are opted in as the first examples: `Organization` (Root), `Project` (Organization), `OrganizationMembership` (Organization + User). Everything else stays visible everywhere until its owner chooses to tag it.

## Follow-up: aggregated apiservers

This PR covers CRDs — Milo's own types and any CRD an external service installs. It does **not** yet cover the aggregated apiservers Milo already proxies (`activity.miloapis.com`, `quota.miloapis.com`, `search.miloapis.com`, `incidents.operations.miloapis.com`, `identity.miloapis.com`). Those are a larger slice of the user-facing surface than CRDs, so coverage is important.

The filter already captures aggregated responses — only the source-of-truth for the mapping is missing. A follow-up PR will add a second registry source that reads an `x-milo-parent-contexts` OpenAPI extension from the aggregated OpenAPI doc each aggregated service already serves. Each aggregated service will get a small companion PR to emit the extension on its schemas. Sequencing this as a follow-up keeps each change small and reviewable.

## Test plan

- [x] Unit tests for parser, registry precedence, and per-context filtering (`go test ./pkg/server/discovery/...`)
- [x] Chainsaw e2e covering Root / Organization / User + an external CRD installed mid-test (`task test:end-to-end -- discovery-context-filter`)
- [x] Manual `kubectl api-resources` against a live dev cluster in all three contexts
- [ ] Reviewer verifies annotations on `Organization`, `Project`, `OrganizationMembership` render correctly after `task generate`

🤖 Generated with [Claude Code](https://claude.com/claude-code)