### PR TITLE
build(ci): publish multi-arch (amd64 + arm64) container image

### DIFF
--- a/.github/workflows/build-apiserver.yaml
+++ b/.github/workflows/build-apiserver.yaml
@@ -15,6 +15,7 @@ jobs:
     uses: datum-cloud/actions/.github/workflows/publish-docker.yaml@v1.8.1
     with:
       image-name: milo
+      platforms: linux/amd64,linux/arm64
     secrets: inherit
 
   publish-kustomize-bundles:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,13 @@
 # Build stage
-FROM golang:1.24 AS builder
+# Use $BUILDPLATFORM so the builder runs natively on the runner's architecture
+# and cross-compiles to $TARGETOS/$TARGETARCH. This makes multi-arch builds
+# (linux/amd64, linux/arm64) fast under buildx without requiring QEMU emulation
+# for the build itself.
+FROM --platform=$BUILDPLATFORM golang:1.24 AS builder
+
+# Provided automatically by BuildKit when using buildx with --platform.
+ARG TARGETOS
+ARG TARGETARCH
 
 WORKDIR /app
 
@@ -20,7 +28,7 @@ ARG VERSION=v0.0.0-master+dev
 ARG GIT_COMMIT=unknown
 ARG GIT_TREE_STATE=dirty
 ARG BUILD_DATE=unknown
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 \
+RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH:-amd64} \
     go build -trimpath -o milo ./cmd/milo
 
 # Final stage: minimal runtime image


### PR DESCRIPTION
## Summary

- Publishes `ghcr.io/datum-cloud/milo` for both `linux/amd64` and `linux/arm64` so Apple Silicon developer machines and arm64 CI runners can pull the image without hitting `ImagePullBackOff: no matching manifest for linux/arm64/v8`.
- Switches the Dockerfile builder to `--platform=$BUILDPLATFORM` and parameterizes `GOOS`/`GOARCH` via `$TARGETOS`/`$TARGETARCH`, enabling fast native cross-compilation under buildx (no QEMU emulation needed for the build step; the runtime stage is `gcr.io/distroless/static`, which is COPY-only).
- Unblocks local e2e for `datum-cloud/resource-metrics` against milo on Apple Silicon.

## Test plan

- [ ] CI `publish-container-image` job succeeds with `platforms: linux/amd64,linux/arm64`.
- [ ] After the next release, `docker manifest inspect ghcr.io/datum-cloud/milo:<next-tag>` lists both `linux/amd64` and `linux/arm64` entries.
- [ ] Pulling `ghcr.io/datum-cloud/milo:<next-tag>` on an arm64 host (Apple Silicon / arm64 Kubernetes node) succeeds and the container starts.

## Notes

- The reusable workflow `datum-cloud/actions/.github/workflows/publish-docker.yaml@v1.8.1` already accepts a `platforms` input and wires it into `docker/setup-buildx-action` and `docker/build-push-action`, so no cross-repo change is required.
- Local validation: `docker buildx build --platform=linux/amd64,linux/arm64 -t milo:multiarch-test .` completed successfully on Apple Silicon (without `--load`, since multi-platform images can't be loaded into the local Docker engine in one shot). The arm64 binary built natively; the amd64 binary was cross-compiled by Go on the arm64 builder. No QEMU was required.
- No follow-ups in other repos.