### PR TITLE
feat: add standalone Kustomization wrapper for milo activity policies

### DIFF
--- a/config/milo/activity/kustomization.yaml
+++ b/config/milo/activity/kustomization.yaml
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+components:
+  - ../../services/identity


### PR DESCRIPTION
## Summary

- Adds `config/milo/activity/kustomization.yaml` as a deploy-ready standalone Kustomization that wraps `config/services/identity`
- Enables FluxCD in the infra repo to deploy the MachineAccount ActivityPolicy by pointing a Flux Kustomization at `config/milo/activity`

## Context

`config/services/identity/` uses `kind: Component` which cannot be used directly as a FluxCD Kustomization `path`. This wrapper provides a standalone `kind: Kustomization` entrypoint following the same convention used by other operators (e.g. dns-operator's `config/milo/activity/`).

## Test plan

- [x] `kustomize build config/milo/activity` renders the MachineAccount ActivityPolicy correctly
- [ ] After merging and wiring up in infra, `datumctl get activitypolicies` shows `iam.miloapis.com-machineaccount`