### PR TITLE
fix: context-aware API discovery now works with datumctl

### DIFF
--- a/pkg/server/discovery/filter.go
+++ b/pkg/server/discovery/filter.go
@@ -105,8 +105,19 @@ func filterAPIIndex(w http.ResponseWriter, req *http.Request, next http.Handler,
 
 	parentCtx := FromRequest(req.Context())
 
-	// Aggregated discovery (modern kubectl) — APIGroupDiscoveryList.
-	if isAggregatedDiscovery(cw.Header().Get("Content-Type")) {
+	// Detect aggregated discovery by Content-Type OR by the response body's
+	// kind field. The Milo API server returns plain application/json rather
+	// than the media type that includes as=APIGroupDiscoveryList, so we cannot
+	// rely on the header alone.
+	var kindProbe struct {
+		Kind string `json:"kind"`
+	}
+	if err := json.Unmarshal(cw.body.Bytes(), &kindProbe); err != nil {
+		cw.flushUnchanged()
+		return
+	}
+
+	if kindProbe.Kind == "APIGroupDiscoveryList" || isAggregatedDiscovery(cw.Header().Get("Content-Type")) {
 		var list apidiscoveryv2.APIGroupDiscoveryList
 		if err := json.Unmarshal(cw.body.Bytes(), &list); err != nil {
 			cw.flushUnchanged()

--- a/pkg/server/discovery/filter.go
+++ b/pkg/server/discovery/filter.go
@@ -105,19 +105,11 @@ func filterAPIIndex(w http.ResponseWriter, req *http.Request, next http.Handler,
 
 	parentCtx := FromRequest(req.Context())
 
-	// Detect aggregated discovery by Content-Type OR by the response body's
-	// kind field. The Milo API server returns plain application/json rather
-	// than the media type that includes as=APIGroupDiscoveryList, so we cannot
-	// rely on the header alone.
-	var kindProbe struct {
-		Kind string `json:"kind"`
-	}
-	if err := json.Unmarshal(cw.body.Bytes(), &kindProbe); err != nil {
-		cw.flushUnchanged()
-		return
-	}
-
-	if kindProbe.Kind == "APIGroupDiscoveryList" || isAggregatedDiscovery(cw.Header().Get("Content-Type")) {
+	// Detect aggregated discovery from the request Accept header. kubectl sends
+	// Accept: application/json;...;as=APIGroupDiscoveryList and a conformant
+	// server echoes it in Content-Type — but checking the request is more
+	// reliable since Milo returns plain application/json in the response.
+	if isAggregatedDiscovery(req.Header.Get("Accept")) {
 		var list apidiscoveryv2.APIGroupDiscoveryList
 		if err := json.Unmarshal(cw.body.Bytes(), &list); err != nil {
 			cw.flushUnchanged()


### PR DESCRIPTION
## What changed

When you run `datumctl api-resources`, the list of resources is now correctly filtered based on your current context — so you only see what's relevant to where you are (organization, project, or user).

## Why it wasn't working

The previous release (#567) introduced context-aware discovery filtering. It worked correctly when tested via direct HTTP calls, but `datumctl api-resources` was still showing everything regardless of context.

The root cause: the filter was checking the response `Content-Type` header to detect the discovery format. In standard Kubernetes, the server echoes back the requested format in `Content-Type` — but Milo returns plain `application/json`, so the filter never recognized the format and skipped filtering entirely.

## The fix

kubectl always declares the format it wants via the request `Accept` header. The filter now checks that instead, which is both more reliable and simpler — no dependency on what the server echoes back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)