### PR TITLE
chore(identity): drop unused location, browser, os SessionStatus fields

### DIFF
--- a/docs/api/identity.md
+++ b/docs/api/identity.md
@@ -74,9 +74,6 @@ This resource provides information about user authentication sessions, including
 | `createdAt` | metav1.Time | The timestamp when the session was created. |
 | `lastUpdatedAt` | *metav1.Time | The last time the provider updated this session, e.g. Zitadel `change_date` (optional). |
 | `userAgent` | string | The client User-Agent string for this session, when the provider supplies it (optional). |
-| `location` | string | Geographic location derived from the session IP, formatted as "City, Country" when both are available. Populated by an external enrichment service; empty when enrichment is unavailable or the IP is unknown (optional). |
-| `browser` | string | Browser name parsed from the session User-Agent string. Populated by an external enrichment service; empty when enrichment is unavailable or the User-Agent is unknown (optional). |
-| `os` | string | Operating system name parsed from the session User-Agent string. Populated by an external enrichment service; empty when enrichment is unavailable or the User-Agent is unknown (optional). |
 
 ---
 

--- a/pkg/apis/identity/v1alpha1/types.go
+++ b/pkg/apis/identity/v1alpha1/types.go
@@ -35,21 +35,6 @@ type SessionStatus struct {
 
 	// UserAgent is the client User-Agent string for this session, if the provider supplies it.
 	UserAgent string `json:"userAgent,omitempty"`
-
-	// Location is the geographic location derived from the session IP, formatted as
-	// "City, Country" when both are available. Populated by an external enrichment
-	// service; empty when enrichment is unavailable or the IP is unknown.
-	Location string `json:"location,omitempty"`
-
-	// Browser is the browser name parsed from the session User-Agent string.
-	// Populated by an external enrichment service; empty when enrichment is
-	// unavailable or the User-Agent is unknown.
-	Browser string `json:"browser,omitempty"`
-
-	// OS is the operating system name parsed from the session User-Agent string.
-	// Populated by an external enrichment service; empty when enrichment is
-	// unavailable or the User-Agent is unknown.
-	OS string `json:"os,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/apis/identity/v1alpha1/zz_generated.openapi.go
+++ b/pkg/apis/identity/v1alpha1/zz_generated.openapi.go
@@ -356,27 +356,6 @@ func schema_pkg_apis_identity_v1alpha1_SessionStatus(ref common.ReferenceCallbac
 							Format:      "",
 						},
 					},
-					"location": {
-						SchemaProps: spec.SchemaProps{
-							Description: "Location is the geographic location derived from the session IP, formatted as \"City, Country\" when both are available. Populated by an external enrichment service; empty when enrichment is unavailable or the IP is unknown.",
-							Type:        []string{"string"},
-							Format:      "",
-						},
-					},
-					"browser": {
-						SchemaProps: spec.SchemaProps{
-							Description: "Browser is the browser name parsed from the session User-Agent string. Populated by an external enrichment service; empty when enrichment is unavailable or the User-Agent is unknown.",
-							Type:        []string{"string"},
-							Format:      "",
-						},
-					},
-					"os": {
-						SchemaProps: spec.SchemaProps{
-							Description: "OS is the operating system name parsed from the session User-Agent string. Populated by an external enrichment service; empty when enrichment is unavailable or the User-Agent is unknown.",
-							Type:        []string{"string"},
-							Format:      "",
-						},
-					},
 				},
 				Required: []string{"userUID", "provider", "createdAt"},
 			},


### PR DESCRIPTION
## Summary
- Removes `location`, `browser`, and `os` from `SessionStatus` (added in #534).
- Keeps `ip`, `fingerprintID`, `lastUpdatedAt`, and `userAgent` — those are the raw fields the auth provider actually populates.
- Regenerates `zz_generated.openapi.go` via \`task generate:openapi:identity\`.
- Hand-edits `docs/api/identity.md` to remove the three rows from the SessionStatus table (this file is hand-maintained because `config/crd/bases/identity/` is empty).

## Why
The session-enrichment topology has been re-aligned: the GraphQL gateway now fetches sessions from this API and produces its own `ExtendedSession` type with geolocation and parsed user-agent attached. The `auth-provider-zitadel` apiserver only writes raw values, so these three derived-data fields on `SessionStatus` are never populated. Leaving them in place would suggest the API surfaces data it doesn't actually carry.

## Companion PRs
- `datum-cloud/auth-provider-zitadel#81` — corrected to expose raw IP / fingerprint / lastUpdatedAt / userAgent only (no enrichment).
- `datum-cloud/graphql-gateway` — new sessions resolver coming next.
- `datum-cloud/infra#2268` — auth-provider gateway-call wiring removed; gateway-side MaxMind plumbing retained.

## Test plan
- [x] \`task generate:code\` and \`task generate:openapi:identity\` clean.
- [x] \`go build ./pkg/apis/...\` clean.
- [ ] After this lands and milo cuts \`v0.24.6\`, bump \`go.miloapis.com/milo\` in auth-provider-zitadel to drop the now-stale dependency on the removed fields (no code changes needed there since the auth provider never set them).