### PR TITLE
fix: register status.userUID field selector for Session

### DIFF
--- a/pkg/apis/identity/scheme.go
+++ b/pkg/apis/identity/scheme.go
@@ -7,12 +7,14 @@ import (
 	"go.miloapis.com/milo/pkg/apis/identity/v1alpha1"
 )
 
-// Install registers the identity API group versions into the provided scheme.
+// Install registers the identity API group versions into the provided scheme,
+// along with FieldLabelConversionFuncs for any selectors served by aggregated
+// apiservers under this group. Without these registrations the milo aggregator
+// pre-rejects requests with the default "is not a known field selector" error
+// before proxying them to the backing apiserver.
 func Install(scheme *runtime.Scheme) {
 	v1alpha1.AddToScheme(scheme)
 
-	// Register valid field selectors for ServiceAccountKey so the generic API
-	// server passes them through to the REST handler instead of rejecting them.
 	_ = scheme.AddFieldLabelConversionFunc(
 		schema.GroupVersionKind{
 			Group:   v1alpha1.SchemeGroupVersion.Group,
@@ -22,6 +24,27 @@ func Install(scheme *runtime.Scheme) {
 		func(label, value string) (string, string, error) {
 			switch label {
 			case "spec.serviceAccountUserName", "metadata.name", "metadata.namespace":
+				return label, value, nil
+			default:
+				return "", "", nil
+			}
+		},
+	)
+
+	// Sessions are listed by callers (e.g. fraud-operator) using
+	// status.userUID=<uid> for cross-user lookups. The auth-provider-zitadel
+	// aggregated apiserver consumes this selector behind a SAR-gated REST
+	// handler, but the request never reaches it without this registration on
+	// the milo aggregator.
+	_ = scheme.AddFieldLabelConversionFunc(
+		schema.GroupVersionKind{
+			Group:   v1alpha1.SchemeGroupVersion.Group,
+			Version: v1alpha1.SchemeGroupVersion.Version,
+			Kind:    "Session",
+		},
+		func(label, value string) (string, string, error) {
+			switch label {
+			case "status.userUID", "metadata.name", "metadata.namespace":
 				return label, value, nil
 			default:
 				return "", "", nil


### PR DESCRIPTION
## Summary

The milo aggregator pre-validates List field selectors against its own scheme before proxying to aggregated apiservers. Without a registered `FieldLabelConversionFunc` for the `Session` GVK, the default convertor rejects `status.userUID` with:

```
"status.userUID" is not a known field selector: only "metadata.name", "metadata.namespace"
```

…and the request never reaches the auth-provider-zitadel apiserver that actually serves sessions. Observed live in staging:

```
LIST /apis/identity.miloapis.com/v1alpha1/sessions?fieldSelector=status.userUID%3D...  resp:400
                                                                                       ^^^^^^^^
```

Companion PR datum-cloud/auth-provider-zitadel#105 already added the same registration on the auth-provider-zitadel side, but that wasn't enough — milo is the entry point and needs to allow the selector through too.

## Fix

Add a `Session` registration to `identity.Install` in `pkg/apis/identity/scheme.go`, mirroring the existing `ServiceAccountKey` block. Allows `status.userUID` (plus the standard `metadata.name`/`metadata.namespace`). SAR enforcement is unchanged — the REST handler in auth-provider-zitadel still gates unauthorized cross-user lookups.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./pkg/apis/identity/...` clean
- [ ] Once merged + rolled to staging milo, fraud-operator's Sessions list returns instead of `400`. Verify via `kubectl -n datum-system logs deploy/milo-apiserver | grep sessions` showing `resp:200`.

## Related

- datum-cloud/auth-provider-zitadel#105 — auth-provider-zitadel side of the same registration (already merged + rolled)
- datum-cloud/auth-provider-zitadel#69 — added the Session REST handler with the `status.userUID` selector consumer
- datum-cloud/fraud#32 — fraud-operator caller that surfaced the bug

🤖 Generated with [Claude Code](https://claude.com/claude-code)
