### PR TITLE
fix: forward field selector to sessions backend

### DIFF
--- a/internal/apiserver/identity/sessions/rest.go
+++ b/internal/apiserver/identity/sessions/rest.go
@@ -49,9 +49,20 @@ func (r *REST) List(ctx context.Context, opts *metainternalversion.ListOptions) 
 		uid = u.GetUID()
 		groups = u.GetGroups()
 	}
-	logger.V(4).Info("Listing sessions", "username", username, "uid", uid, "groups", groups)
-	// ignore selectors; self-scoped list delegated to provider
+	// Forward the caller's selectors to the backend so cross-user lookups
+	// (e.g. status.userUID=<uid>) reach the auth-provider-zitadel REST
+	// handler. The handler runs its own SAR check against milo using the
+	// caller identity preserved via X-Remote-* headers in DynamicProvider.
 	lo := metav1.ListOptions{}
+	if opts != nil {
+		if opts.FieldSelector != nil {
+			lo.FieldSelector = opts.FieldSelector.String()
+		}
+		if opts.LabelSelector != nil {
+			lo.LabelSelector = opts.LabelSelector.String()
+		}
+	}
+	logger.V(4).Info("Listing sessions", "username", username, "uid", uid, "groups", groups, "fieldSelector", lo.FieldSelector, "labelSelector", lo.LabelSelector)
 	res, err := r.backend.ListSessions(ctx, u, &lo)
 	if err != nil {
 		logger.Error(err, "List sessions failed")


### PR DESCRIPTION
## Summary

milo's local Sessions REST handler at `internal/apiserver/identity/sessions/rest.go:43` was building a fresh empty `ListOptions{}` and **discarding the caller's `FieldSelector`** before delegating to the `DynamicProvider` backend that proxies to auth-provider-zitadel. The comment said "ignore selectors; self-scoped list delegated to provider" — written before the cross-user lookup pattern landed (datum-cloud/milo#588 / datum-cloud/auth-provider-zitadel#69).

## Symptom (observed live in staging)

After #588 merged, the field-selector validation 400 went away — but the request still returned no sessions for the targeted user. Tracing showed:

- fraud-operator → milo: `LIST sessions?fieldSelector=status.userUID=<uid>` ✓
- milo local REST handler → backend: `ListOptions{}` (selector dropped)
- backend → auth-provider-zitadel: `LIST sessions?timeout=3s` (no selector)
- auth-provider-zitadel REST handler: `opts.FieldSelector == nil` → falls back to `u.GetUID()` → caller is `system:control@fraud.miloapis.com` (service account, no UID) → `uid=""` → 0 sessions

apiserver logs confirmed the empty UID:
```
"Listing sessions" uid=""
"ListSessions: found 0 session(s) for userID=""
URI="/apis/identity.miloapis.com/v1alpha1/sessions?timeout=3s"
```

## Fix

Forward `opts.FieldSelector` (and `opts.LabelSelector` for completeness) into the `metav1.ListOptions` passed to `Backend.ListSessions`. The `DynamicProvider` backend already preserves the caller identity via X-Remote-* headers (`internal/apiserver/identity/sessions/dynamic.go:108-119`), so auth-provider-zitadel's REST handler still runs its own SAR check against milo and rejects unauthorized cross-user reads.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./internal/apiserver/identity/sessions/...` clean
- [ ] Once merged + rolled to staging milo, fraud-operator's Sessions list returns the user's actual sessions instead of `0 session(s) for userID=""`. Verify via `kubectl -n datum-iam-system logs deploy/auth-provider-zitadel-apiserver | grep "Listing sessions"` showing `uid=<actual-target-uid>`.

## Related

- datum-cloud/milo#588 — fixed the field-selector 400 at the conversion layer (necessary precondition; this PR is the missing piece)
- datum-cloud/auth-provider-zitadel#105 — same field-selector registration on the auth-provider-zitadel scheme
- datum-cloud/auth-provider-zitadel#69 — added the Session REST handler with the `status.userUID` selector consumer + SAR enforcement
- datum-cloud/fraud#32 — fraud-operator caller that surfaced the issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)
