### PR TITLE
feat: provision iroh-quic-tunnel ConnectorClass on projects

### DIFF
--- a/internal/controllers/resourcemanager/project_controller.go
+++ b/internal/controllers/resourcemanager/project_controller.go
@@ -306,8 +306,8 @@ func (r *ProjectController) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	}
 	if ok {
 		if err := ensureConnectorClass(ctx, pc.Dynamic,
-			"datum-connect",
-			"networking.datumapis.com/datum-connect",
+			"iroh-quic-tunnel",
+			"networking.datumapis.com/iroh-quic-tunnel",
 		); err != nil {
 			logger.Error(err, "ensure connectorclass failed", "project", project.Name)
 			return ctrl.Result{RequeueAfter: 2 * time.Second}, nil


### PR DESCRIPTION
## Summary
- Project controller now provisions a ConnectorClass named `iroh-quic-tunnel` (controllerName `networking.datumapis.com/iroh-quic-tunnel`) instead of `datum-connect`.
- Existing projects keep their `datum-connect` ConnectorClass (the ensure path is create-only) and additionally pick up `iroh-quic-tunnel` on next reconcile, so old and new desktop clients both resolve.
- Companion change in `datum-cloud/datum-connect` switches the desktop default `connectorClassName` to `iroh-quic-tunnel`.
- Legacy `datum-connect` ConnectorClass instances will be cleaned up in a follow-up once old desktop builds have aged out.

## Test plan
- [ ] New project provisioning creates the `iroh-quic-tunnel` ConnectorClass.
- [ ] Reconcile of an existing project adds `iroh-quic-tunnel` without disturbing the existing `datum-connect`.
- [ ] Desktop client (with companion PR) connects and the resulting Connector resolves to `iroh-quic-tunnel`.
- [ ] Older desktop client still defaulting to `datum-connect` continues to resolve against the legacy class on existing projects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)