### PR TITLE
fix: move ResourceMetricsPolicies out of services component

### DIFF
--- a/config/resources-metrics/kustomization.yaml
+++ b/config/resources-metrics/kustomization.yaml
@@ -5,3 +5,9 @@ components:
   - iam/
   - identity/
   - resources-manager/
+  # ResourceMetricsPolicy resources for each service. These are owned exclusively
+  # by the milo-resource-metrics Kustomization and must not be included in any
+  # other path (e.g. crd/overlays/core-control-plane via the services component).
+  - ../services/iam/telemetry/metrics
+  - ../services/quota/telemetry/metrics
+  - ../services/resourcemanager/telemetry/metrics

--- a/config/services/iam/kustomization.yaml
+++ b/config/services/iam/kustomization.yaml
@@ -1,5 +1,2 @@
 apiVersion: kustomize.config.k8s.io/v1alpha1
 kind: Component
-
-components:
-  - telemetry/metrics

--- a/config/services/kustomization.yaml
+++ b/config/services/kustomization.yaml
@@ -5,10 +5,13 @@ kind: Component
 # Add new service directories here as they are created.
 
 components:
-  - iam
-  - resourcemanager
   - quota
   # identity is intentionally excluded here — it contains ActivityPolicy resources
   # which require the activity.miloapis.com CRDs to be installed. Those CRDs are
   # provided by the activity service, which is not deployed in the milo test cluster.
   # Deploy config/services/identity/ separately once the activity service is present.
+  #
+  # iam and resourcemanager are intentionally excluded here — their only content was
+  # ResourceMetricsPolicy resources, which are now owned exclusively by the
+  # resources-metrics component. Including them here would create Flux ownership
+  # conflicts with the milo-resource-metrics Kustomization.

--- a/config/services/quota/kustomization.yaml
+++ b/config/services/quota/kustomization.yaml
@@ -3,6 +3,5 @@ kind: Component
 
 components:
   - iam
-  - telemetry/metrics
   - registrations
   - claim-policies

--- a/config/services/resourcemanager/kustomization.yaml
+++ b/config/services/resourcemanager/kustomization.yaml
@@ -1,5 +1,2 @@
 apiVersion: kustomize.config.k8s.io/v1alpha1
 kind: Component
-
-components:
-  - telemetry/metrics


### PR DESCRIPTION
## Problem

The `milo-core-control-plane-crds` Flux Kustomization (path `crd/overlays/core-control-plane`) includes a `../../../services` component. That component transitively pulled in `ResourceMetricsPolicy` resources via sub-components:

- `services/iam` → `telemetry/metrics` → `milo-iam-metrics`
- `services/quota` → `telemetry/metrics` → `milo-quota-metrics`
- `services/resourcemanager` → `telemetry/metrics` → `milo-resourcemanager-metrics`

The `milo-resource-metrics` Flux Kustomization (path `resources-metrics`) is supposed to be the sole owner of these policies, but because both Kustomizations resolved the same resources, Flux fired `FluxResourceOwnershipConflict` alerts.

The workaround was adding `$patch: delete` entries in the infra repo every time a policy got its own Kustomization. This already happened twice (`milo-infrastructure-metrics`, `milo-quota-metrics`) and is not sustainable.

## Fix

Remove `telemetry/metrics` from `services/iam`, `services/quota`, and `services/resourcemanager`. Since `telemetry/metrics` was the only content of `services/iam` and `services/resourcemanager`, also remove those two entries from `services/kustomization.yaml`.

Add all three policy components as explicit entries in `config/resources-metrics/kustomization.yaml`, making the `resources-metrics` component the sole owner.

## No bootstrapping gap

The `milo-resource-metrics` Kustomization already has `dependsOn: milo-apiserver`, which is the same dependency that `milo-core-control-plane-crds` uses. Removing the policies from the CRD overlay does not leave a window where the policies are absent; they are still applied by `milo-resource-metrics` on the same dependency chain.

## Follow-up in infra repo

The `$patch: delete` workarounds for `milo-infrastructure-metrics` and `milo-quota-metrics` in `apps/datum-control-plane-system/core-control-plane/base/milo-system/crds-kustomization.yaml` can be removed once this change ships and the infra repo's `milo-resource-metrics` Kustomization is updated to include all three policy components (or verified that it picks them up via the `resources-metrics` path).

## Verification

```
# No ResourceMetricsPolicies in the CRD overlay:
kustomize build config/crd/overlays/core-control-plane | grep ResourceMetricsPolicy
# (empty)

# All three policies present in resources-metrics:
kustomize build config/resources-metrics | grep -E "^kind:|^  name:"
kind: ConfigMap
  name: milo-iam-resource-metrics-...
kind: ConfigMap
  name: milo-identity-resource-metrics-...
kind: ConfigMap
  name: milo-resource-metrics-...
kind: ResourceMetricsPolicy
  name: milo-iam-metrics
kind: ResourceMetricsPolicy
  name: milo-quota-metrics
kind: ResourceMetricsPolicy
  name: milo-resourcemanager-metrics
```