### PR TITLE
feat: add feature flag Kustomize config and feature-flag-operator IAM role

### DIFF
--- a/config/services/features/iam/kustomization.yaml
+++ b/config/services/features/iam/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+components:
+  - roles

--- a/config/services/features/iam/roles/feature-flag-operator.yaml
+++ b/config/services/features/iam/roles/feature-flag-operator.yaml
@@ -1,0 +1,31 @@
+apiVersion: iam.miloapis.com/v1alpha1
+kind: Role
+metadata:
+  name: features.miloapis.com-operator
+  namespace: milo-system
+  annotations:
+    kubernetes.io/display-name: Feature Flag Operator
+    kubernetes.io/description: Operational access to quota resources required to manage feature flags, including read access to registrations and allowance buckets and full management of resource grants
+  labels:
+    features.miloapis.com/role-type: operator
+    features.miloapis.com/service: features
+spec:
+  launchStage: Beta
+  includedPermissions:
+    # ResourceRegistration read permissions
+    - quota.miloapis.com/resourceregistrations.get
+    - quota.miloapis.com/resourceregistrations.list
+    - quota.miloapis.com/resourceregistrations.watch
+
+    # ResourceGrant full management (feature flags are granted via ResourceGrants)
+    - quota.miloapis.com/resourcegrants.get
+    - quota.miloapis.com/resourcegrants.list
+    - quota.miloapis.com/resourcegrants.watch
+    - quota.miloapis.com/resourcegrants.create
+    - quota.miloapis.com/resourcegrants.update
+    - quota.miloapis.com/resourcegrants.delete
+
+    # AllowanceBucket read permissions
+    - quota.miloapis.com/allowancebuckets.get
+    - quota.miloapis.com/allowancebuckets.list
+    - quota.miloapis.com/allowancebuckets.watch

--- a/config/services/features/iam/roles/kustomization.yaml
+++ b/config/services/features/iam/roles/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+resources:
+  - feature-flag-operator.yaml

--- a/config/services/features/kustomization.yaml
+++ b/config/services/features/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+components:
+  - iam
+  - registrations

--- a/config/services/features/registrations/kustomization.yaml
+++ b/config/services/features/registrations/kustomization.yaml
@@ -1,0 +1,38 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+# Placeholder — no feature flags are registered yet.
+#
+# When adding a new feature flag, create a ResourceRegistration file in this
+# directory and add it to the resources list below, then add the corresponding
+# ResourceGrant(s) in datum-cloud/infra for the specific organizations that
+# should receive the flag.
+#
+# ResourceRegistration shape for a feature flag:
+#
+#   apiVersion: quota.miloapis.com/v1alpha1
+#   kind: ResourceRegistration
+#   metadata:
+#     name: feature-<name>
+#     labels:
+#       app.kubernetes.io/name: milo
+#       app.kubernetes.io/component: feature-flags
+#       features.miloapis.com/feature-name: <name>
+#   spec:
+#     consumerType:
+#       apiGroup: resourcemanager.miloapis.com
+#       kind: Organization
+#     type: Feature
+#     resourceType: features.miloapis.com/<name>
+#     description: "<human readable description>"
+#     baseUnit: feature
+#     displayUnit: features
+#     unitConversionFactor: 1
+#     claimingResources:
+#       - apiGroup: features.miloapis.com
+#         kind: FeatureGrant   # sentinel; satisfies minItems=1, no admission enforcement
+
+sortOptions:
+  order: fifo
+
+resources: []

--- a/config/services/kustomization.yaml
+++ b/config/services/kustomization.yaml
@@ -8,6 +8,7 @@ components:
   - iam
   - resourcemanager
   - quota
+  - features
   # identity is intentionally excluded here — it contains ActivityPolicy resources
   # which require the activity.miloapis.com CRDs to be installed. Those CRDs are
   # provided by the activity service, which is not deployed in the milo test cluster.


### PR DESCRIPTION
## Summary

- Add `config/services/features/` directory mirroring the quota service structure to support feature flag management via the quota ResourceRegistration API
- Add `feature-flag-operator` IAM Role granting minimum quota permissions needed to manage feature flags (read on ResourceRegistrations + AllowanceBuckets, full CRUD on ResourceGrants)
- Add placeholder `registrations/` component with inline documentation of the canonical ResourceRegistration shape for future feature flags
- Wire `features` into the top-level `config/services/kustomization.yaml` aggregate component

## Context

- Enhancement: datum-cloud/enhancements#695
- Parent issue: datum-cloud/enhancements#711
- `type=Feature` is valid in the CRD as of #575
- ResourceGrant instances (granting flags to specific orgs) live in `datum-cloud/infra`, not here

Closes #576

## Test plan

- [ ] `kustomize build config/services/features/` produces a single Role resource with the expected permissions
- [ ] `kustomize build config/services/` includes the new Role without errors
- [ ] Verify `feature-flag-operator` permissions match the spec: `resourceregistrations` get/list/watch, `resourcegrants` get/list/watch/create/update/delete, `allowancebuckets` get/list/watch