### PR TITLE
feat: add cloud-portal-usage-metering feature flag

### DIFF
--- a/config/services/features/kustomization.yaml
+++ b/config/services/features/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+components:
+  - registrations

--- a/config/services/features/registrations/cloud-portal-usage-metering.yaml
+++ b/config/services/features/registrations/cloud-portal-usage-metering.yaml
@@ -1,0 +1,21 @@
+apiVersion: quota.miloapis.com/v1alpha1
+kind: ResourceRegistration
+metadata:
+  name: feature-cloud-portal-usage-metering
+  labels:
+    app.kubernetes.io/name: milo
+    app.kubernetes.io/component: feature-flags
+    features.miloapis.com/feature-name: cloud-portal-usage-metering
+spec:
+  consumerType:
+    apiGroup: resourcemanager.miloapis.com
+    kind: Organization
+  type: Feature
+  resourceType: features.miloapis.com/cloud-portal-usage-metering
+  description: "Controls visibility of the Usage tab in the Datum Cloud portal. When enabled for an organization, the Usage & Metering section is shown in their portal navigation."
+  baseUnit: feature
+  displayUnit: features
+  unitConversionFactor: 1
+  claimingResources:
+    - apiGroup: features.miloapis.com
+      kind: FeatureGrant

--- a/config/services/features/registrations/kustomization.yaml
+++ b/config/services/features/registrations/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+resources:
+  - cloud-portal-usage-metering.yaml

--- a/config/services/kustomization.yaml
+++ b/config/services/kustomization.yaml
@@ -8,4 +8,8 @@ components:
   - iam
   - resourcemanager
   - quota
-  - activity
+  - features
+  # identity is intentionally excluded here — it contains ActivityPolicy resources
+  # which require the activity.miloapis.com CRDs to be installed. Those CRDs are
+  # provided by the activity service, which is not deployed in the milo test cluster.
+  # Deploy config/services/identity/ separately once the activity service is present.


### PR DESCRIPTION
## Summary

Adds the first feature flag `ResourceRegistration` to the Milo bundle, along with the `config/services/features/` Kustomize scaffold.

This flag controls visibility of the Usage & Metering tab in the Datum Cloud portal — when granted to an organization the tab is shown, otherwise hidden.

## Changes

- `config/services/features/` — new Kustomize component wired into `config/services/`
- `config/services/features/registrations/cloud-portal-usage-metering.yaml` — `ResourceRegistration` with `type=Feature`

## Notes

- `claimingResources` uses `features.miloapis.com/FeatureGrant` sentinel to satisfy `minItems=1` without enabling admission enforcement
- `ResourceGrant` instances (granting this flag to specific orgs) live in `datum-cloud/infra`, not here
- Operators granting this flag need the existing `quota.miloapis.com-manager` role — no new role needed

Closes datum-cloud/enhancements#711