### PR TITLE
feat: add public read access to ResourceRegistration catalog

### DIFF
--- a/config/services/quota/iam/kustomization.yaml
+++ b/config/services/quota/iam/kustomization.yaml
@@ -4,3 +4,4 @@ kind: Component
 components:
   - protected-resources
   - roles
+  - policies

--- a/config/services/quota/iam/policies/authenticated-user-resource-registration-read.yaml
+++ b/config/services/quota/iam/policies/authenticated-user-resource-registration-read.yaml
@@ -1,0 +1,14 @@
+apiVersion: iam.miloapis.com/v1alpha1
+kind: PolicyBinding
+metadata:
+  name: authenticated-user-resource-registration-read
+spec:
+  roleRef:
+    name: quota.miloapis.com-resource-registration-viewer
+  subjects:
+    - kind: Group
+      name: "system:authenticated"
+  resourceSelector:
+    resourceKind:
+      apiGroup: "quota.miloapis.com"
+      kind: ResourceRegistration

--- a/config/services/quota/iam/policies/kustomization.yaml
+++ b/config/services/quota/iam/policies/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+configurations:
+  - kustomizeconfig.yaml
+
+resources:
+  - authenticated-user-resource-registration-read.yaml

--- a/config/services/quota/iam/policies/kustomizeconfig.yaml
+++ b/config/services/quota/iam/policies/kustomizeconfig.yaml
@@ -1,0 +1,5 @@
+namespace:
+- kind: PolicyBinding
+  group: iam.miloapis.com
+  path: spec/roleRef/namespace
+  create: true

--- a/config/services/quota/iam/roles/feature-flag-viewer.yaml
+++ b/config/services/quota/iam/roles/feature-flag-viewer.yaml
@@ -1,0 +1,17 @@
+apiVersion: iam.miloapis.com/v1alpha1
+kind: Role
+metadata:
+  name: quota.miloapis.com-resource-registration-viewer
+  namespace: milo-system
+  annotations:
+    kubernetes.io/display-name: Resource Registration Viewer
+    kubernetes.io/description: View access to the ResourceRegistration catalog (feature flags, entities, allocations)
+  labels:
+    quota.miloapis.com/role-type: viewer
+    quota.miloapis.com/service: quota
+spec:
+  launchStage: Beta
+  includedPermissions:
+    - quota.miloapis.com/resourceregistrations.get
+    - quota.miloapis.com/resourceregistrations.list
+    - quota.miloapis.com/resourceregistrations.watch

--- a/config/services/quota/iam/roles/kustomization.yaml
+++ b/config/services/quota/iam/roles/kustomization.yaml
@@ -7,3 +7,4 @@ resources:
   - quota-viewer.yaml
   - quota-operator.yaml
   - organization-quota-manager.yaml
+  - feature-flag-viewer.yaml


### PR DESCRIPTION
## Summary

Make the `ResourceRegistration` catalog readable by any authenticated user, so the staff-portal Feature Flags UI can list available flags. Modeled after billing's `meter-definition-viewer` + `authenticated-user-meter-definition-read` pattern.

- New `config/services/features/` component scaffolding (`iam` + `registrations` placeholder).
- `quota.miloapis.com-resource-registration-viewer` Role: read-only on the registration catalog.
- `authenticated-user-resource-registration-read` PolicyBinding: grants the viewer role to `system:authenticated`, scoped via `resourceSelector.resourceKind` to `ResourceRegistration`.
- Wire `features` into `config/services/kustomization.yaml`.

## Why

Staff-portal needs to call `list resourceregistrations.quota.miloapis.com` (cluster-scoped) to enumerate the feature flag catalog before a flag can be toggled on for an org. Today this returns `403 Forbidden` for authenticated users because no PolicyBinding grants list access.

The catalog of registered resource types is non-sensitive metadata — same reasoning as `MeterDefinition` — so making it readable by all authenticated users keeps parity and unblocks the UI without per-team binding.

## Out of scope

- Roles for managing `ResourceGrant` create/delete (the toggle action). Those bindings live in `datum-cloud/infra` and aren't required to render the catalog.
- Specific feature flag registrations (e.g. cloud-portal-usage-metering) — separate PRs.

## Notes

The viewer role grants read on **all** `ResourceRegistration`s (`type` ∈ {Entity, Allocation, Feature}). PolicyBinding's `resourceSelector` is kind-only — no spec filter. If we ever want to restrict catalog visibility to only `type=Feature`, that requires admission/webhook enforcement, not IAM.

## Test plan

- [ ] `kustomize build config/services/features/` produces the Role + PolicyBinding without errors
- [ ] `kustomize build config/services/` includes them in the aggregate
- [ ] After deploy, verify `datumctl get resourceregistrations --platform-wide` succeeds for any authenticated user