### PR TITLE
fix(services): exclude activity from default aggregate

### DIFF
--- a/config/services/kustomization.yaml
+++ b/config/services/kustomization.yaml
@@ -3,9 +3,13 @@ kind: Component
 
 # This component aggregates all Milo service configurations.
 # Add new service directories here as they are created.
+#
+# `activity` is intentionally NOT included here: ActivityPolicy resources
+# require the activity.miloapis.com CRDs, which are not part of the milo
+# control plane. Deploy `config/services/activity/` explicitly in
+# environments where the activity service is present.
 
 components:
   - iam
   - resourcemanager
   - quota
-  - activity


### PR DESCRIPTION
## Summary

Remove ` activity` from the default `config/services/kustomization.yaml` aggregate so its `ActivityPolicy` resources aren't applied to clusters that don't have the `activity.miloapis.com` CRDs installed.

## Why

PR #579 added 23 `ActivityPolicy` resources under `config/services/activity/policies/...` and wired `activity` into the top-level `config/services/kustomization.yaml`, but the `ActivityPolicy` CRD is not part of the milo control plane bootstrap. As a result, every PR's `test-environment-validation` job fails when `task dev:deploy` runs `kubectl apply -k config/services/`:

```
resource mapping not found for name: "..." namespace: "" from "config/services/":
  no matches for kind "ActivityPolicy" in version "activity.miloapis.com/v1alpha1"
ensure CRDs are installed first
```

`config/services/activity/kustomization.yaml` already explicitly documents that this component should be applied separately once the activity service is present:

```yaml
# ActivityPolicy resources require the activity.miloapis.com CRDs to be installed.
# Those CRDs are provided by the activity service, which is not deployed in the
# milo test cluster. Deploy this directory separately once the activity service is present.
```

But the aggregate kept pulling it in regardless. This change makes the comment match the behavior.

## Behavior change

- `kustomize build config/services/` no longer emits `ActivityPolicy` resources (verified: 0 emitted, was 23).
- `kustomize build config/services/activity/` still emits all 23 `ActivityPolicy` resources for environments that need them.
- Test-environment bootstrap stops failing on missing `ActivityPolicy` CRD.

## Test plan

- [x] `kustomize build config/services/ | grep -c ActivityPolicy` → `0`
- [x] `kustomize build config/services/activity/ | grep -c ActivityPolicy` → `23`
- [ ] `test-environment-validation` job passes on this PR