### PR TITLE
fix(identity): allow cross-user UserIdentity lookups by status.userUID

### DIFF
--- a/internal/apiserver/identity/useridentities/rest.go
+++ b/internal/apiserver/identity/useridentities/rest.go
@@ -46,9 +46,20 @@ func (r *REST) List(ctx context.Context, opts *metainternalversion.ListOptions) 
 		uid = u.GetUID()
 		groups = u.GetGroups()
 	}
-	logger.V(4).Info("Listing user identities", "username", username, "uid", uid, "groups", groups)
-	// ignore selectors; self-scoped list delegated to provider
+	// Forward the caller's selectors to the backend so cross-user lookups
+	// (e.g. status.userUID=<uid>) reach the auth-provider-zitadel REST
+	// handler. The handler runs its own SAR check against milo using the
+	// caller identity preserved via X-Remote-* headers in DynamicProvider.
 	lo := metav1.ListOptions{}
+	if opts != nil {
+		if opts.FieldSelector != nil {
+			lo.FieldSelector = opts.FieldSelector.String()
+		}
+		if opts.LabelSelector != nil {
+			lo.LabelSelector = opts.LabelSelector.String()
+		}
+	}
+	logger.V(4).Info("Listing user identities", "username", username, "uid", uid, "groups", groups, "fieldSelector", lo.FieldSelector, "labelSelector", lo.LabelSelector)
 	res, err := r.backend.ListUserIdentities(ctx, u, &lo)
 	if err != nil {
 		logger.Error(err, "List user identities failed")

--- a/pkg/apis/identity/scheme.go
+++ b/pkg/apis/identity/scheme.go
@@ -31,24 +31,35 @@ func Install(scheme *runtime.Scheme) {
 		},
 	)
 
-	// Sessions are listed by callers (e.g. fraud-operator) using
-	// status.userUID=<uid> for cross-user lookups. The auth-provider-zitadel
-	// aggregated apiserver consumes this selector behind a SAR-gated REST
-	// handler, but the request never reaches it without this registration on
-	// the milo aggregator.
+	// Sessions and UserIdentities are listed by callers (e.g. fraud-operator,
+	// staff-portal) using status.userUID=<uid> for cross-user lookups. The
+	// auth-provider-zitadel aggregated apiserver consumes this selector
+	// behind a SAR-gated REST handler, but the request never reaches it
+	// without this registration on the milo aggregator.
+	userScopedSelector := func(label, value string) (string, string, error) {
+		switch label {
+		case "status.userUID", "metadata.name", "metadata.namespace":
+			return label, value, nil
+		default:
+			return "", "", nil
+		}
+	}
+
 	_ = scheme.AddFieldLabelConversionFunc(
 		schema.GroupVersionKind{
 			Group:   v1alpha1.SchemeGroupVersion.Group,
 			Version: v1alpha1.SchemeGroupVersion.Version,
 			Kind:    "Session",
 		},
-		func(label, value string) (string, string, error) {
-			switch label {
-			case "status.userUID", "metadata.name", "metadata.namespace":
-				return label, value, nil
-			default:
-				return "", "", nil
-			}
+		userScopedSelector,
+	)
+
+	_ = scheme.AddFieldLabelConversionFunc(
+		schema.GroupVersionKind{
+			Group:   v1alpha1.SchemeGroupVersion.Group,
+			Version: v1alpha1.SchemeGroupVersion.Version,
+			Kind:    "UserIdentity",
 		},
+		userScopedSelector,
 	)
 }


### PR DESCRIPTION
## Summary

Mirrors 8e9843d for `UserIdentity`. Two changes, both on the milo side:

1. **`pkg/apis/identity/scheme.go`** — register `status.userUID` as a valid field selector for `UserIdentity`. Without this, milo's aggregator pre-rejects List requests with `"status.userUID" is not a known field selector: only "metadata.name", "metadata.namespace"` before they ever proxy to auth-provider-zitadel.

2. **`internal/apiserver/identity/useridentities/rest.go`** — forward the caller's field/label selectors to the backend instead of dropping them with `lo := metav1.ListOptions{}`. The auth-provider-zitadel REST handler relies on receiving `status.userUID` to switch into the SAR-gated cross-user code path. With the milo handler discarding it, even after datum-cloud/zitadel-provider#108 the cross-user path could not be reached for identities — the request never made it past milo.

## Why now

The April 29 cross-user work (#583 here, datum-cloud/zitadel-provider#69) registered `Session` on both sides and intentionally deferred `UserIdentity` ("only Session is needed today"). Staff portal now wants the same lookup for IdP links — Google/GitHub/email — so support agents can see which providers a user has linked. End-to-end this PR + datum-cloud/zitadel-provider#108 unblock the staff-portal user detail page's read-only Account Identities card.

## Authorization

Unchanged. The SAR check in auth-provider-zitadel remains the gate — `staff-users` already has `iam.miloapis.com/users.get` cluster-wide via `staff-user-manager-binding`, so no IAM changes needed.

## Test plan
- [x] `go build ./pkg/apis/identity/... ./internal/apiserver/identity/...` — clean
- [x] `go test ./internal/apiserver/identity/... ./pkg/apis/identity/...` — sessions tests still pass
- [ ] Verify in staging: staff portal user detail page populates the Account Identities card with the *target* user's IdP links (currently shows the staff user's own — bug confirmed via apiserver logs and field-selector error)

Pairs with datum-cloud/zitadel-provider#108. Refs datum-cloud/zitadel-provider#69.