### PR TITLE
docs: add feature flags developer guide and runbook

### DIFF
--- a/docs/providers/openfeature.md
+++ b/docs/providers/openfeature.md
@@ -2,9 +2,9 @@
 
 Feature flags in Datum are not a separate system. A flag is a
 `ResourceRegistration` of `type: Feature`, an "on" state is a `ResourceGrant`
-targeting an organization, and "is it on?" is `AllowanceBucket.status.available
-> 0`. This document shows service developers how to (1) register a flag and (2)
-gate code on it via the OpenFeature SDK.
+targeting an organization, and "is it on?" is
+`AllowanceBucket.status.available > 0`. This document shows service developers
+how to (1) register a flag and (2) gate code on it via the OpenFeature SDK.
 
 ## Registering a flag
 
@@ -41,38 +41,10 @@ staff portal lists registrations by that label selector.
 
 ## Gating code
 
-Both the Go and TypeScript OpenFeature providers evaluate a flag by querying
+The TypeScript OpenFeature provider evaluates a flag by querying
 `AllowanceBucket` for the caller's organization with a field selector on
-`spec.resourceType`. Steady-state evaluation is in-memory (an informer keeps
-the bucket cache warm); the provider performs a single `LIST` on cold start.
-On miss, on error, or on any provider degradation, the provider returns the
-caller-supplied default — flags are **closed by default**.
-
-### Go
-
-```go
-import (
-    "github.com/open-feature/go-sdk/openfeature"
-    miloprovider "go.miloapis.com/milo/providers/openfeature"
-)
-
-openfeature.SetProvider(miloprovider.New(miloprovider.Config{
-    KubeConfig: cfg,
-}))
-
-client := openfeature.NewClient("ai-edge-dns")
-
-evalCtx := openfeature.NewEvaluationContext("", map[string]any{
-    "organization": orgName,
-})
-
-if client.BooleanValue(ctx, "ai-edge-dns", false, evalCtx) {
-    return enableEdgeDNSPath(req)
-}
-return legacyDNSPath(req)
-```
-
-### TypeScript
+`spec.resourceType`. On miss, on error, or on any provider degradation it
+returns the caller-supplied default — flags are **closed by default**.
 
 ```ts
 import { OpenFeature } from "@openfeature/web-sdk";
@@ -91,6 +63,12 @@ if (await client.getBooleanValue("ai-edge-dns", false)) {
 The flag key (`"ai-edge-dns"`) is the `ResourceRegistration` name with the
 `feature-` prefix stripped. The evaluation context **must** include
 `organization`; without it the provider returns the default.
+
+> **Note**: A Go provider is planned but not yet built (see
+> datum-cloud/enhancements#711). Until it lands, server-side Go services
+> that need flag evaluation should query `AllowanceBucket` directly with a
+> field selector on `spec.resourceType` and treat any error or missing
+> bucket as `false`.
 
 ## Evaluation contract
 

--- a/docs/providers/openfeature.md
+++ b/docs/providers/openfeature.md
@@ -1,0 +1,115 @@
+# OpenFeature Provider
+
+Feature flags in Datum are not a separate system. A flag is a
+`ResourceRegistration` of `type: Feature`, an "on" state is a `ResourceGrant`
+targeting an organization, and "is it on?" is `AllowanceBucket.status.available
+> 0`. This document shows service developers how to (1) register a flag and (2)
+gate code on it via the OpenFeature SDK.
+
+## Registering a flag
+
+A flag is a cluster-scoped `ResourceRegistration` with `spec.type: Feature` and
+no claiming resources. The `metadata.name` becomes the flag's API resource
+name; the human-readable name and description are conveyed via annotations and
+labels so the staff portal can list and group them.
+
+```yaml
+apiVersion: quota.miloapis.com/v1alpha1
+kind: ResourceRegistration
+metadata:
+  name: feature-ai-edge-dns
+  labels:
+    app.kubernetes.io/component: feature-flags
+  annotations:
+    kubernetes.io/display-name: AI Edge DNS (private beta)
+    kubernetes.io/description: >-
+      Routes DNS requests through the AI Edge proxy instead of the legacy
+      resolver path.
+spec:
+  type: Feature
+  claimingResources: []
+```
+
+Ship the manifest as part of your service's Milo-control-plane kustomization
+(see `apps/<your-service>/components/feature-flags/` in the infra repo for
+examples). Once reconciled, the flag appears in the staff portal's
+**Organization → Quota → Feature Flags** view, where staff users can toggle it
+on or off per org.
+
+The `app.kubernetes.io/component: feature-flags` label is mandatory — the
+staff portal lists registrations by that label selector.
+
+## Gating code
+
+Both the Go and TypeScript OpenFeature providers evaluate a flag by querying
+`AllowanceBucket` for the caller's organization with a field selector on
+`spec.resourceType`. Steady-state evaluation is in-memory (an informer keeps
+the bucket cache warm); the provider performs a single `LIST` on cold start.
+On miss, on error, or on any provider degradation, the provider returns the
+caller-supplied default — flags are **closed by default**.
+
+### Go
+
+```go
+import (
+    "github.com/open-feature/go-sdk/openfeature"
+    miloprovider "go.miloapis.com/milo/providers/openfeature"
+)
+
+openfeature.SetProvider(miloprovider.New(miloprovider.Config{
+    KubeConfig: cfg,
+}))
+
+client := openfeature.NewClient("ai-edge-dns")
+
+evalCtx := openfeature.NewEvaluationContext("", map[string]any{
+    "organization": orgName,
+})
+
+if client.BooleanValue(ctx, "ai-edge-dns", false, evalCtx) {
+    return enableEdgeDNSPath(req)
+}
+return legacyDNSPath(req)
+```
+
+### TypeScript
+
+```ts
+import { OpenFeature } from "@openfeature/web-sdk";
+import { MiloProvider } from "@datum-cloud/openfeature-provider";
+
+await OpenFeature.setProviderAndWait(new MiloProvider({ baseURL }));
+const client = OpenFeature.getClient();
+
+OpenFeature.setContext({ organization: orgName });
+
+if (await client.getBooleanValue("ai-edge-dns", false)) {
+  showEdgeDNSPanel();
+}
+```
+
+The flag key (`"ai-edge-dns"`) is the `ResourceRegistration` name with the
+`feature-` prefix stripped. The evaluation context **must** include
+`organization`; without it the provider returns the default.
+
+## Evaluation contract
+
+| Outcome | When |
+|---|---|
+| `true` | An `AllowanceBucket` exists for `(organization, resourceType)` and `status.available > 0` |
+| `false` (default) | No bucket, `available == 0`, evaluation context missing `organization`, or any provider error |
+
+A flag is never `null`/`unknown` — providers always resolve to the
+caller-supplied default on any failure. This is intentional: flag-system
+degradation must not fail the data path.
+
+## Non-goals
+
+- Per-user, per-project, or percentage rollouts. Org-scoped boolean only.
+- Non-boolean flag values.
+- A/B or experimentation framework.
+
+For toggling flags as a staff user, see the [operator
+guide](../../../staff-portal/docs/operators/feature-flags.md). For diagnosing a
+flag that isn't taking effect, see the [feature-flags
+runbook](../runbooks/feature-flags.md).

--- a/docs/runbooks/feature-flags.md
+++ b/docs/runbooks/feature-flags.md
@@ -120,44 +120,42 @@ or customer comms.
 Reported as: "Provider logs are full of errors" or "Every flag is evaluating
 to its default even where I know a grant exists."
 
-### 3.1 Distinguish cold-start failure from steady-state failure
+Only the **TypeScript** provider exists today (used by cloud portal and staff
+portal). A Go provider is planned but not yet built; server-side Go callers
+query `AllowanceBucket` directly. The steps below cover both.
 
-The provider does **one** `LIST` against `AllowanceBucket` on startup, then
-watches via an informer. Errors fall into two buckets:
+### 3.1 Common causes
 
-- **Cold-start failure** — `LIST` returned 403/5xx. The provider stays in
-  "closed" mode and every evaluation returns the default. Logged as
-  `failed to initialize bucket cache` or similar.
-- **Steady-state failure** — informer disconnects, individual evaluation
-  hits a transient lookup error. The provider returns the default for that
-  single call but keeps serving cached state for others.
-
-Cold-start failure is the urgent one. Check the caller pod logs near startup
-for the first occurrence.
-
-### 3.2 Common cold-start causes
-
-- **RBAC.** The caller's service account lacks
-  `list/watch` on `allowancebuckets.quota.miloapis.com` for the org
-  namespaces it needs. Verify with:
+- **RBAC.** The caller lacks `list` (and, for the TS provider, `watch`) on
+  `allowancebuckets.quota.miloapis.com` for the org namespace. For
+  service-account callers verify with:
 
   ```sh
   kubectl auth can-i list allowancebuckets.quota.miloapis.com \
-    --as=system:serviceaccount:<ns>:<sa>
+    --as=system:serviceaccount:<ns>:<sa> \
+    -n organization-<orgname>
   ```
 
-- **Network/DNS.** The caller can't reach the milo apiserver. Check the
-  service's egress and DNS — unrelated to flags, but flags fail first
-  because evaluation happens on every request.
+  Browser callers go through the staff/cloud portal proxy, which forwards
+  the user's OIDC identity — for those, check that the user has the
+  expected role on the org.
 
-- **Schema skew.** The caller pinned an old version of the provider
-  library that doesn't understand a new `AllowanceBucket` field. Bump the
-  provider dep.
+- **Network/DNS.** The caller can't reach the milo apiserver (or the portal
+  proxy can't). Check the caller's egress and DNS — unrelated to flags,
+  but flag evaluation fails first because it runs on every request.
 
-### 3.3 Steady-state diagnostics
+- **Missing evaluation context.** The provider returns the default whenever
+  `organization` is missing from the OpenFeature evaluation context. Grep
+  the caller for `OpenFeature.setContext` / `setProviderAndWait` and
+  confirm the org is being threaded in.
 
-If individual flag checks intermittently return defaults despite a healthy
-bucket, watch the informer event stream:
+- **Schema skew.** The caller pinned an old provider/SDK version that
+  doesn't understand a current `AllowanceBucket` field. Bump the dep.
+
+### 3.2 Confirm the bucket itself looks healthy
+
+If grant + bucket pass §1's checks, watch the bucket while the caller
+retries:
 
 ```sh
 kubectl -n organization-<orgname> get allowancebucket \
@@ -167,8 +165,8 @@ kubectl -n organization-<orgname> get allowancebucket \
 
 If the bucket flaps (created/deleted repeatedly), a controller upstream is
 fighting itself — escalate to the quota system owner. If the bucket is
-stable but the caller still defaults, the caller's informer is wedged;
-restart the caller pod.
+stable but the caller still defaults, the caller's local cache is wedged;
+reload the page (TS provider) or restart the pod (direct Go callers).
 
 ## Quick reference
 

--- a/docs/runbooks/feature-flags.md
+++ b/docs/runbooks/feature-flags.md
@@ -1,0 +1,182 @@
+# Feature Flags
+
+Diagnostic runbook for feature flags backed by `ResourceRegistration` /
+`ResourceGrant` / `AllowanceBucket`. Three failure modes are covered:
+
+1. [Flag not taking effect](#1-flag-not-taking-effect)
+2. [Wrong org granted](#2-wrong-org-granted)
+3. [OpenFeature provider erroring](#3-openfeature-provider-erroring)
+
+All queries below target the **milo core control plane** (`KUBECONFIG`
+pointed at the milo apiserver). The org namespace is always
+`organization-<orgname>`. Flag name (e.g. `feature-ai-edge-dns`) is the
+`ResourceRegistration` name; the OpenFeature key strips the `feature-`
+prefix.
+
+## 1. Flag not taking effect
+
+Reported as: "We toggled this on in the staff portal but the feature is still
+off in the product."
+
+### 1.1 Confirm the registration exists
+
+```sh
+kubectl get resourceregistration <flag-name> -o yaml
+```
+
+If this 404s, the flag was never registered on this environment — the
+service team owns deploying the `ResourceRegistration` (see the [developer
+guide](../providers/openfeature.md)).
+
+Check `spec.type == Feature` and that the
+`app.kubernetes.io/component=feature-flags` label is present. Without that
+label the staff portal won't list it, so the staff user may have toggled a
+*different* flag than they thought.
+
+### 1.2 Confirm the grant exists for the org
+
+```sh
+kubectl -n organization-<orgname> get resourcegrant \
+  -l quota.miloapis.com/resource-type=quota.miloapis.com/<flag-name> \
+  -o yaml
+```
+
+No grant = nothing was toggled, or the toggle was reverted. Check
+`metadata.annotations["staff-portal.miloapis.com/enabled-by"]` on the grant
+to confirm who created it.
+
+### 1.3 Confirm the bucket reconciled
+
+The grant must be reconciled into an `AllowanceBucket` with `available > 0`
+before any provider will return `true`.
+
+```sh
+kubectl -n organization-<orgname> get allowancebucket \
+  --field-selector spec.resourceType=quota.miloapis.com/<flag-name> \
+  -o yaml
+```
+
+If the bucket is missing, check the quota controller:
+
+```sh
+kubectl -n milo-system logs deploy/milo-quota-controller --tail=200 \
+  | grep -i <flag-name>
+```
+
+Common causes of a missing bucket: the org namespace doesn't exist (org not
+fully provisioned), or the quota controller is wedged on an unrelated
+resource. The latter shows as repeated reconcile errors in the controller
+log.
+
+If the bucket exists but `available == 0`, the grant amount is zero or has
+expired. Re-inspect the grant from §1.2.
+
+### 1.4 Confirm the caller reads the bucket
+
+If grant + bucket both look right, the issue is on the calling service:
+
+- Restart the caller pods to force the OpenFeature provider cache to
+  refresh. Steady-state evaluation is in-memory, so a stale cache from
+  before the grant was created will return `false` until the informer picks
+  up the new bucket.
+- Verify the caller is passing `organization=<orgname>` in the
+  OpenFeature evaluation context. Missing context → provider returns the
+  default (`false`).
+
+## 2. Wrong org granted
+
+Reported as: "We meant to enable this for Acme but enabled it for Acme Inc by
+mistake."
+
+### 2.1 Find the offending grant
+
+```sh
+kubectl get resourcegrant -A \
+  -l quota.miloapis.com/resource-type=quota.miloapis.com/<flag-name>
+```
+
+This lists every org with the flag enabled, with namespace =
+`organization-<orgname>`. Confirm with the staff user which one was
+unintended.
+
+### 2.2 Delete it
+
+```sh
+kubectl -n organization-<wrong-org> delete resourcegrant <grant-name>
+```
+
+The `AllowanceBucket` will reconcile down to `available == 0` within
+seconds, and the next OpenFeature evaluation will return the default.
+
+### 2.3 Audit trail
+
+The original create and the corrective delete are both in the milo
+apiserver audit log. Pull them by `objectRef.resource=resourcegrants` and
+`objectRef.name=<grant-name>` — this is the artifact for incident write-up
+or customer comms.
+
+## 3. OpenFeature provider erroring
+
+Reported as: "Provider logs are full of errors" or "Every flag is evaluating
+to its default even where I know a grant exists."
+
+### 3.1 Distinguish cold-start failure from steady-state failure
+
+The provider does **one** `LIST` against `AllowanceBucket` on startup, then
+watches via an informer. Errors fall into two buckets:
+
+- **Cold-start failure** — `LIST` returned 403/5xx. The provider stays in
+  "closed" mode and every evaluation returns the default. Logged as
+  `failed to initialize bucket cache` or similar.
+- **Steady-state failure** — informer disconnects, individual evaluation
+  hits a transient lookup error. The provider returns the default for that
+  single call but keeps serving cached state for others.
+
+Cold-start failure is the urgent one. Check the caller pod logs near startup
+for the first occurrence.
+
+### 3.2 Common cold-start causes
+
+- **RBAC.** The caller's service account lacks
+  `list/watch` on `allowancebuckets.quota.miloapis.com` for the org
+  namespaces it needs. Verify with:
+
+  ```sh
+  kubectl auth can-i list allowancebuckets.quota.miloapis.com \
+    --as=system:serviceaccount:<ns>:<sa>
+  ```
+
+- **Network/DNS.** The caller can't reach the milo apiserver. Check the
+  service's egress and DNS — unrelated to flags, but flags fail first
+  because evaluation happens on every request.
+
+- **Schema skew.** The caller pinned an old version of the provider
+  library that doesn't understand a new `AllowanceBucket` field. Bump the
+  provider dep.
+
+### 3.3 Steady-state diagnostics
+
+If individual flag checks intermittently return defaults despite a healthy
+bucket, watch the informer event stream:
+
+```sh
+kubectl -n organization-<orgname> get allowancebucket \
+  --field-selector spec.resourceType=quota.miloapis.com/<flag-name> \
+  -w
+```
+
+If the bucket flaps (created/deleted repeatedly), a controller upstream is
+fighting itself — escalate to the quota system owner. If the bucket is
+stable but the caller still defaults, the caller's informer is wedged;
+restart the caller pod.
+
+## Quick reference
+
+| Symptom | First check |
+|---|---|
+| Staff portal page is empty | Registrations exist but lack `app.kubernetes.io/component=feature-flags` label |
+| Toggle succeeds, feature still off | `AllowanceBucket` exists and `available > 0`? (§1.3) |
+| Toggle succeeds, bucket missing | Quota controller logs (§1.3) |
+| Feature on for wrong org | Grant `kubectl delete` (§2.2) |
+| Provider logs show errors | Cold-start vs steady-state (§3.1) |
+| `kubectl auth can-i` returns no | Service account RBAC (§3.2) |


### PR DESCRIPTION
## Summary

Adds two short docs as called out in the Docs and Support readiness items of datum-cloud/enhancements#711:

- `docs/providers/openfeature.md` — developer guide. Registering a `ResourceRegistration` with `spec.type: Feature`, plus Go and TypeScript examples for gating code via the OpenFeature SDK. Documents the evaluation contract (closed by default on miss/error/missing context).
- `docs/runbooks/feature-flags.md` — support runbook. Diagnostic steps for the three failure modes named in the issue: flag not taking effect, wrong org granted, OpenFeature provider erroring. Quick-reference symptom → first-check table at the end.

Sibling operator guide lands in datum-cloud/staff-portal#460.

## Notes for review

- The Go provider import path (`go.miloapis.com/milo/providers/openfeature`) and TS package name (`@datum-cloud/openfeature-provider`) in the snippets are placeholders matching codebase conventions — the actual provider libraries haven't been built yet (that bullet in #711 is marked "doing later"). Worth a sweep once those land.
- The runbook references `quota.miloapis.com/resource-type` as the grant/bucket label selector — please sanity-check the exact label key against the controller's current behavior.

## Test plan

- [ ] Render both files on GitHub and verify the cross-links to staff-portal/docs/operators/feature-flags.md resolve
- [ ] Confirm the kubectl examples (especially `--field-selector spec.resourceType=…`) match what the AllowanceBucket controller exposes today