### PR TITLE
chore: implement a project overhead scale test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ vendor/
 # Files used by the taskfile.
 .task
 
+# Scale test pprof profiles
+dev/profiles/
+

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -292,6 +292,30 @@ tasks:
         KUBECONFIG=.milo/kubeconfig "{{.TOOL_DIR}}/chainsaw" test $TEST_PATHS --selector "requires!=authorization-provider"
     silent: true
 
+  test:scale:
+    desc: Run scale benchmarks against a running Milo API server. Requires 'task dev:setup' to be run first.
+    silent: true
+    cmds:
+      - |
+        set -e
+
+        if [ ! -f ".milo/kubeconfig" ]; then
+          echo "Error: Milo kubeconfig not found at .milo/kubeconfig"
+          echo "Please run 'task dev:setup' to set up the test infrastructure first."
+          exit 1
+        fi
+
+        if ! KUBECONFIG=.milo/kubeconfig kubectl get --raw /healthz &>/dev/null; then
+          echo "Error: Cannot connect to Milo API server"
+          echo "Please ensure the test infrastructure is running with 'task dev:setup'"
+          echo "You can check the status with:"
+          echo "  task test-infra:kubectl -- get pods -n milo-system"
+          exit 1
+        fi
+        echo "✓ Connected to Milo API server"
+
+        go test -tags scale -v -timeout 30m ./test/scale/...
+
   test:unit:
     desc: Run unit tests
     cmds:

--- a/test/scale/cluster_test.go
+++ b/test/scale/cluster_test.go
@@ -1,0 +1,227 @@
+//go:build scale
+
+package scale
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"crypto/tls"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+type endpoint struct {
+	url   string
+	token string
+}
+
+func (e *endpoint) get(ctx context.Context, path string) (string, error) {
+	return httpGet(ctx, e.url, e.token, path)
+}
+
+func (e *endpoint) post(ctx context.Context, path string, body []byte) (string, error) {
+	return httpPost(ctx, e.url, e.token, path, body)
+}
+
+func (e *endpoint) delete(ctx context.Context, path string) error {
+	return httpDelete(ctx, e.url, e.token, path)
+}
+
+// connect reads .milo/kubeconfig and returns a handle to the Milo API server.
+// Requires 'task dev:setup' to have been run first.
+func connect(t *testing.T) *endpoint {
+	t.Helper()
+	cfg, err := clientcmd.BuildConfigFromFlags("", filepath.Join(repoRoot(t), ".milo", "kubeconfig"))
+	if err != nil {
+		t.Fatalf("load .milo/kubeconfig: %v", err)
+	}
+	s := &endpoint{url: cfg.Host, token: cfg.BearerToken}
+	s.waitReady(t)
+	t.Logf("connected to milo apiserver at %s", s.url)
+	return s
+}
+
+func (s *endpoint) waitReady(t *testing.T) {
+	t.Helper()
+	client := &http.Client{
+		Timeout: 2 * time.Second,
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, //nolint:gosec
+		},
+	}
+	deadline := time.Now().Add(30 * time.Second)
+	var lastErr error
+	for time.Now().Before(deadline) {
+		req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, s.url+"/readyz", nil)
+		req.Header.Set("Authorization", "Bearer "+s.token)
+		resp, err := client.Do(req)
+		if err == nil {
+			_ = resp.Body.Close()
+			if resp.StatusCode == http.StatusOK {
+				return
+			}
+			err = fmt.Errorf("readyz status=%d", resp.StatusCode)
+		}
+		lastErr = err
+		time.Sleep(500 * time.Millisecond)
+	}
+	t.Fatalf("milo apiserver not ready at %s: %v", s.url, lastErr)
+}
+
+// portForward starts a kubectl port-forward to a cluster service, returning
+// an endpoint at the assigned local port. Killed in t.Cleanup.
+func portForward(t *testing.T, namespace, service string, remotePort int, scheme, token string) *endpoint {
+	t.Helper()
+	kubeconfig := filepath.Join(repoRoot(t), ".test-infra", "kubeconfig")
+	if _, err := os.Stat(kubeconfig); err != nil {
+		t.Fatalf("port-forward %s/%s: .test-infra/kubeconfig not found — run 'task test-infra-cluster' first", namespace, service)
+	}
+	cmd := exec.CommandContext(context.Background(), "kubectl",
+		"--kubeconfig", kubeconfig,
+		"-n", namespace,
+		"port-forward", service,
+		fmt.Sprintf(":%d", remotePort),
+	)
+	pr, pw, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe for port-forward: %v", err)
+	}
+	cmd.Stdout = pw
+	cmd.Stderr = os.Stderr
+	if err := cmd.Start(); err != nil {
+		_ = pr.Close()
+		_ = pw.Close()
+		t.Fatalf("port-forward %s/%s:%d: %v", namespace, service, remotePort, err)
+	}
+	_ = pw.Close()
+	t.Cleanup(func() {
+		_ = cmd.Process.Kill()
+		_ = pr.Close()
+	})
+	localPort := parseForwardPort(t, pr, remotePort)
+	t.Logf("port-forward %s/%s: localhost:%d -> %d", namespace, service, localPort, remotePort)
+	return &endpoint{url: fmt.Sprintf("%s://localhost:%d", scheme, localPort), token: token}
+}
+
+// parseForwardPort scans kubectl stdout for "Forwarding from 127.0.0.1:PORT -> ..."
+func parseForwardPort(t *testing.T, r *os.File, remotePort int) int {
+	t.Helper()
+	scanner := bufio.NewScanner(r)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if !strings.HasPrefix(line, "Forwarding from 127.0.0.1:") {
+			continue
+		}
+		portStr, _, _ := strings.Cut(strings.TrimPrefix(line, "Forwarding from 127.0.0.1:"), " ")
+		if port, err := strconv.Atoi(portStr); err == nil {
+			return port
+		}
+	}
+	t.Fatalf("port-forward: did not see forwarding line for remote port %d", remotePort)
+	return 0
+}
+
+var insecureClient = &http.Client{
+	Timeout: 30 * time.Second,
+	Transport: &http.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, //nolint:gosec
+	},
+}
+
+func httpPost(ctx context.Context, baseURL, token, path string, body []byte) (string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, baseURL+path, bytes.NewReader(body))
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	resp, err := insecureClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	b, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		return "", &httpStatusError{code: resp.StatusCode, body: string(b)}
+	}
+	return string(b), nil
+}
+
+func httpDelete(ctx context.Context, baseURL, token, path string) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, baseURL+path, nil)
+	if err != nil {
+		return err
+	}
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	resp, err := insecureClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	_, _ = io.Copy(io.Discard, resp.Body)
+	return nil
+}
+
+func httpGet(ctx context.Context, baseURL, token, path string) (string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, baseURL+path, nil)
+	if err != nil {
+		return "", err
+	}
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	resp, err := insecureClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	b, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		return "", &httpStatusError{code: resp.StatusCode, body: string(b)}
+	}
+	return string(b), nil
+}
+
+type httpStatusError struct {
+	code int
+	body string
+}
+
+func (e *httpStatusError) Error() string { return fmt.Sprintf("HTTP %d: %s", e.code, e.body) }
+
+func repoRoot(t *testing.T) string {
+	t.Helper()
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	for dir := wd; ; dir = filepath.Dir(dir) {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		if filepath.Dir(dir) == dir {
+			t.Fatalf("could not find go.mod from %s", wd)
+		}
+	}
+}

--- a/test/scale/project_overhead_test.go
+++ b/test/scale/project_overhead_test.go
@@ -1,0 +1,489 @@
+//go:build scale
+
+package scale
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"slices"
+	"strconv"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"golang.org/x/sync/errgroup"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/rest"
+
+	rmv1alpha1 "go.miloapis.com/milo/pkg/apis/resourcemanager/v1alpha1"
+)
+
+const rmAPIBase = "/apis/resourcemanager.miloapis.com/v1alpha1"
+
+const (
+	workerCount = 24
+	mib         = 1024 * 1024
+)
+
+func projectCount() int {
+	if s := os.Getenv("SCALE_PROJECTS"); s != "" {
+		if n, err := strconv.Atoi(s); err == nil && n > 0 {
+			return n
+		}
+	}
+	return 20
+}
+
+// identity.miloapis.com is backed by Zitadel, which is not deployed in the
+// scale test environment, and returns 503 on all requests.
+var skipGroups = map[string]struct{}{"identity.miloapis.com": {}}
+
+// --- snapshots ---
+
+type memorySnapshot struct {
+	heapInuse  float64
+	sys        float64
+	goroutines float64
+}
+
+func (m memorySnapshot) String() string {
+	return fmt.Sprintf("heap=%.1fMiB sys=%.1fMiB goroutines=%.0f",
+		m.heapInuse/mib, m.sys/mib, m.goroutines)
+}
+
+func (m memorySnapshot) sub(other memorySnapshot) memorySnapshot {
+	return memorySnapshot{
+		heapInuse:  m.heapInuse - other.heapInuse,
+		sys:        m.sys - other.sys,
+		goroutines: m.goroutines - other.goroutines,
+	}
+}
+
+func (m memorySnapshot) div(n int) memorySnapshot {
+	f := float64(n)
+	return memorySnapshot{m.heapInuse / f, m.sys / f, m.goroutines / f}
+}
+
+type etcdSnapshot struct{ watchers float64 }
+
+func (e etcdSnapshot) String() string                  { return fmt.Sprintf("watchers=%.0f", e.watchers) }
+func (e etcdSnapshot) sub(o etcdSnapshot) etcdSnapshot { return etcdSnapshot{e.watchers - o.watchers} }
+func (e etcdSnapshot) div(n int) etcdSnapshot          { return etcdSnapshot{e.watchers / float64(n)} }
+
+type clusterSnapshot struct {
+	apiserver memorySnapshot
+	etcd      etcdSnapshot
+}
+
+func (c clusterSnapshot) String() string {
+	return fmt.Sprintf("apiserver[%s] etcd[%s]", c.apiserver, c.etcd)
+}
+
+func (c clusterSnapshot) sub(other clusterSnapshot) clusterSnapshot {
+	return clusterSnapshot{c.apiserver.sub(other.apiserver), c.etcd.sub(other.etcd)}
+}
+
+func (c clusterSnapshot) div(n int) clusterSnapshot {
+	return clusterSnapshot{c.apiserver.div(n), c.etcd.div(n)}
+}
+
+type latencyReport struct {
+	count, errors      int
+	p50, p90, p99, max time.Duration
+}
+
+func (l latencyReport) String() string {
+	return fmt.Sprintf("n=%d errors=%d p50=%s p90=%s p99=%s max=%s",
+		l.count, l.errors,
+		l.p50.Round(time.Millisecond), l.p90.Round(time.Millisecond),
+		l.p99.Round(time.Millisecond), l.max.Round(time.Millisecond))
+}
+
+// --- test ---
+
+func TestProjectControlPlaneOverhead(t *testing.T) {
+	s := connect(t)
+	etcd := portForward(t, "milo-system", "svc/etcd", 2379, "http", "")
+	nProjects := projectCount()
+
+	// Warn once if etcd watcher metric is unavailable so callers know whether
+	// to trust the etcd watcher readings (which show 0 when the metric is absent).
+	if _, err := sampleEtcd(context.Background(), etcd); err != nil {
+		t.Logf("warning: etcd watcher metric unavailable — etcd readings will show 0 (%v)", err)
+	}
+
+	gvrs := mustDiscoverGVRs(t, s)
+	t.Logf("resources: %d listable types", len(gvrs))
+
+	globalPaths := buildGlobalPaths(gvrs)
+
+	before := waitUntilStable(t, s, etcd, "before")
+	t.Logf("latency before: %s", measureLatency(s, globalPaths))
+	saveProfiles(t, s, nProjects, "before")
+
+	runPrefix := fmt.Sprintf("scale-%d", time.Now().Unix())
+	orgName := runPrefix
+	projectIDs := makeProjectIDs(nProjects, runPrefix)
+
+	t.Cleanup(func() {
+		ctx := context.Background()
+		for _, id := range projectIDs {
+			if err := s.delete(ctx, rmAPIBase+"/projects/"+id); err != nil {
+				t.Logf("cleanup: delete project %s: %v", id, err)
+			}
+		}
+		if err := s.delete(ctx, rmAPIBase+"/organizations/"+orgName); err != nil {
+			t.Logf("cleanup: delete org %s: %v", orgName, err)
+		}
+	})
+
+	t.Logf("bootstrap: creating org=%s and %d projects", orgName, nProjects)
+	createOrg(t, s, orgName)
+	for _, id := range projectIDs {
+		createProject(t, s, id, orgName)
+	}
+	bootstrapProjects(t, s, projectIDs, gvrs)
+
+	after := waitUntilStable(t, s, etcd, "after")
+	t.Logf("latency after:  %s", measureLatency(s, globalPaths))
+	saveProfiles(t, s, nProjects, "after")
+
+	delta := after.sub(before)
+	t.Logf("results: projects=%d resources_per_project=%d", nProjects, len(gvrs))
+	t.Logf("  before:      %s", before)
+	t.Logf("  after:       %s", after)
+	t.Logf("  per-project: %s", delta.div(nProjects))
+}
+
+// --- bootstrap ---
+
+func makeProjectIDs(n int, prefix string) []string {
+	ids := make([]string, n)
+	for i := range ids {
+		ids[i] = fmt.Sprintf("%s-p-%03d", prefix, i)
+	}
+	return ids
+}
+
+func createOrg(t *testing.T, s *endpoint, name string) {
+	t.Helper()
+	org := rmv1alpha1.Organization{
+		TypeMeta:   metav1.TypeMeta{APIVersion: "resourcemanager.miloapis.com/v1alpha1", Kind: "Organization"},
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Spec:       rmv1alpha1.OrganizationSpec{Type: "Standard"},
+	}
+	body, err := json.Marshal(org)
+	if err != nil {
+		t.Fatalf("marshal org: %v", err)
+	}
+	if _, err := s.post(context.Background(), rmAPIBase+"/organizations", body); err != nil {
+		t.Fatalf("create org %s: %v", name, err)
+	}
+}
+
+func createProject(t *testing.T, s *endpoint, name, orgName string) {
+	t.Helper()
+	proj := rmv1alpha1.Project{
+		TypeMeta:   metav1.TypeMeta{APIVersion: "resourcemanager.miloapis.com/v1alpha1", Kind: "Project"},
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Spec: rmv1alpha1.ProjectSpec{
+			OwnerRef: rmv1alpha1.OwnerReference{Kind: "Organization", Name: orgName},
+		},
+	}
+	body, err := json.Marshal(proj)
+	if err != nil {
+		t.Fatalf("marshal project: %v", err)
+	}
+	// Projects must be created via the org-scoped path so that
+	// OrganizationContextHandler injects the required parent Extra fields
+	// (iam.miloapis.com/parent-*) that the admission webhook enforces.
+	path := fmt.Sprintf("/apis/resourcemanager.miloapis.com/v1alpha1/organizations/%s/control-plane%s/projects", orgName, rmAPIBase)
+	if _, err := s.post(context.Background(), path, body); err != nil {
+		t.Fatalf("create project %s: %v", name, err)
+	}
+}
+
+func bootstrapProjects(t *testing.T, s *endpoint, projectIDs []string, gvrs []schema.GroupVersionResource) {
+	t.Helper()
+	total := int32(len(projectIDs) * len(gvrs))
+	var done atomic.Int32
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Minute)
+	defer cancel()
+
+	eg, ctx := errgroup.WithContext(ctx)
+	eg.SetLimit(workerCount)
+
+	for _, pid := range projectIDs {
+		for _, gvr := range gvrs {
+			eg.Go(func() error {
+				if err := initProjectGVR(ctx, s, pid, gvr); err != nil {
+					return fmt.Errorf("project=%s resource=%v: %w", pid, gvr, err)
+				}
+				if n := done.Add(1); total >= 10 && n%(total/10) == 0 {
+					t.Logf("bootstrap: %d/%d", n, total)
+				}
+				return nil
+			})
+		}
+	}
+	if err := eg.Wait(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// initProjectGVR lists one resource in a project's control plane, triggering
+// projectMux child creation for that (project, GVR) pair.
+//
+// 429/503 (watchcache reinit) are retried indefinitely.
+// All other errors (including 500) are retried up to maxTransportRetries times.
+func initProjectGVR(ctx context.Context, s *endpoint, projectID string, gvr schema.GroupVersionResource) error {
+	const maxTransportRetries = 10
+	base := "/apis/resourcemanager.miloapis.com/v1alpha1/projects/" + projectID + "/control-plane"
+	backoff := 200 * time.Millisecond
+	transportRetries := 0
+	for {
+		_, err := s.get(ctx, gvrPath(base, gvr))
+		if err == nil {
+			return nil
+		}
+		var se *httpStatusError
+		if errors.As(err, &se) {
+			switch se.code {
+			case http.StatusServiceUnavailable, http.StatusTooManyRequests:
+				transportRetries = 0 // watchcache reinit — retry indefinitely
+			default:
+				if transportRetries++; transportRetries > maxTransportRetries {
+					return fmt.Errorf("listing %v: %w", gvr, err)
+				}
+			}
+		} else {
+			if transportRetries++; transportRetries > maxTransportRetries {
+				return fmt.Errorf("listing %v: %w", gvr, err)
+			}
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(backoff):
+			backoff = min(backoff*2, 5*time.Second)
+		}
+	}
+}
+
+// --- measurement ---
+
+// waitUntilStable polls until apiserver goroutines settle, returning a cluster
+// snapshot. Stability is 3 consecutive samples within 100 goroutines of each
+// other; times out after 8 minutes.
+func waitUntilStable(t *testing.T, s *endpoint, etcd *endpoint, label string) clusterSnapshot {
+	t.Helper()
+	const (
+		interval  = 10 * time.Second
+		threshold = 100
+		window    = 3
+		timeout   = 8 * time.Minute
+	)
+	deadline := time.Now().Add(timeout)
+	var prev float64
+	streak := 0
+	var snap clusterSnapshot
+	for {
+		var err error
+		snap, err = sampleCluster(context.Background(), s, etcd)
+		if err != nil {
+			t.Logf("[%s] sample error: %v", label, err)
+			time.Sleep(interval)
+			continue
+		}
+		delta := snap.apiserver.goroutines - prev
+		if delta < 0 {
+			delta = -delta
+		}
+		t.Logf("[%s] Δgoroutines=%.0f %s", label, delta, snap)
+		if prev > 0 && delta < threshold {
+			if streak++; streak >= window {
+				return snap
+			}
+		} else {
+			streak = 0
+		}
+		prev = snap.apiserver.goroutines
+		if time.Now().After(deadline) {
+			t.Logf("[%s] goroutines still growing after %s — measurement may be premature", label, timeout)
+			return snap
+		}
+		time.Sleep(interval)
+	}
+}
+
+// measureLatency makes one sequential pass through paths and returns latency percentiles
+func measureLatency(s *endpoint, paths []string) latencyReport {
+	ctx := context.Background()
+	var samples []time.Duration
+	var errCount int
+	for _, path := range paths {
+		t0 := time.Now()
+		_, err := s.get(ctx, path)
+		if err != nil {
+			errCount++
+		} else {
+			samples = append(samples, time.Since(t0))
+		}
+	}
+	if len(samples) == 0 {
+		return latencyReport{errors: errCount}
+	}
+	slices.Sort(samples)
+	n := len(samples)
+	return latencyReport{
+		count:  n,
+		errors: errCount,
+		p50:    samples[(n-1)*50/100],
+		p90:    samples[(n-1)*90/100],
+		p99:    samples[(n-1)*99/100],
+		max:    samples[n-1],
+	}
+}
+
+// --- sampling ---
+
+func sampleCluster(ctx context.Context, s *endpoint, etcd *endpoint) (clusterSnapshot, error) {
+	api, err := sampleMemory(ctx, s)
+	if err != nil {
+		return clusterSnapshot{}, fmt.Errorf("apiserver: %w", err)
+	}
+	var e etcdSnapshot
+	if etcd != nil {
+		if v, err := sampleEtcd(ctx, etcd); err == nil {
+			e = v
+		}
+	}
+	return clusterSnapshot{apiserver: api, etcd: e}, nil
+}
+
+func sampleMemory(ctx context.Context, e *endpoint) (memorySnapshot, error) {
+	text, err := e.get(ctx, "/metrics")
+	if err != nil {
+		return memorySnapshot{}, err
+	}
+	heap, err := promGauge(text, "go_memstats_heap_inuse_bytes")
+	if err != nil {
+		return memorySnapshot{}, err
+	}
+	sys, err := promGauge(text, "go_memstats_sys_bytes")
+	if err != nil {
+		return memorySnapshot{}, err
+	}
+	goroutines, err := promGauge(text, "go_goroutines")
+	if err != nil {
+		return memorySnapshot{}, err
+	}
+	return memorySnapshot{heapInuse: heap, sys: sys, goroutines: goroutines}, nil
+}
+
+func sampleEtcd(ctx context.Context, e *endpoint) (etcdSnapshot, error) {
+	text, err := e.get(ctx, "/metrics")
+	if err != nil {
+		return etcdSnapshot{}, err
+	}
+	watchers, err := promGauge(text, "etcd_debugging_mvcc_watcher_total")
+	if err != nil {
+		return etcdSnapshot{}, err
+	}
+	return etcdSnapshot{watchers: watchers}, nil
+}
+
+// --- discovery ---
+
+func mustDiscoverGVRs(t *testing.T, s *endpoint) []schema.GroupVersionResource {
+	t.Helper()
+	dc, err := discovery.NewDiscoveryClientForConfig(&rest.Config{
+		Host:            s.url,
+		BearerToken:     s.token,
+		TLSClientConfig: rest.TLSClientConfig{Insecure: true},
+	})
+	if err != nil {
+		t.Fatalf("discovery client: %v", err)
+	}
+	lists, err := dc.ServerPreferredResources()
+	if err != nil && !discovery.IsGroupDiscoveryFailedError(err) {
+		t.Fatalf("server preferred resources: %v", err)
+	}
+	var gvrs []schema.GroupVersionResource
+	for _, list := range lists {
+		gv, err := schema.ParseGroupVersion(list.GroupVersion)
+		if err != nil {
+			continue
+		}
+		if _, skip := skipGroups[gv.Group]; skip {
+			continue
+		}
+		for _, r := range list.APIResources {
+			if !strings.Contains(r.Name, "/") && slices.Contains(r.Verbs, "list") {
+				gvrs = append(gvrs, gv.WithResource(r.Name))
+			}
+		}
+	}
+	return gvrs
+}
+
+func buildGlobalPaths(gvrs []schema.GroupVersionResource) []string {
+	paths := make([]string, len(gvrs))
+	for i, gvr := range gvrs {
+		paths[i] = gvrPath("", gvr)
+	}
+	return paths
+}
+
+func gvrPath(base string, gvr schema.GroupVersionResource) string {
+	if gvr.Group == "" {
+		return fmt.Sprintf("%s/api/%s/%s", base, gvr.Version, gvr.Resource)
+	}
+	return fmt.Sprintf("%s/apis/%s/%s/%s", base, gvr.Group, gvr.Version, gvr.Resource)
+}
+
+// --- profiles ---
+
+func saveProfiles(t *testing.T, s *endpoint, nProjects int, label string) {
+	t.Helper()
+	outDir := filepath.Join(repoRoot(t), "dev", "profiles")
+	if err := os.MkdirAll(outDir, 0o755); err != nil {
+		t.Fatalf("profiles mkdir: %v", err)
+	}
+	for _, p := range []struct{ path, name string }{
+		{"/debug/pprof/heap?gc=1", fmt.Sprintf("heap-%dp-%s.pb.gz", nProjects, label)},
+		{"/debug/pprof/goroutine?debug=1", fmt.Sprintf("goroutine-%dp-%s.txt", nProjects, label)},
+	} {
+		body, err := s.get(context.Background(), p.path)
+		if err != nil {
+			t.Logf("profiles: fetch %s: %v", p.name, err)
+			continue
+		}
+		dst := filepath.Join(outDir, p.name)
+		if err := os.WriteFile(dst, []byte(body), 0o644); err != nil {
+			t.Logf("profiles: write %s: %v", p.name, err)
+			continue
+		}
+		t.Logf("profiles: saved %s", dst)
+	}
+}
+
+// --- helpers ---
+
+func promGauge(text, metric string) (float64, error) {
+	for _, line := range strings.Split(text, "\n") {
+		if val, ok := strings.CutPrefix(line, metric+" "); ok {
+			return strconv.ParseFloat(strings.TrimSpace(val), 64)
+		}
+	}
+	return 0, fmt.Errorf("metric %s not found", metric)
+}


### PR DESCRIPTION
## Summary

Phase one of #596.

- Adds a `scale` build-tag test in `test/scale/` that measures per-project memory, goroutine, and etcd watcher overhead against a live Milo API server
- Captures before/after snapshots (heap, sys, goroutines, etcd watchers) with pprof profile export to `dev/profiles/`
- Adds `task test:scale` and excludes generated profiles from git
- Uses existing dev cluster setup and `go test`

This establishes a baseline (the test does not define any thresholds) to help us quantify the current per-project costs before implementing any architectural changes.

### How to run
```shell
task dev:setup                     # provision dev infra 
task test:scale                    # 20 projects (default)
```

```shell
# or to run with n projects
SCALE_PROJECTS=50 task test:scale
```

Profiles are written to `dev/profiles/heap-{N}p-{before,after}.pb.gz` and can be compared with `go tool pprof`.

### Test plan
  - [x] `task test:scale` completes against a `task dev:setup` environment
  - [x] `go test ./...` (without `-tags scale`) is unaffected

### Example Run

<details><summary>Log</summary>

```
=== RUN   TestProjectControlPlaneOverhead
    project_overhead_test.go:107: connected to milo apiserver at https://localhost:30443
    project_overhead_test.go:108: port-forward milo-system/svc/etcd: localhost:63269 -> 2379
    project_overhead_test.go:112: resources: 52 listable types
    project_overhead_test.go:114: [before] Δgoroutines=1661 apiserver[heap=125.1MiB sys=183.7MiB goroutines=1661] etcd[watchers=54]
    project_overhead_test.go:114: [before] Δgoroutines=1 apiserver[heap=129.9MiB sys=183.7MiB goroutines=1662] etcd[watchers=54]
    project_overhead_test.go:114: [before] Δgoroutines=9 apiserver[heap=134.8MiB sys=183.7MiB goroutines=1653] etcd[watchers=54]
    project_overhead_test.go:114: [before] Δgoroutines=1 apiserver[heap=111.4MiB sys=183.7MiB goroutines=1654] etcd[watchers=54]
    project_overhead_test.go:115: latency before: n=52 errors=0 p50=1ms p90=2ms p99=3ms max=8ms
    project_overhead_test.go:160: bootstrap: 104/1040
    project_overhead_test.go:160: bootstrap: 208/1040
    project_overhead_test.go:160: bootstrap: 312/1040
    project_overhead_test.go:160: bootstrap: 416/1040
    project_overhead_test.go:160: bootstrap: 520/1040
    project_overhead_test.go:160: bootstrap: 624/1040
    project_overhead_test.go:160: bootstrap: 728/1040
    project_overhead_test.go:160: bootstrap: 832/1040
    project_overhead_test.go:160: bootstrap: 936/1040
    project_overhead_test.go:160: bootstrap: 1040/1040
    project_overhead_test.go:119: [after] Δgoroutines=21782 apiserver[heap=333.1MiB sys=484.9MiB goroutines=21782] etcd[watchers=1054]
    project_overhead_test.go:119: [after] Δgoroutines=1097 apiserver[heap=341.0MiB sys=484.9MiB goroutines=20685] etcd[watchers=1054]
    project_overhead_test.go:119: [after] Δgoroutines=0 apiserver[heap=348.8MiB sys=484.9MiB goroutines=20685] etcd[watchers=1054]
    project_overhead_test.go:119: [after] Δgoroutines=8 apiserver[heap=361.6MiB sys=484.9MiB goroutines=20693] etcd[watchers=1054]
    project_overhead_test.go:119: [after] Δgoroutines=5 apiserver[heap=371.1MiB sys=484.9MiB goroutines=20698] etcd[watchers=1054]
    project_overhead_test.go:120: latency after:  n=52 errors=0 p50=1ms p90=1ms p99=3ms max=5ms
    project_overhead_test.go:123: results: projects=20 resources_per_project=52
    project_overhead_test.go:124:   before:      apiserver[heap=111.4MiB sys=183.7MiB goroutines=1654] etcd[watchers=54]
    project_overhead_test.go:125:   after:       apiserver[heap=371.1MiB sys=484.9MiB goroutines=20698] etcd[watchers=1054]
    project_overhead_test.go:126:   per-project: apiserver[heap=13.0MiB sys=15.1MiB goroutines=952] etcd[watchers=50]
    project_overhead_test.go:128: profiles: saved milo/dev/profiles/heap-20p.pb.gz
    project_overhead_test.go:128: profiles: saved milo/dev/profiles/goroutine-20p.txt
--- PASS: TestProjectControlPlaneOverhead (73.27s)
```

</details> 
