### PR TITLE
feat: add billing ActivityPolicies for BillingAccount + PaymentMethod

### DIFF
--- a/config/services/activity/policies/billing/billingaccount-policy.yaml
+++ b/config/services/activity/policies/billing/billingaccount-policy.yaml
@@ -1,0 +1,44 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+
+# ActivityPolicy for BillingAccount resources.
+# Defines how BillingAccount API operations appear in activity timelines.
+#
+# Audit rules handle CRUD operations captured by the Kubernetes API server audit log.
+# No eventRules — the controller sets conditions but does not emit Kubernetes Events.
+#
+# Design principles:
+# - Prefer contactInfo.businessName / contactInfo.name as the display label,
+#   falling back to the BillingAccount metadata name. The has() guards mean
+#   create entries surface the human-recognisable label while delete entries
+#   (which carry no requestObject) cleanly degrade to the resource name.
+# - Action-oriented language ("created billing account", ...)
+# - Exclude system actors so controller reconciliation does not generate noise.
+apiVersion: activity.miloapis.com/v1alpha1
+kind: ActivityPolicy
+metadata:
+  name: billing.miloapis.com-billingaccount
+spec:
+  resource:
+    apiGroup: billing.miloapis.com
+    kind: BillingAccount
+
+  auditRules:
+    - name: create-with-business-name
+      match: "!audit.user.username.startsWith('system:') && audit.verb == 'create' && has(audit.requestObject.spec) && has(audit.requestObject.spec.contactInfo) && has(audit.requestObject.spec.contactInfo.businessName)"
+      summary: "{{ actor }} created billing account {{ audit.requestObject.spec.contactInfo.businessName }}"
+
+    - name: create-with-contact-name
+      match: "!audit.user.username.startsWith('system:') && audit.verb == 'create' && has(audit.requestObject.spec) && has(audit.requestObject.spec.contactInfo) && has(audit.requestObject.spec.contactInfo.name)"
+      summary: "{{ actor }} created billing account for {{ audit.requestObject.spec.contactInfo.name }}"
+
+    - name: create-fallback
+      match: "!audit.user.username.startsWith('system:') && audit.verb == 'create'"
+      summary: "{{ actor }} created billing account {{ link(audit.objectRef.name, audit.objectRef) }}"
+
+    - name: delete
+      match: "!audit.user.username.startsWith('system:') && audit.verb == 'delete'"
+      summary: "{{ actor }} deleted billing account {{ audit.objectRef.name }}"
+
+    - name: update
+      match: "!audit.user.username.startsWith('system:') && audit.verb in ['update', 'patch'] && !has(audit.objectRef.subresource)"
+      summary: "{{ actor }} updated billing account {{ link(audit.objectRef.name, audit.objectRef) }}"

--- a/config/services/activity/policies/billing/billingaccountbinding-policy.yaml
+++ b/config/services/activity/policies/billing/billingaccountbinding-policy.yaml
@@ -1,0 +1,34 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+
+# ActivityPolicy for BillingAccountBinding resources.
+# A BillingAccountBinding attaches a Project to a BillingAccount; surfacing
+# create/delete events lets organisation operators see when projects are
+# rerouted to a different billing account.
+#
+# Audit rules handle CRUD operations captured by the Kubernetes API server audit log.
+# No eventRules — the controller sets conditions but does not emit Kubernetes Events.
+apiVersion: activity.miloapis.com/v1alpha1
+kind: ActivityPolicy
+metadata:
+  name: billing.miloapis.com-billingaccountbinding
+spec:
+  resource:
+    apiGroup: billing.miloapis.com
+    kind: BillingAccountBinding
+
+  auditRules:
+    - name: create-with-refs
+      match: "!audit.user.username.startsWith('system:') && audit.verb == 'create' && has(audit.requestObject.spec) && has(audit.requestObject.spec.projectRef) && has(audit.requestObject.spec.billingAccountRef)"
+      summary: "{{ actor }} bound project {{ audit.requestObject.spec.projectRef.name }} to billing account {{ audit.requestObject.spec.billingAccountRef.name }}"
+
+    - name: create-fallback
+      match: "!audit.user.username.startsWith('system:') && audit.verb == 'create'"
+      summary: "{{ actor }} created billing account binding {{ link(audit.objectRef.name, audit.objectRef) }}"
+
+    - name: delete
+      match: "!audit.user.username.startsWith('system:') && audit.verb == 'delete'"
+      summary: "{{ actor }} deleted billing account binding {{ audit.objectRef.name }}"
+
+    - name: update
+      match: "!audit.user.username.startsWith('system:') && audit.verb in ['update', 'patch'] && !has(audit.objectRef.subresource)"
+      summary: "{{ actor }} updated billing account binding {{ link(audit.objectRef.name, audit.objectRef) }}"

--- a/config/services/activity/policies/billing/kustomization.yaml
+++ b/config/services/activity/policies/billing/kustomization.yaml
@@ -1,0 +1,9 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+resources:
+  - billingaccount-policy.yaml
+  - billingaccountbinding-policy.yaml
+  - paymentmethod-policy.yaml

--- a/config/services/activity/policies/billing/paymentmethod-policy.yaml
+++ b/config/services/activity/policies/billing/paymentmethod-policy.yaml
@@ -1,0 +1,38 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+
+# ActivityPolicy for PaymentMethod resources.
+# A PaymentMethod represents a single tokenized payment instrument owned by a
+# BillingAccount. Card details (brand, last4, etc.) only exist on .status
+# after the provider controller has attached the upstream PaymentMethod, and
+# audit events for updates are dominated by controller status writes —
+# the user-visible mutations are create (add a card) and delete (remove it).
+#
+# Audit rules handle CRUD operations captured by the Kubernetes API server audit log.
+# eventRules surface the provider controller's phase transition Events
+# (PaymentMethodAttached, PaymentMethodFailed) so the timeline reflects the
+# asynchronous outcome of card collection without leaking SDK detail.
+apiVersion: activity.miloapis.com/v1alpha1
+kind: ActivityPolicy
+metadata:
+  name: billing.miloapis.com-paymentmethod
+spec:
+  resource:
+    apiGroup: billing.miloapis.com
+    kind: PaymentMethod
+
+  auditRules:
+    - name: create-with-display-name
+      match: "!audit.user.username.startsWith('system:') && audit.verb == 'create' && has(audit.requestObject.spec) && has(audit.requestObject.spec.displayName)"
+      summary: "{{ actor }} added payment method {{ audit.requestObject.spec.displayName }}"
+
+    - name: create-fallback
+      match: "!audit.user.username.startsWith('system:') && audit.verb == 'create'"
+      summary: "{{ actor }} added payment method {{ link(audit.objectRef.name, audit.objectRef) }}"
+
+    - name: delete
+      match: "!audit.user.username.startsWith('system:') && audit.verb == 'delete'"
+      summary: "{{ actor }} removed payment method {{ audit.objectRef.name }}"
+
+    - name: update
+      match: "!audit.user.username.startsWith('system:') && audit.verb in ['update', 'patch'] && !has(audit.objectRef.subresource)"
+      summary: "{{ actor }} updated payment method {{ link(audit.objectRef.name, audit.objectRef) }}"

--- a/config/services/activity/policies/kustomization.yaml
+++ b/config/services/activity/policies/kustomization.yaml
@@ -4,6 +4,7 @@ apiVersion: kustomize.config.k8s.io/v1alpha1
 kind: Component
 
 components:
+  - billing
   - iam
   - resourcemanager
   - identity-provider


### PR DESCRIPTION
## Summary

Adds ActivityPolicy coverage for the user-facing billing API resources introduced in milo-os/billing v0.2.0 so organisation operators can see who created billing accounts, attached projects, and added or removed payment methods in the activity timeline.

Lives under \`config/services/activity/policies/billing/\` and wired in alongside the existing \`iam\`, \`resourcemanager\`, \`identity-provider\`, \`notes\`, \`notification\`, \`quota\` components.

## Coverage

| Resource | Why |
|---|---|
| \`BillingAccount\` | User-created; surfaces \`contactInfo.businessName\` / \`contactInfo.name\` in the summary when present, falling back to the resource name. |
| \`BillingAccountBinding\` | Surfaces \`projectRef\` + \`billingAccountRef\` so the timeline reads \`<actor> bound project X to billing account Y\` even when the binding's own \`metadata.name\` is generated. |
| \`PaymentMethod\` | Tracks the user-driven add / remove path. Async attach phase is system-actor-owned, gets filtered out as noise. |

## Out of scope

- **\`PaymentMethodClass\`** — cluster-scoped, operator-managed via Git; no user audit trail.
- **\`MeterDefinition\`**, **\`MonitoredResourceType\`** — admin-managed.
- **\`stripe.billing.miloapis.com/{StripeProviderConfig, StripePaymentMethod}\`** — controller-owned, written exclusively under the \`system:\` actor and consumed by billing's user-facing \`PaymentMethod\` rather than directly by humans.

## Validation

\`kustomize build config/services/activity\` clean; new policies render alongside the existing ones.