### PR TITLE
Make system Kubernetes resources visible in all discovery contexts

### DIFF
--- a/config/discovery/core/discovery-context-policy.yaml
+++ b/config/discovery/core/discovery-context-policy.yaml
@@ -16,18 +16,6 @@ spec:
     - group: "apiregistration.k8s.io"
       resources: ["apiservices"]
       contexts: ["Platform"]
-    - group: "authentication.k8s.io"
-      resources: ["selfsubjectreviews", "tokenreviews"]
-      contexts: ["Platform"]
-    - group: "authorization.k8s.io"
-      resources: ["localsubjectaccessreviews", "selfsubjectaccessreviews", "selfsubjectrulesreviews", "subjectaccessreviews"]
-      contexts: ["Platform"]
-    - group: "flowcontrol.apiserver.k8s.io"
-      resources: ["flowschemas", "prioritylevelconfigurations"]
-      contexts: ["Platform"]
-    - group: "coordination.k8s.io"
-      resources: ["leases"]
-      contexts: ["Platform"]
     - group: "admissionregistration.k8s.io"
       resources: ["mutatingwebhookconfigurations", "validatingadmissionpolicies", "validatingadmissionpolicybindings", "validatingwebhookconfigurations"]
       contexts: ["Platform"]


### PR DESCRIPTION
## Summary

- Removes `authentication.k8s.io` (TokenReview, SelfSubjectReview) and `authorization.k8s.io` (SubjectAccessReview, LocalSubjectAccessReview, etc.) from the `core-kubernetes-resources` DiscoveryContextPolicy, making them available in all contexts rather than Platform-only.
- Removes `flowcontrol.apiserver.k8s.io` (FlowSchema, PriorityLevelConfiguration) and `coordination.k8s.io` (Lease) for the same reason.

## Why

The `DiscoveryContextPolicy` was hiding these resources from clients operating in Organization, Project, and User contexts. Clients in those contexts legitimately need them:

- **Auth resources** (`authentication.k8s.io`, `authorization.k8s.io`) — token validation and permission checks are required regardless of which context a client is scoped to.
- **Leases** (`coordination.k8s.io`) — used for leader election by controllers that may run within project or organization contexts.
- **Flow control** (`flowcontrol.apiserver.k8s.io`) — API priority and fairness metadata is infrastructure that should be transparent to all clients.

Removing a resource from the policy causes the registry to return `nil` for `AllowedContexts`, which the discovery filter treats as "visible everywhere" — the same default used for resources with no policy entry at all.

## Test plan

- [ ] Verify `kubectl api-resources` returns auth/authorization/coordination/flowcontrol resources when queried through an organization or project context URL prefix.
- [ ] Confirm Platform context discovery is unaffected.
- [ ] Confirm resources still restricted to Platform (RBAC, CRDs, webhooks) are not visible in Project/Organization contexts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)