### PR TITLE
feat(iam): aggregate billing-admin into owner role

### DIFF
--- a/config/roles/owner.yaml
+++ b/config/roles/owner.yaml
@@ -12,3 +12,5 @@ spec:
     - name: iam-admin
     - name: core-admin
     - name: apiextensions-reader
+    - name: billing.miloapis.com-admin
+      namespace: milo-system


### PR DESCRIPTION
## What

Add `billing.miloapis.com-admin` (installed in `milo-system` by milo-os/billing) as an `inheritedRoles` entry on the `owner` role.

```diff
 spec:
   launchStage: Beta
   inheritedRoles:
     - name: resourcemanager-admin
     - name: iam-admin
     - name: core-admin
     - name: apiextensions-reader
+    - name: billing.miloapis.com-admin
+      namespace: milo-system
```

## Why

Today nothing wires billing's IAM into the owner aggregation:

- `owner` is the Role every organization owner is bound to via PolicyBinding (datum's milo runs with `--organization-owner-role-name=owner --organization-owner-role-namespace=datum-cloud`).
- `billing.miloapis.com-admin` is defined in milo-os/billing and installed into `milo-system` by infra's `billing-milo-control-plane` Flux Kustomization. It carries `billingaccounts.{create,update,patch,delete}`, `billingaccountbindings.{create,update,patch,delete}`, and `paymentmethods.{create,update,patch,delete}`.
- No PolicyBinding in milo, billing, or infra connects the two.

Concrete effect: organization owners hit a 403 when the cloud-portal posts a BillingAccount on their behalf through the org's control plane proxy. Diagnosed today against staging while testing cloud-portal's `feat/org-billing` branch — the portal renders this 403 as a generic *"Something went wrong while checking your quota for this request"* error, which is what surfaced the issue.

## Pattern match

`owner` already aggregates the per-domain service admin roles — `resourcemanager-admin`, `iam-admin`, `core-admin`, `apiextensions-reader`. Billing is just another domain, so this PR follows the exact same shape.

`ScopedRoleReference` supports an optional `namespace` field (`pkg/apis/iam/v1alpha1/types.go`), so we can reference the billing-admin role across namespaces without copying it into `datum-cloud`.

## Scope of permissions granted

`billing.miloapis.com-admin` deliberately does **not** include `paymentmethodclasses.*` mutating verbs (cluster-admin only per the comment in billing's protected-resources). So org owners gain no control surface over payment method class definitions — only their own accounts, bindings, and payment methods.

## Risk

If milo is deployed somewhere without billing installed in `milo-system`, the IAM controller will surface a missing-inheritedRole condition on the owner role. Non-fatal — owner just won't gain billing permissions there. Datum staging and production both deploy billing-milo-control-plane today, so the warning won't appear in our environments.