### PR TITLE
fix(quota): derive Organization consumer from request context

### DIFF
--- a/internal/quota/admission/plugin.go
+++ b/internal/quota/admission/plugin.go
@@ -33,6 +33,7 @@ import (
 	"go.miloapis.com/milo/internal/quota/validation"
 	quotav1alpha1 "go.miloapis.com/milo/pkg/apis/quota/v1alpha1"
 	milorequest "go.miloapis.com/milo/pkg/request"
+	milofilters "go.miloapis.com/milo/pkg/server/filters"
 )
 
 const (
@@ -735,7 +736,6 @@ func (p *ResourceQuotaEnforcementPlugin) createAndWaitForResourceClaim(ctx conte
 	}
 }
 
-
 // getClaimNamespace determines the namespace for a ResourceClaim.
 // If the policy template specifies a namespace containing CEL expressions,
 // the template is rendered to evaluate those expressions. Otherwise, the
@@ -803,14 +803,23 @@ func (p *ResourceQuotaEnforcementPlugin) createResourceClaim(ctx context.Context
 		Namespace: attrs.GetNamespace(),
 	}
 
-	// Derive consumer from project context when template doesn't specify one
+	// Derive consumer from the request's parent context when the
+	// ClaimCreationPolicy template doesn't specify one. Project context
+	// wins over Organization context when both are present (project
+	// control plane requests carry the org for telemetry but the
+	// consumer is the project).
 	if claim.Spec.ConsumerRef.Kind == "" || claim.Spec.ConsumerRef.Name == "" {
-		projectID, ok := milorequest.ProjectID(ctx)
-		if ok && projectID != "" {
+		if projectID, ok := milorequest.ProjectID(ctx); ok && projectID != "" {
 			claim.Spec.ConsumerRef = quotav1alpha1.ConsumerRef{
 				APIGroup: "resourcemanager.miloapis.com",
 				Kind:     "Project",
 				Name:     projectID,
+			}
+		} else if orgID, ok := milofilters.OrganizationID(ctx); ok && orgID != "" {
+			claim.Spec.ConsumerRef = quotav1alpha1.ConsumerRef{
+				APIGroup: "resourcemanager.miloapis.com",
+				Kind:     "Organization",
+				Name:     orgID,
 			}
 		}
 	}


### PR DESCRIPTION
## What

`internal/quota/admission/plugin.go`: extend the empty-consumer fallback to derive an Organization consumer from the request's parent-context URL, mirroring the existing Project branch.

```diff
 // Derive consumer from the request's parent context when the
 // ClaimCreationPolicy template doesn't specify one.
 if claim.Spec.ConsumerRef.Kind == "" || claim.Spec.ConsumerRef.Name == "" {
-    projectID, ok := milorequest.ProjectID(ctx)
-    if ok && projectID != "" {
+    if projectID, ok := milorequest.ProjectID(ctx); ok && projectID != "" {
         claim.Spec.ConsumerRef = quotav1alpha1.ConsumerRef{
             APIGroup: "resourcemanager.miloapis.com",
             Kind:     "Project",
             Name:     projectID,
         }
+    } else if orgID, ok := milofilters.OrganizationID(ctx); ok && orgID != "" {
+        claim.Spec.ConsumerRef = quotav1alpha1.ConsumerRef{
+            APIGroup: "resourcemanager.miloapis.com",
+            Kind:     "Organization",
+            Name:     orgID,
+        }
     }
 }
```

## Why

ClaimCreationPolicy templates produced by service-catalog's QuotaFanOut ship with `consumerRef.{kind,name}` empty and rely on the admission plugin to fill in the consumer from the request's parent context. The plugin already does this for project control plane requests:

```go
if projectID, ok := milorequest.ProjectID(ctx); ok && projectID != "" {
    claim.Spec.ConsumerRef = ConsumerRef{APIGroup: "resourcemanager.miloapis.com", Kind: "Project", Name: projectID}
}
```

There is no equivalent branch for Organization. So creating an organization-scoped resource (e.g. a `BillingAccount` posted to `/apis/resourcemanager.miloapis.com/v1alpha1/organizations/<org>/control-plane/apis/billing.miloapis.com/v1alpha1/namespaces/organization-<org>/billingaccounts`) produces a ResourceClaim with `consumerRef.{apiGroup,kind,name} = ""`. `validation.IsClaimingResourceAllowed` then rejects it:

```
consumer type mismatch for resource type billing.miloapis.com/billingaccount/count:
expected resourcemanager.miloapis.com/Organization, got /
```

…and the parent BillingAccount create returns 403 to the client. This is exactly the failure cloud-portal's `feat/org-billing` work hit against staging today.

`pkg/server/filters/OrganizationID(ctx)` is the symmetric counterpart of `milorequest.ProjectID(ctx)` — set by the existing `OrganizationContextHandler` when the request URL carries the `/apis/resourcemanager.miloapis.com/v1alpha1/organizations/<id>/control-plane/` prefix. The fix is a one-line behavioural addition that uses it.

## Precedence

Project wins when both are present. That matches the single-branch behaviour the plugin had before — a project control plane request that happens to also carry an org for telemetry should still produce a Project consumer. No service today registers a resource type as both project-scoped and org-scoped, so the precedence is observationally invisible; encoding it explicitly here keeps the intent obvious to a reader.

## Validation

- `go build ./...` clean.
- `go test ./internal/quota/admission/...` clean.
- Once merged + the milo bundle reconciles in staging, re-enable the temporarily-disabled `billing-miloapis-com-billingaccount` ClaimCreationPolicy and retry a BillingAccount create — should succeed with the policy's "1 per Organization" cap enforced.