### PR TITLE
fix(controller-manager): scope per-project quota caches to cut memory

### DIFF
--- a/cmd/milo/controller-manager/controllermanager.go
+++ b/cmd/milo/controller-manager/controllermanager.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apiserver/pkg/server/healthz"
 	"k8s.io/apiserver/pkg/server/mux"
+	apiservercompat "k8s.io/apiserver/pkg/util/compatibility"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	cacheddiscovery "k8s.io/client-go/discovery/cached/memory"
 	"k8s.io/client-go/dynamic"
@@ -43,6 +44,7 @@ import (
 	certutil "k8s.io/client-go/util/cert"
 	cliflag "k8s.io/component-base/cli/flag"
 	"k8s.io/component-base/cli/globalflag"
+	basecompatibility "k8s.io/component-base/compatibility"
 	"k8s.io/component-base/configz"
 	"k8s.io/component-base/featuregate"
 	"k8s.io/component-base/logs"
@@ -53,8 +55,6 @@ import (
 	"k8s.io/component-base/term"
 	"k8s.io/component-base/version"
 	"k8s.io/component-base/version/verflag"
-	basecompatibility "k8s.io/component-base/compatibility"
-	apiservercompat "k8s.io/apiserver/pkg/util/compatibility"
 	genericcontrollermanager "k8s.io/controller-manager/app"
 	"k8s.io/controller-manager/controller"
 	"k8s.io/controller-manager/pkg/clientbuilder"
@@ -69,6 +69,8 @@ import (
 	garbagecollector "k8s.io/kubernetes/pkg/controller/garbagecollector"
 	kubefeatures "k8s.io/kubernetes/pkg/features"
 	controllerruntime "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/cluster"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
@@ -630,6 +632,15 @@ func Run(ctx context.Context, c *config.CompletedConfig, opts *Options) error {
 				ClusterOptions: []cluster.Option{
 					func(o *cluster.Options) {
 						o.Scheme = Scheme
+						o.Cache = cache.Options{
+							ByObject: map[client.Object]cache.ByObject{
+								&quotav1alpha1.ResourceClaim{}:   {},
+								&quotav1alpha1.ResourceGrant{}:   {},
+								&quotav1alpha1.AllowanceBucket{}: {},
+							},
+							DefaultTransform:            cache.TransformStripManagedFields(),
+							ReaderFailOnMissingInformer: true,
+						}
 					},
 				},
 				InternalServiceDiscovery: false, // Use Project resources for user-facing API


### PR DESCRIPTION
## Problem

The Milo multicluster provider engages one full controller-runtime cluster per Ready Project (`pkg/multicluster-runtime/milo/provider.go:251`, `cluster.New`), and the only `ClusterOption` set is the `Scheme` (`cmd/milo/controller-manager/controllermanager.go:630-634`). Each per-project cache therefore stores **full objects, including `managedFields`**, for every type the provider-engaged quota controllers watch.

Memory scales linearly with project count. In production ~395 projects drive the single controller-manager replica past its 6Gi limit:

| Metric | Value |
|---|---|
| project control-plane namespaces | 395 |
| `go_goroutines` | 438,125 (~1,100 / project) |
| `go_memstats_stack_inuse_bytes` | 1.51 GiB |
| heap + stack | 4.87 GiB |
| `container_memory_working_set_bytes` | 5.51 GiB |

Result: cgroup OOMKills of the `milo` process and node memory-pressure evictions (incl. collateral promtail / node_exporter).

Full diagnosis: #631.

## Change

Scope each per-project cache to the three GVKs the provider-engaged quota controllers actually watch (`ResourceClaim`, `ResourceGrant`, `AllowanceBucket` — `internal/quota/controllers/core/{claim,grant,bucket}.go`, all `WithEngageWithProviderClusters(true)`), and strip `managedFields` from all cached objects via `cache.TransformStripManagedFields()`.

```go
o.Cache = cache.Options{
    ByObject: map[client.Object]cache.ByObject{
        &quotav1alpha1.ResourceClaim{}:   {},
        &quotav1alpha1.ResourceGrant{}:   {},
        &quotav1alpha1.AllowanceBucket{}: {},
    },
    DefaultTransform:            cache.TransformStripManagedFields(),
    ReaderFailOnMissingInformer: true,
}
```

## Expected impact

- `DefaultTransform: TransformStripManagedFields()` is the primary win — applies across all ~395 project caches, typically 30-50% per-object heap, cutting a large chunk of the ~3.35 GiB informer heap. No behavioral change: reconcilers do not read `managedFields`.
- Does **not** reduce the 1.51 GiB of goroutine stacks (one reflector set per project). That needs an architectural follow-up: shard projects across replicas, lazy/idle cache eviction, or a shared cache.

## Verification

- `go build ./cmd/milo/...` — passes
- `go vet ./cmd/milo/controller-manager/` — passes
- Symbols confirmed in vendored controller-runtime v0.23.3 (`pkg/cache/cache.go`: `ByObject`, `DefaultTransform`, `ReaderFailOnMissingInformer`, `TransformStripManagedFields`).

## Review note / risk

`ReaderFailOnMissingInformer: true` makes cached reads of any type **outside** the three above fail on project clusters (instead of silently creating a wide informer). Please confirm no provider-cluster controller does a cached `Get`/`List` of another type before merging. The ResourceClaimOwnershipController already uses a direct dynamic client (`internal/quota/controllers/lifecycle/ownership.go:226`), not the cache. If any such read exists, drop `ReaderFailOnMissingInformer` or add the type to `ByObject`.

## Recommended companion changes (separate)

- Set `GOMEMLIMIT` (~90% of the memory limit) on the deployment — converts residual spikes into GC backpressure instead of OOMKills.
- Apply the same `cache.Options` scoping to the core manager + infraCluster.
- Fix the `cancelFns` leak / add Ready→NotReady teardown in `provider.go`.

Draft pending the review note above.
