### PR TITLE
fix(controller-manager): set GOMEMLIMIT from cgroup limit

### DIFF
--- a/config/controller-manager/base/deployment.yaml
+++ b/config/controller-manager/base/deployment.yaml
@@ -66,6 +66,14 @@ spec:
             value: /etc/kubernetes/pki/webhook/ca.crt
           - name: CONTROL_PLANE_SCOPE
             value: "core"
+          # Soft memory limit tracking the cgroup cap so GC reclaims before
+          # OOMKill (#631).
+          - name: GOMEMLIMIT
+            valueFrom:
+              resourceFieldRef:
+                containerName: milo-controller-manager
+                resource: limits.memory
+                divisor: "1"
         resources:
           requests:
             cpu: 100m


### PR DESCRIPTION
## Problem

The controller-manager runs with the default `GOMEMLIMIT` (off / `math.MaxInt64`), so the garbage collector only collects when the heap doubles per `GOGC`. Under the per-project cache growth diagnosed in #631, the heap climbs past the 6Gi container limit, producing cgroup OOMKills of the `milo` process and node memory-pressure evictions (incl. collateral promtail / node_exporter).

## Change

Set `GOMEMLIMIT` from the container memory limit via the downward API (`resourceFieldRef: limits.memory`) in the base controller-manager deployment.

```yaml
- name: GOMEMLIMIT
  valueFrom:
    resourceFieldRef:
      containerName: milo-controller-manager
      resource: limits.memory
      divisor: "1"
```

- `divisor: "1"` emits the limit as a plain byte integer; Go reads a bare integer as bytes.
- Tracks `limits.memory` automatically across overlays — 512Mi (base) and 6Gi (core-control-plane prod) — no hardcoded value.

## Expected impact

- The GC grows more aggressive as the heap approaches the cgroup cap, trading CPU to stay under the limit instead of OOMKilling. Go caps GC at 50% CPU, avoiding a death spiral.
- Backstop to #632, which addresses the root-cause heap growth. This change increases resilience even if heap pressure returns.

## Verification

- `kubectl kustomize` builds clean for base, core-control-plane, and project-control-plane overlays; `GOMEMLIMIT` is inherited in all three.

Closes part of #631.

🤖 Generated with [Claude Code](https://claude.com/claude-code)