### PR TITLE
fix(quota): stop ownership controller from garbage-collecting manually created ResourceClaims

### DIFF
--- a/internal/quota/controllers/lifecycle/cleanup.go
+++ b/internal/quota/controllers/lifecycle/cleanup.go
@@ -157,15 +157,11 @@ func (r *DeniedAutoClaimCleanupController) stalePendingAge() time.Duration {
 // isAutoCreatedClaim checks if a ResourceClaim was automatically created by the admission plugin.
 // Returns true only if both the label and annotation markers are present.
 func (r *DeniedAutoClaimCleanupController) isAutoCreatedClaim(claim *quotav1alpha1.ResourceClaim) bool {
-	autoCreatedLabel := claim.Labels["quota.miloapis.com/auto-created"] == "true"
-	createdByPlugin := claim.Annotations["quota.miloapis.com/created-by"] == "claim-creation-plugin"
-
 	r.logger.V(3).Info("Checking auto-created markers",
 		"claim", claim.Name,
-		"autoCreatedLabel", autoCreatedLabel,
-		"createdByPlugin", createdByPlugin)
-
-	return autoCreatedLabel && createdByPlugin
+		"autoCreatedLabel", claim.Labels["quota.miloapis.com/auto-created"] == "true",
+		"createdByPlugin", claim.Annotations["quota.miloapis.com/created-by"] == "claim-creation-plugin")
+	return isAutoCreatedClaim(claim)
 }
 
 // isClaimDenied checks if a ResourceClaim has been denied due to quota exceeded.
@@ -217,12 +213,7 @@ func (r *DeniedAutoClaimCleanupController) SetupWithManager(mgr mcmanager.Manage
 			if !ok {
 				return false
 			}
-
-			// Only watch auto-created claims to reduce controller load
-			autoCreated := claim.Labels["quota.miloapis.com/auto-created"] == "true"
-			createdByPlugin := claim.Annotations["quota.miloapis.com/created-by"] == "claim-creation-plugin"
-
-			return autoCreated && createdByPlugin
+			return isAutoCreatedClaim(claim)
 		})).
 		Named("denied-auto-claim-cleanup").
 		Complete(r)

--- a/internal/quota/controllers/lifecycle/ownership.go
+++ b/internal/quota/controllers/lifecycle/ownership.go
@@ -93,6 +93,13 @@ func (r *ResourceClaimOwnershipController) Reconcile(ctx context.Context, req mc
 		return ctrl.Result{}, nil
 	}
 
+	// Only process claims created by the admission plugin; manually created claims
+	// are managed externally and must not have owner references imposed on them.
+	if !isAutoCreatedClaim(&claim) {
+		logger.V(2).Info("Skipping manually created claim", "name", claim.Name, "ns", claim.Namespace)
+		return ctrl.Result{}, nil
+	}
+
 	// Only process granted claims
 	if !isResourceClaimGranted(&claim) {
 		logger.V(2).Info("Claim not granted; skipping", "name", claim.Name, "ns", claim.Namespace)
@@ -186,11 +193,14 @@ func (r *ResourceClaimOwnershipController) SetupWithManager(mgr mcmanager.Manage
 			if !ok {
 				return false
 			}
-			return isResourceClaimGranted(claim) && len(claim.GetOwnerReferences()) == 0
+			return isAutoCreatedClaim(claim) && isResourceClaimGranted(claim) && len(claim.GetOwnerReferences()) == 0
 		},
 		UpdateFunc: func(e event.UpdateEvent) bool {
 			newClaim, ok := e.ObjectNew.(*quotav1alpha1.ResourceClaim)
 			if !ok {
+				return false
+			}
+			if !isAutoCreatedClaim(newClaim) {
 				return false
 			}
 			if !(isResourceClaimGranted(newClaim) && len(newClaim.GetOwnerReferences()) == 0) {
@@ -289,4 +299,11 @@ func (r *ResourceClaimOwnershipController) applyOwnerReferenceSSA(ctx context.Co
 // isResourceClaimGranted checks if the claim has Granted=True.
 func isResourceClaimGranted(claim *quotav1alpha1.ResourceClaim) bool {
 	return meta.IsStatusConditionTrue(claim.Status.Conditions, quotav1alpha1.ResourceClaimGranted)
+}
+
+// isAutoCreatedClaim returns true when the claim was created by the admission
+// plugin, identified by both the auto-created label and created-by annotation.
+func isAutoCreatedClaim(claim *quotav1alpha1.ResourceClaim) bool {
+	return claim.Labels["quota.miloapis.com/auto-created"] == "true" &&
+		claim.Annotations["quota.miloapis.com/created-by"] == "claim-creation-plugin"
 }

--- a/internal/quota/controllers/lifecycle/ownership_test.go
+++ b/internal/quota/controllers/lifecycle/ownership_test.go
@@ -1,0 +1,165 @@
+package lifecycle
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	mcreconcile "sigs.k8s.io/multicluster-runtime/pkg/reconcile"
+
+	quotav1alpha1 "go.miloapis.com/milo/pkg/apis/quota/v1alpha1"
+)
+
+// grantedManualClaim returns a manually created ResourceClaim (no auto-created
+// markers) with a Granted=True condition and no owner references.
+func grantedManualClaim(name, namespace string) *quotav1alpha1.ResourceClaim {
+	claim := manualClaim(name, namespace)
+	claim.Status.Conditions = []metav1.Condition{{
+		Type:               quotav1alpha1.ResourceClaimGranted,
+		Status:             metav1.ConditionTrue,
+		Reason:             quotav1alpha1.ResourceClaimGrantedReason,
+		LastTransitionTime: metav1.Time{Time: time.Now()},
+	}}
+	return claim
+}
+
+// TestIsAutoCreatedClaim verifies the package-level helper correctly
+// distinguishes admission-plugin claims from manually created ones.
+func TestIsAutoCreatedClaim(t *testing.T) {
+	cases := []struct {
+		name  string
+		claim *quotav1alpha1.ResourceClaim
+		want  bool
+	}{
+		{
+			name:  "both markers present",
+			claim: autoClaim("auto", "default", "", "", time.Now()),
+			want:  true,
+		},
+		{
+			name:  "manual claim - no markers",
+			claim: manualClaim("manual", "default"),
+			want:  false,
+		},
+		{
+			name: "label present, annotation missing",
+			claim: &quotav1alpha1.ResourceClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "label-only",
+					Namespace: "default",
+					Labels:    map[string]string{"quota.miloapis.com/auto-created": "true"},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "annotation present, label missing",
+			claim: &quotav1alpha1.ResourceClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "annotation-only",
+					Namespace:   "default",
+					Annotations: map[string]string{"quota.miloapis.com/created-by": "claim-creation-plugin"},
+				},
+			},
+			want: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isAutoCreatedClaim(tc.claim); got != tc.want {
+				t.Errorf("isAutoCreatedClaim() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestResourceClaimOwnershipController_Reconcile verifies that Reconcile skips
+// manually created claims and only proceeds with admission-plugin claims.
+func TestResourceClaimOwnershipController_Reconcile(t *testing.T) {
+	now := time.Date(2025, 1, 1, 12, 0, 0, 0, time.UTC)
+	scheme := testScheme(t)
+
+	cases := []struct {
+		name        string
+		claim       *quotav1alpha1.ResourceClaim
+		wantErr     bool
+		wantDeleted bool
+	}{
+		{
+			name:        "manual claim with Granted=True is not touched",
+			claim:       grantedManualClaim("manual-granted", "default"),
+			wantErr:     false,
+			wantDeleted: false,
+		},
+		{
+			name: "claim with auto-created label but missing annotation is not touched",
+			claim: func() *quotav1alpha1.ResourceClaim {
+				c := grantedManualClaim("label-only", "default")
+				c.Labels = map[string]string{"quota.miloapis.com/auto-created": "true"}
+				return c
+			}(),
+			wantErr:     false,
+			wantDeleted: false,
+		},
+		{
+			name: "claim with created-by annotation but missing label is not touched",
+			claim: func() *quotav1alpha1.ResourceClaim {
+				c := grantedManualClaim("annotation-only", "default")
+				c.Annotations = map[string]string{"quota.miloapis.com/created-by": "claim-creation-plugin"}
+				return c
+			}(),
+			wantErr:     false,
+			wantDeleted: false,
+		},
+		{
+			// Auto-created claim passes the guard and reaches resolveOwner, which
+			// returns an error because restMapper is nil in this unit test.
+			// This confirms the guard does not block auto-created claims.
+			name:        "auto-created granted claim proceeds past guard to owner resolution",
+			claim:       autoClaim("auto-granted", "default", "True", quotav1alpha1.ResourceClaimGrantedReason, now.Add(-10*time.Second)),
+			wantErr:     true,
+			wantDeleted: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(tc.claim).Build()
+			mgr := &testManager{cluster: &testCluster{client: cli}}
+
+			r := &ResourceClaimOwnershipController{
+				Scheme:  scheme,
+				Manager: mgr,
+				// restMapper intentionally nil so resolveOwner returns early with
+				// "RESTMapper not initialized", which is the expected error for
+				// auto-created claims that pass the guard in this unit test.
+			}
+
+			req := mcreconcile.Request{
+				Request: ctrl.Request{
+					NamespacedName: types.NamespacedName{
+						Name:      tc.claim.Name,
+						Namespace: tc.claim.Namespace,
+					},
+				},
+			}
+
+			_, err := r.Reconcile(context.Background(), req)
+			if (err != nil) != tc.wantErr {
+				t.Errorf("Reconcile() error = %v, wantErr %v", err, tc.wantErr)
+			}
+
+			var got quotav1alpha1.ResourceClaim
+			getErr := cli.Get(context.Background(), client.ObjectKey{Name: tc.claim.Name, Namespace: tc.claim.Namespace}, &got)
+			if deleted := (getErr != nil); deleted != tc.wantDeleted {
+				t.Errorf("deleted=%v want=%v (get err=%v)", deleted, tc.wantDeleted, getErr)
+			}
+		})
+	}
+}

--- a/test/quota/manual-claim-preservation/01-resource-registration.yaml
+++ b/test/quota/manual-claim-preservation/01-resource-registration.yaml
@@ -1,0 +1,19 @@
+apiVersion: quota.miloapis.com/v1alpha1
+kind: ResourceRegistration
+metadata:
+  name: manual-claim-test-resource-reg
+  labels:
+    test.miloapis.com/scenario: "manual-claim-preservation"
+spec:
+  consumerType:
+    apiGroup: resourcemanager.miloapis.com
+    kind: Organization
+  type: "Entity"
+  resourceType: "test.manual-claim.miloapis.com/projects"
+  description: "Test quota type for verifying manual claim preservation"
+  baseUnit: "project"
+  displayUnit: "projects"
+  unitConversionFactor: 1
+  claimingResources:
+    - apiGroup: resourcemanager.miloapis.com
+      kind: Project

--- a/test/quota/manual-claim-preservation/02-organization.yaml
+++ b/test/quota/manual-claim-preservation/02-organization.yaml
@@ -1,0 +1,8 @@
+apiVersion: resourcemanager.miloapis.com/v1alpha1
+kind: Organization
+metadata:
+  name: manual-claim-test-org
+  labels:
+    test.miloapis.com/scenario: "manual-claim-preservation"
+spec:
+  type: Standard

--- a/test/quota/manual-claim-preservation/03-resource-grant.yaml
+++ b/test/quota/manual-claim-preservation/03-resource-grant.yaml
@@ -1,0 +1,16 @@
+apiVersion: quota.miloapis.com/v1alpha1
+kind: ResourceGrant
+metadata:
+  name: manual-claim-test-org-grant
+  namespace: organization-manual-claim-test-org
+  labels:
+    test.miloapis.com/scenario: "manual-claim-preservation"
+spec:
+  consumerRef:
+    apiGroup: resourcemanager.miloapis.com
+    kind: Organization
+    name: manual-claim-test-org
+  allowances:
+    - resourceType: "test.manual-claim.miloapis.com/projects"
+      buckets:
+        - amount: 10

--- a/test/quota/manual-claim-preservation/04-manual-resource-claim.yaml
+++ b/test/quota/manual-claim-preservation/04-manual-resource-claim.yaml
@@ -1,0 +1,30 @@
+apiVersion: quota.miloapis.com/v1alpha1
+kind: ResourceClaim
+metadata:
+  name: manual-claim-test-claim
+  namespace: organization-manual-claim-test-org
+  labels:
+    test.miloapis.com/scenario: "manual-claim-preservation"
+    # Intentionally no auto-created markers:
+    #   quota.miloapis.com/auto-created: "true"
+    #   quota.miloapis.com/created-by: "claim-creation-plugin"
+    # This simulates a claim created directly by an external service or operator,
+    # not by the Milo admission plugin.
+spec:
+  consumerRef:
+    apiGroup: resourcemanager.miloapis.com
+    kind: Organization
+    name: manual-claim-test-org
+  requests:
+    - resourceType: "test.manual-claim.miloapis.com/projects"
+      amount: 1
+  # resourceRef points to a Project that does not exist. Before the fix for issue
+  # #642, the ownership controller would resolve this via the REST mapper, receive
+  # a NotFound response, wait past the orphan grace period, then delete the claim.
+  # After the fix, the controller skips this claim entirely because it lacks the
+  # auto-created markers.
+  resourceRef:
+    apiGroup: resourcemanager.miloapis.com
+    kind: Project
+    name: non-existent-project-for-ownership-test
+    namespace: organization-manual-claim-test-org

--- a/test/quota/manual-claim-preservation/chainsaw-test.yaml
+++ b/test/quota/manual-claim-preservation/chainsaw-test.yaml
@@ -1,0 +1,124 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: quota-manual-claim-preservation
+spec:
+  description: |
+    Verifies that manually created ResourceClaims are not garbage-collected by the
+    ResourceClaimOwnershipController (regression test for issue #642).
+
+    Before the fix, the controller incorrectly processed any ResourceClaim with
+    Granted=True and no owner references, including service-managed claims whose
+    owning resource lives in a different control plane. It would enter a continuous
+    delete-recreate loop once the orphan grace period elapsed.
+
+    This test creates a ResourceClaim without the admission-plugin auto-created
+    markers (quota.miloapis.com/auto-created=true and
+    quota.miloapis.com/created-by=claim-creation-plugin) and a resourceRef that
+    points to a non-existent Project. Before the fix, the controller would delete
+    this claim after the orphan max-age (default 30s). After the fix, the controller
+    skips it entirely because the auto-created markers are absent.
+
+  steps:
+    - name: setup-resource-registration
+      description: |
+        Register the resource type used by this test. The registration must be active
+        before the quota system can evaluate claims for this resource type.
+      try:
+        - description: Create ResourceRegistration for the test quota type
+          create:
+            file: 01-resource-registration.yaml
+        - description: Wait for ResourceRegistration to become active
+          wait:
+            apiVersion: quota.miloapis.com/v1alpha1
+            kind: ResourceRegistration
+            name: manual-claim-test-resource-reg
+            timeout: 30s
+            for:
+              condition:
+                name: Active
+                value: 'True'
+
+    - name: setup-organization
+      description: |
+        Create the Organization that acts as the quota consumer. The ownership
+        controller runs across all control planes, so this step uses the main cluster.
+      try:
+        - description: Create test Organization
+          create:
+            file: 02-organization.yaml
+        - description: Wait for the Organization namespace to become active
+          wait:
+            apiVersion: v1
+            kind: Namespace
+            name: organization-manual-claim-test-org
+            timeout: 30s
+            for:
+              jsonPath:
+                path: '{.status.phase}'
+                value: Active
+
+    - name: setup-resource-grant
+      description: |
+        Grant quota to the Organization so the manually created claim can be
+        evaluated and granted. Without available quota the claim would be denied
+        rather than granted, and the ownership controller would not process it.
+      try:
+        - description: Create ResourceGrant for the test Organization
+          create:
+            file: 03-resource-grant.yaml
+        - description: Wait for ResourceGrant to become active
+          wait:
+            apiVersion: quota.miloapis.com/v1alpha1
+            kind: ResourceGrant
+            name: manual-claim-test-org-grant
+            namespace: organization-manual-claim-test-org
+            timeout: 30s
+            for:
+              condition:
+                name: Active
+                value: 'True'
+
+    - name: create-manual-claim-and-wait-for-grant
+      description: |
+        Create a ResourceClaim that is missing the auto-created label and annotation
+        normally set by the admission plugin. The resourceRef points to a Project that
+        does not exist — without the fix this is what triggers the ownership controller
+        to eventually delete the claim after the orphan grace period elapses.
+      try:
+        - description: Create manual ResourceClaim without auto-created markers
+          create:
+            file: 04-manual-resource-claim.yaml
+        - description: Wait for the claim to reach Granted=True
+          wait:
+            apiVersion: quota.miloapis.com/v1alpha1
+            kind: ResourceClaim
+            name: manual-claim-test-claim
+            namespace: organization-manual-claim-test-org
+            timeout: 30s
+            for:
+              condition:
+                name: Granted
+                value: 'True'
+
+    - name: verify-claim-not-garbage-collected
+      description: |
+        Sleep past the ownership controller's default orphan max-age threshold (30s)
+        then assert the claim still exists with Granted=True. Before issue #642 was
+        fixed, the controller would have deleted this claim because it had no owner
+        references and its resourceRef pointed to a non-existent Project.
+      try:
+        - description: Wait past the default orphan max-age (30s)
+          sleep:
+            duration: 35s
+        - description: Assert the manually created claim was not garbage-collected
+          wait:
+            apiVersion: quota.miloapis.com/v1alpha1
+            kind: ResourceClaim
+            name: manual-claim-test-claim
+            namespace: organization-manual-claim-test-org
+            timeout: 10s
+            for:
+              condition:
+                name: Granted
+                value: 'True'


### PR DESCRIPTION
## Problem

The `ResourceClaimOwnershipController` was incorrectly processing **any** `ResourceClaim` with `Granted=True` and no owner references — including claims created manually or by external services. Because it found no recognizable owner for these service-managed claims, it entered a continuous delete-recreate loop, causing:

- ~600 churn cycles per day in affected clusters
- `allocated=0` reported in `AllowanceBuckets`  
- `QuotaGranted` condition flapping

The `DeniedAutoClaimCleanupController` in the same package already handles this correctly by gating on the admission-plugin markers. The ownership controller simply lacked the same guard.

## Solution

- Extract `isAutoCreatedClaim` as a **package-level function** in `ownership.go`, making it the single source of truth for both controllers (the cleanup controller's method now delegates to it).
- Add the guard to the **watch predicate** in `SetupWithManager` so manually created claims are never enqueued.
- Add the guard to **`Reconcile`** as defence-in-depth, catching any claims already in the queue at rollout time.

## Test plan

- [x] `TestIsAutoCreatedClaim` — unit tests for the helper: both markers required, missing label → false, missing annotation → false
- [x] `TestResourceClaimOwnershipController_Reconcile` — confirms manual claims (including partial-marker cases) return `ctrl.Result{}, nil` without touching the claim; auto-created claims proceed past the guard to `resolveOwner`
- [x] Existing `TestDeniedAutoClaimCleanupController` — all 6 cases still pass after the cleanup controller refactor

Closes #642

🤖 Generated with [Claude Code](https://claude.ai/claude-code)