### PR TITLE
fix(controller-manager): exit deterministically instead of panicking on manager shutdown

### DIFF
--- a/cmd/milo/controller-manager/controllermanager.go
+++ b/cmd/milo/controller-manager/controllermanager.go
@@ -701,8 +701,13 @@ func Run(ctx context.Context, c *config.CompletedConfig, opts *Options) error {
 			go func() {
 				logger.Info("Starting multicluster manager for quota system")
 				if err := mcMgr.Start(ctx); err != nil {
-					logger.Error(err, "Multicluster manager failed")
-					panic(err)
+					// Exit deterministically (code 1) and flush logs instead of
+					// panicking (which exits 2 with a stack that obscures the
+					// real cause, e.g. a missed graceful-shutdown deadline under
+					// load). FlushAndExit terminates the process, stopping the
+					// sibling managers and releasing the leader lease.
+					logger.Error(err, "Multicluster manager failed; shutting down controller-manager")
+					klog.FlushAndExit(klog.ExitFlushTimeout, 1)
 				}
 			}()
 
@@ -811,13 +816,15 @@ func Run(ctx context.Context, c *config.CompletedConfig, opts *Options) error {
 
 			go func() {
 				if err := infraCluster.Start(ctx); err != nil {
-					panic(err)
+					logger.Error(err, "Infrastructure cluster failed; shutting down controller-manager")
+					klog.FlushAndExit(klog.ExitFlushTimeout, 1)
 				}
 			}()
 
 			go func() {
 				if err := ctrl.Start(ctx); err != nil {
-					panic(err)
+					logger.Error(err, "Controller manager failed; shutting down controller-manager")
+					klog.FlushAndExit(klog.ExitFlushTimeout, 1)
 				}
 			}()
 		}


### PR DESCRIPTION
## Problem

Addresses the exit-2 / leader-lease crashloop in **#645** (and the recurring pathology in **#631**).

The leader callback (`OnStartedLeading`) starts three long-lived runnables in goroutines:

```go
go func() { if err := mcMgr.Start(ctx); err != nil { logger.Error(...); panic(err) } }()
go func() { if err := infraCluster.Start(ctx); err != nil { panic(err) } }()
go func() { if err := ctrl.Start(ctx); err != nil { panic(err) } }()
```

controller-runtime's `Manager.Start` (and the cluster / multicluster-runtime `Start`) returns a **non-nil error when its runnables miss the graceful-shutdown deadline**. Under the prod cold-resync storm (quota grant-creation across all project control planes + GC backlog + client-side throttling), that's exactly what happens on leader-context cancellation. The `panic(err)` then:

- terminated the process with **exit code 2** (matching the reported `exitCode: 2`), with a panic stack that **obscured the real cause** (missed grace deadline vs. OOM vs. context error), and
- exited **mid-shutdown, skipping clean leader-lease release** — so the next pod's lease GET timed out until the lease expired (`leaderelection: Error retrieving lease lock ... Client.Timeout exceeded`), feeding the observed restart + cold-resync loop (`restartCount: 11`).

## Change

Replace the three runtime `panic(err)` calls with logged `klog.FlushAndExit(klog.ExitFlushTimeout, 1)` — the same deterministic error handling used everywhere else in this callback. The process now exits with a **consistent code (1)**, **flushes the real error** to the logs, and terminates the sibling managers so the lease is released promptly.

## Scope / what this does NOT fix

This makes the failure **deterministic and diagnosable** and stops the panic-driven crashloop, but it does **not** eliminate the underlying cold-resync storm that triggers the overloaded shutdown. Those need separate, metrics-informed work (tracked for follow-up):

1. **Quota grant-creation parallelism** — `default-{networking,notes,dns,core}-quota-policy` created per project control plane on every cold start; consider bounding concurrency / backoff so a cold start doesn't saturate the client (QPS 500 / Burst 1000 on the quota dynamic client today).
2. **GC `unable to get REST mapping for iam.miloapis.com/User`** — the garbage collector keeps trying to resolve the cluster-scoped `User` owner kind in project control planes that don't serve it, churning the GC backlog. Likely wants the unmappable cluster-scoped IAM kinds excluded from per-project GC.
3. **Leader-election timing vs. throttling** — under client-side throttling the lease renew can miss `RenewDeadline`, dropping leadership and forcing the (now-clean) shutdown. Worth revisiting lease timing and/or `GracefulShutdownTimeout`, and the single-replica / resource sizing (cf. #631 memory growth).

## Testing

`go build ./cmd/...` passes. The change is process-lifecycle/logging only (no unit-testable logic); behavior verified by reading the controller-runtime shutdown contract (Start returns error on missed grace deadline) against the panic path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)