### PR TITLE
feat(quota): add quota display metadata convention + enrich core/notes registrations

### DIFF
--- a/config/services/quota/registrations/configmap-registration.yaml
+++ b/config/services/quota/registrations/configmap-registration.yaml
@@ -5,6 +5,10 @@ metadata:
   labels:
     app.kubernetes.io/name: milo
     app.kubernetes.io/component: quota-system
+    services.miloapis.com/owner: core.miloapis.com
+  annotations:
+    kubernetes.io/display-name: "Config Maps"
+    kubernetes.io/description: "Maximum number of config maps that can be created within a project"
 spec:
   consumerType:
     apiGroup: resourcemanager.miloapis.com

--- a/config/services/quota/registrations/note-registration.yaml
+++ b/config/services/quota/registrations/note-registration.yaml
@@ -5,6 +5,10 @@ metadata:
   labels:
     app.kubernetes.io/name: milo
     app.kubernetes.io/component: quota-system
+    services.miloapis.com/owner: notes.miloapis.com
+  annotations:
+    kubernetes.io/display-name: "Notes"
+    kubernetes.io/description: "Maximum number of notes (namespaced and cluster-scoped) that can be created within a project"
 spec:
   consumerType:
     apiGroup: resourcemanager.miloapis.com

--- a/config/services/quota/registrations/secret-registration.yaml
+++ b/config/services/quota/registrations/secret-registration.yaml
@@ -5,6 +5,10 @@ metadata:
   labels:
     app.kubernetes.io/name: milo
     app.kubernetes.io/component: quota-system
+    services.miloapis.com/owner: core.miloapis.com
+  annotations:
+    kubernetes.io/display-name: "Secrets"
+    kubernetes.io/description: "Maximum number of secrets that can be created within a project"
 spec:
   consumerType:
     apiGroup: resourcemanager.miloapis.com

--- a/docs/architecture/quota-display.md
+++ b/docs/architecture/quota-display.md
@@ -1,0 +1,47 @@
+# Quota Display Metadata
+
+How quota resources expose human-readable names and group membership to UIs
+(the cloud-portal Quotas page). This is a thin, forward-compatible convention
+that anticipates [milo-os/service-catalog](https://github.com/milo-os/service-catalog);
+when the catalog ships, the central resolution below is replaced by
+`Service.spec.displayName` with no change to what services author here.
+
+## What each service authors (on its ResourceRegistration)
+
+| Key | Kind | Purpose |
+|---|---|---|
+| `kubernetes.io/display-name` | annotation | Friendly row name, e.g. "HTTP Proxies" |
+| `kubernetes.io/description` | annotation | Row subtitle/tooltip |
+| `services.miloapis.com/owner` | label | The owning service's canonical name (a reference, not a display name), e.g. `networking.datumapis.com` |
+
+The `owner` value is the service's reverse-DNS canonical name — the same value
+that will become `Service.spec.serviceName` in the service-catalog. It is a
+**reference**: services never declare their product's display name here, only
+which service they belong to.
+
+## How the group display name is resolved (central)
+
+The owning service's **display name** ("Networking", "DNS") is resolved
+centrally — never re-declared per registration. Until the service-catalog is
+deployed, the cloud-portal carries an interim `serviceName → displayName` map
+(plus a `resourceType → serviceName` bridge for registrations that have not yet
+adopted the `owner` label). When the catalog ships, both are replaced by
+`Service` lookups via graphql-gateway.
+
+## Example
+
+```yaml
+apiVersion: quota.miloapis.com/v1alpha1
+kind: ResourceRegistration
+metadata:
+  name: httpproxies-per-project
+  labels:
+    app.kubernetes.io/name: network-services-operator
+    app.kubernetes.io/component: quota-system
+    services.miloapis.com/owner: networking.datumapis.com
+  annotations:
+    kubernetes.io/display-name: "HTTP Proxies"
+    kubernetes.io/description: "Maximum number of HTTP proxies per project"
+spec:
+  # … unchanged …
+```


### PR DESCRIPTION
Part of datum-cloud/enhancements#735 (quota display: human-readable, service-grouped).

Adds a thin, forward-compatible **quota display metadata** convention and applies it to milo's own quota registrations so the cloud-portal can render quotas with friendly names grouped by owning service.

### Convention — `docs/architecture/quota-display.md`
Each `ResourceRegistration` carries:
- `kubernetes.io/display-name` — friendly row name
- `kubernetes.io/description` — row subtitle
- `services.miloapis.com/owner` (label) — the owning service's canonical name (a **reference**, not a display name)

The owning service's **display name** is resolved centrally — never re-declared per registration — anticipating `milo-os/service-catalog` (`Service.spec.displayName`). Until the catalog ships, the portal carries an interim `serviceName → displayName` map.

### Changes
- `docs/architecture/quota-display.md`
- `configmaps`, `secrets` → owner `core.miloapis.com`; `notes` → owner `notes.miloapis.com`

Metadata-only (spec unchanged). Companion PRs adopt the same convention in `datum-cloud/datum` and `datum-cloud/network-services-operator`.
