### PR TITLE
fix(discovery): expose authorization APIs in project discovery contexts

### DIFF
--- a/config/discovery/core/discovery-context-policy.yaml
+++ b/config/discovery/core/discovery-context-policy.yaml
@@ -16,15 +16,6 @@ spec:
     - group: "apiregistration.k8s.io"
       resources: ["apiservices"]
       contexts: ["Platform"]
-    - group: "authentication.k8s.io"
-      resources: ["selfsubjectreviews", "tokenreviews"]
-      contexts: ["Platform"]
-    - group: "authorization.k8s.io"
-      resources: ["localsubjectaccessreviews", "selfsubjectaccessreviews", "selfsubjectrulesreviews", "subjectaccessreviews"]
-      contexts: ["Platform"]
-    - group: "flowcontrol.apiserver.k8s.io"
-      resources: ["flowschemas", "prioritylevelconfigurations"]
-      contexts: ["Platform"]
     - group: "coordination.k8s.io"
       resources: ["leases"]
       # Leases are used by per-project workloads (leader election in


### PR DESCRIPTION
## Summary

Project (context-scoped) control planes weren't exposing the `authorization.k8s.io`, `authentication.k8s.io`, or `flowcontrol.apiserver.k8s.io` APIs in discovery. As a result, project-scoped clients couldn't resolve `SubjectAccessReview`, so authorization checks failed for anything running against a project control plane — including the compute `vworkload` webhook, which rejected any Workload that references a Secret or Network.

## Root cause

#622 made these system APIs visible in all discovery contexts. A stale-branch merge in #617 reverted that, re-pinning the three groups to `Platform`-only (it only kept `coordination.k8s.io/leases` in `Project`). This restores #622's intent.

## Validation

- [ ] On a project control plane, `GET /apis/authorization.k8s.io/v1` lists `subjectaccessreviews`
- [ ] A Workload referencing a Secret admits through the compute `vworkload` webhook
