### PR TITLE
fix: milo apiserver GOMEMLIMIT

### DIFF
--- a/config/apiserver/deployment.yaml
+++ b/config/apiserver/deployment.yaml
@@ -187,6 +187,12 @@ spec:
             value: "iam.miloapis.com/parent-api-group,iam.miloapis.com/parent-type,iam.miloapis.com/parent-name"
           - name: SHUTDOWN_DELAY_DURATION
             value: "10s"
+          - name: GOMEMLIMIT
+            valueFrom:
+              resourceFieldRef:
+                containerName: milo-apiserver
+                resource: limits.memory
+                divisor: "1"
         livenessProbe:
           failureThreshold: 3
           httpGet:


### PR DESCRIPTION
## Problem

The API server runs with the default `GOMEMLIMIT` (effectively off / `math.MaxInt64`), so the Go GC only collects when the heap doubles per `GOGC`. Under memory pressure the heap can climb past the container limit, producing a cgroup OOMKill before the GC has a chance to reclaim.

The controller-manager received the same fix in #634. This ports it to the API server.

## Change

Set `GOMEMLIMIT` from the container memory limit via the downward API in the base API server deployment:

```yaml
- name: GOMEMLIMIT
  valueFrom:
    resourceFieldRef:
      containerName: milo-apiserver
      resource: limits.memory
      divisor: "1"
```

- `divisor: "1"` emits the limit as a plain byte integer; Go reads a bare integer as bytes.
- Tracks `limits.memory` automatically — if an overlay or Flux patch raises the container limit, `GOMEMLIMIT` follows with no manual update.

## Expected impact

The GC grows more aggressive as the heap approaches the cgroup cap, trading CPU for memory to stay under the limit instead of OOMKilling.

## Verification

`kubectl kustomize config/apiserver` builds clean; `GOMEMLIMIT` appears in the rendered env block.
