### PR TITLE
fix: show newly created projects and resources in the activity feed

### DIFF
--- a/config/services/activity/policies/iam/group-policy.yaml
+++ b/config/services/activity/policies/iam/group-policy.yaml
@@ -25,7 +25,7 @@ spec:
   auditRules:
     - name: create
       match: "!audit.user.username.startsWith('system:') && audit.verb == 'create'"
-      summary: "{{ actor }} created group {{ link(audit.objectRef.name, audit.objectRef) }}"
+      summary: "{{ actor }} created group {{ link(audit.responseObject.metadata.name, audit.objectRef) }}"
 
     - name: delete
       match: "!audit.user.username.startsWith('system:') && audit.verb == 'delete'"

--- a/config/services/activity/policies/iam/role-policy.yaml
+++ b/config/services/activity/policies/iam/role-policy.yaml
@@ -12,7 +12,7 @@ spec:
   auditRules:
     - name: create
       match: "!audit.user.username.startsWith('system:') && audit.verb == 'create'"
-      summary: "{{ actor }} created role {{ link(audit.objectRef.name, audit.objectRef) }}"
+      summary: "{{ actor }} created role {{ link(audit.responseObject.metadata.name, audit.objectRef) }}"
 
     - name: delete
       match: "!audit.user.username.startsWith('system:') && audit.verb == 'delete'"

--- a/config/services/activity/policies/iam/serviceaccount-policy.yaml
+++ b/config/services/activity/policies/iam/serviceaccount-policy.yaml
@@ -26,7 +26,7 @@ spec:
   auditRules:
     - name: create
       match: "!audit.user.username.startsWith('system:') && audit.verb == 'create'"
-      summary: "{{ actor }} created service account {{ link(audit.objectRef.name, audit.objectRef) }}"
+      summary: "{{ actor }} created service account {{ link(audit.responseObject.metadata.name, audit.objectRef) }}"
 
     - name: delete
       match: "!audit.user.username.startsWith('system:') && audit.verb == 'delete'"

--- a/config/services/activity/policies/resourcemanager/organization-policy.yaml
+++ b/config/services/activity/policies/resourcemanager/organization-policy.yaml
@@ -26,7 +26,7 @@ spec:
   auditRules:
     - name: create
       match: "!audit.user.username.startsWith('system:') && audit.verb == 'create'"
-      summary: "{{ actor }} created organization {{ link(audit.objectRef.name, audit.objectRef) }}"
+      summary: "{{ actor }} created organization {{ link(audit.responseObject.metadata.name, audit.objectRef) }}"
 
     - name: delete
       match: "!audit.user.username.startsWith('system:') && audit.verb == 'delete'"

--- a/config/services/activity/policies/resourcemanager/project-policy.yaml
+++ b/config/services/activity/policies/resourcemanager/project-policy.yaml
@@ -25,7 +25,7 @@ spec:
   auditRules:
     - name: create
       match: "!audit.user.username.startsWith('system:') && audit.verb == 'create'"
-      summary: "{{ actor }} created project {{ link(audit.objectRef.name, audit.objectRef) }}"
+      summary: "{{ actor }} created project {{ link(audit.responseObject.metadata.name, audit.objectRef) }}"
 
     - name: delete
       match: "!audit.user.username.startsWith('system:') && audit.verb == 'delete'"

--- a/config/services/identity/policies/serviceaccount-policy.yaml
+++ b/config/services/identity/policies/serviceaccount-policy.yaml
@@ -26,7 +26,7 @@ spec:
   auditRules:
     - name: create
       match: "!audit.user.username.startsWith('system:') && audit.verb == 'create'"
-      summary: "{{ actor }} created service account {{ link(audit.objectRef.name, audit.objectRef) }}"
+      summary: "{{ actor }} created service account {{ link(audit.responseObject.metadata.name, audit.objectRef) }}"
 
     - name: delete
       match: "!audit.user.username.startsWith('system:') && audit.verb == 'delete'"


### PR DESCRIPTION
## What this does

Creating a project should land in your activity feed — but when a project's name is generated automatically, that entry was quietly going missing. This makes new projects show up reliably, and applies the same little fix to a few related resources (organizations, groups, roles, service accounts) so they don't run into the same thing.

## What changed

- Create summaries now use the resource's assigned name, so they always show up.
- Updates and deletes are untouched.

Projects are the one we confirmed in production; the rest are proactive.

