### PR TITLE
fix: null-guard responseObject.metadata.name in ActivityPolicy creates

### DIFF
--- a/config/services/activity/policies/iam/group-policy.yaml
+++ b/config/services/activity/policies/iam/group-policy.yaml
@@ -25,7 +25,7 @@ spec:
   auditRules:
     - name: create
       match: "!audit.user.username.startsWith('system:') && audit.verb == 'create'"
-      summary: "{{ actor }} created group {{ has(audit.responseObject.metadata.name) ? link(audit.responseObject.metadata.name, audit.objectRef) : link(audit.objectRef.name, audit.objectRef) }}"
+      summary: "{{ actor }} created group {{ has(audit.responseObject.metadata.name) ? link(audit.responseObject.metadata.name, audit.objectRef) : has(audit.objectRef.name) ? link(audit.objectRef.name, audit.objectRef) : (has(audit.responseObject.details) && has(audit.responseObject.details.name)) ? link(audit.responseObject.details.name, audit.objectRef) : link('a group', audit.objectRef) }}"
 
     - name: delete
       match: "!audit.user.username.startsWith('system:') && audit.verb == 'delete'"

--- a/config/services/activity/policies/iam/group-policy.yaml
+++ b/config/services/activity/policies/iam/group-policy.yaml
@@ -25,7 +25,7 @@ spec:
   auditRules:
     - name: create
       match: "!audit.user.username.startsWith('system:') && audit.verb == 'create'"
-      summary: "{{ actor }} created group {{ link(audit.responseObject.metadata.name, audit.objectRef) }}"
+      summary: "{{ actor }} created group {{ has(audit.responseObject.metadata.name) ? link(audit.responseObject.metadata.name, audit.objectRef) : link(audit.objectRef.name, audit.objectRef) }}"
 
     - name: delete
       match: "!audit.user.username.startsWith('system:') && audit.verb == 'delete'"

--- a/config/services/activity/policies/iam/role-policy.yaml
+++ b/config/services/activity/policies/iam/role-policy.yaml
@@ -12,7 +12,7 @@ spec:
   auditRules:
     - name: create
       match: "!audit.user.username.startsWith('system:') && audit.verb == 'create'"
-      summary: "{{ actor }} created role {{ has(audit.responseObject.metadata.name) ? link(audit.responseObject.metadata.name, audit.objectRef) : link(audit.objectRef.name, audit.objectRef) }}"
+      summary: "{{ actor }} created role {{ has(audit.responseObject.metadata.name) ? link(audit.responseObject.metadata.name, audit.objectRef) : has(audit.objectRef.name) ? link(audit.objectRef.name, audit.objectRef) : (has(audit.responseObject.details) && has(audit.responseObject.details.name)) ? link(audit.responseObject.details.name, audit.objectRef) : link('a role', audit.objectRef) }}"
 
     - name: delete
       match: "!audit.user.username.startsWith('system:') && audit.verb == 'delete'"

--- a/config/services/activity/policies/iam/role-policy.yaml
+++ b/config/services/activity/policies/iam/role-policy.yaml
@@ -12,7 +12,7 @@ spec:
   auditRules:
     - name: create
       match: "!audit.user.username.startsWith('system:') && audit.verb == 'create'"
-      summary: "{{ actor }} created role {{ link(audit.responseObject.metadata.name, audit.objectRef) }}"
+      summary: "{{ actor }} created role {{ has(audit.responseObject.metadata.name) ? link(audit.responseObject.metadata.name, audit.objectRef) : link(audit.objectRef.name, audit.objectRef) }}"
 
     - name: delete
       match: "!audit.user.username.startsWith('system:') && audit.verb == 'delete'"

--- a/config/services/activity/policies/iam/serviceaccount-policy.yaml
+++ b/config/services/activity/policies/iam/serviceaccount-policy.yaml
@@ -26,7 +26,7 @@ spec:
   auditRules:
     - name: create
       match: "!audit.user.username.startsWith('system:') && audit.verb == 'create'"
-      summary: "{{ actor }} created service account {{ link(audit.responseObject.metadata.name, audit.objectRef) }}"
+      summary: "{{ actor }} created service account {{ has(audit.responseObject.metadata.name) ? link(audit.responseObject.metadata.name, audit.objectRef) : link(audit.objectRef.name, audit.objectRef) }}"
 
     - name: delete
       match: "!audit.user.username.startsWith('system:') && audit.verb == 'delete'"

--- a/config/services/activity/policies/iam/serviceaccount-policy.yaml
+++ b/config/services/activity/policies/iam/serviceaccount-policy.yaml
@@ -26,7 +26,7 @@ spec:
   auditRules:
     - name: create
       match: "!audit.user.username.startsWith('system:') && audit.verb == 'create'"
-      summary: "{{ actor }} created service account {{ has(audit.responseObject.metadata.name) ? link(audit.responseObject.metadata.name, audit.objectRef) : link(audit.objectRef.name, audit.objectRef) }}"
+      summary: "{{ actor }} created service account {{ has(audit.responseObject.metadata.name) ? link(audit.responseObject.metadata.name, audit.objectRef) : has(audit.objectRef.name) ? link(audit.objectRef.name, audit.objectRef) : (has(audit.responseObject.details) && has(audit.responseObject.details.name)) ? link(audit.responseObject.details.name, audit.objectRef) : link('a service account', audit.objectRef) }}"
 
     - name: delete
       match: "!audit.user.username.startsWith('system:') && audit.verb == 'delete'"

--- a/config/services/activity/policies/resourcemanager/organization-policy.yaml
+++ b/config/services/activity/policies/resourcemanager/organization-policy.yaml
@@ -26,7 +26,7 @@ spec:
   auditRules:
     - name: create
       match: "!audit.user.username.startsWith('system:') && audit.verb == 'create'"
-      summary: "{{ actor }} created organization {{ has(audit.responseObject.metadata.name) ? link(audit.responseObject.metadata.name, audit.objectRef) : link(audit.objectRef.name, audit.objectRef) }}"
+      summary: "{{ actor }} created organization {{ has(audit.responseObject.metadata.name) ? link(audit.responseObject.metadata.name, audit.objectRef) : has(audit.objectRef.name) ? link(audit.objectRef.name, audit.objectRef) : (has(audit.responseObject.details) && has(audit.responseObject.details.name)) ? link(audit.responseObject.details.name, audit.objectRef) : link('an organization', audit.objectRef) }}"
 
     - name: delete
       match: "!audit.user.username.startsWith('system:') && audit.verb == 'delete'"

--- a/config/services/activity/policies/resourcemanager/organization-policy.yaml
+++ b/config/services/activity/policies/resourcemanager/organization-policy.yaml
@@ -26,7 +26,7 @@ spec:
   auditRules:
     - name: create
       match: "!audit.user.username.startsWith('system:') && audit.verb == 'create'"
-      summary: "{{ actor }} created organization {{ link(audit.responseObject.metadata.name, audit.objectRef) }}"
+      summary: "{{ actor }} created organization {{ has(audit.responseObject.metadata.name) ? link(audit.responseObject.metadata.name, audit.objectRef) : link(audit.objectRef.name, audit.objectRef) }}"
 
     - name: delete
       match: "!audit.user.username.startsWith('system:') && audit.verb == 'delete'"

--- a/config/services/activity/policies/resourcemanager/project-policy.yaml
+++ b/config/services/activity/policies/resourcemanager/project-policy.yaml
@@ -25,7 +25,7 @@ spec:
   auditRules:
     - name: create
       match: "!audit.user.username.startsWith('system:') && audit.verb == 'create'"
-      summary: "{{ actor }} created project {{ link(audit.responseObject.metadata.name, audit.objectRef) }}"
+      summary: "{{ actor }} created project {{ has(audit.responseObject.metadata.name) ? link(audit.responseObject.metadata.name, audit.objectRef) : link(audit.objectRef.name, audit.objectRef) }}"
 
     - name: delete
       match: "!audit.user.username.startsWith('system:') && audit.verb == 'delete'"

--- a/config/services/activity/policies/resourcemanager/project-policy.yaml
+++ b/config/services/activity/policies/resourcemanager/project-policy.yaml
@@ -25,7 +25,7 @@ spec:
   auditRules:
     - name: create
       match: "!audit.user.username.startsWith('system:') && audit.verb == 'create'"
-      summary: "{{ actor }} created project {{ has(audit.responseObject.metadata.name) ? link(audit.responseObject.metadata.name, audit.objectRef) : link(audit.objectRef.name, audit.objectRef) }}"
+      summary: "{{ actor }} created project {{ has(audit.responseObject.metadata.name) ? link(audit.responseObject.metadata.name, audit.objectRef) : has(audit.objectRef.name) ? link(audit.objectRef.name, audit.objectRef) : (has(audit.responseObject.details) && has(audit.responseObject.details.name)) ? link(audit.responseObject.details.name, audit.objectRef) : link('a project', audit.objectRef) }}"
 
     - name: delete
       match: "!audit.user.username.startsWith('system:') && audit.verb == 'delete'"

--- a/config/services/identity/policies/serviceaccount-policy.yaml
+++ b/config/services/identity/policies/serviceaccount-policy.yaml
@@ -26,7 +26,7 @@ spec:
   auditRules:
     - name: create
       match: "!audit.user.username.startsWith('system:') && audit.verb == 'create'"
-      summary: "{{ actor }} created service account {{ link(audit.responseObject.metadata.name, audit.objectRef) }}"
+      summary: "{{ actor }} created service account {{ has(audit.responseObject.metadata.name) ? link(audit.responseObject.metadata.name, audit.objectRef) : link(audit.objectRef.name, audit.objectRef) }}"
 
     - name: delete
       match: "!audit.user.username.startsWith('system:') && audit.verb == 'delete'"

--- a/config/services/identity/policies/serviceaccount-policy.yaml
+++ b/config/services/identity/policies/serviceaccount-policy.yaml
@@ -26,7 +26,7 @@ spec:
   auditRules:
     - name: create
       match: "!audit.user.username.startsWith('system:') && audit.verb == 'create'"
-      summary: "{{ actor }} created service account {{ has(audit.responseObject.metadata.name) ? link(audit.responseObject.metadata.name, audit.objectRef) : link(audit.objectRef.name, audit.objectRef) }}"
+      summary: "{{ actor }} created service account {{ has(audit.responseObject.metadata.name) ? link(audit.responseObject.metadata.name, audit.objectRef) : has(audit.objectRef.name) ? link(audit.objectRef.name, audit.objectRef) : (has(audit.responseObject.details) && has(audit.responseObject.details.name)) ? link(audit.responseObject.details.name, audit.objectRef) : link('a service account', audit.objectRef) }}"
 
     - name: delete
       match: "!audit.user.username.startsWith('system:') && audit.verb == 'delete'"


### PR DESCRIPTION
## What

Make the `create` rule summaries null-safe in six ActivityPolicies that
dereference `audit.responseObject.metadata.name`. Guard the leaf and fall back
to `audit.objectRef.name`.

## Why

Same DLQ-leak class as the prod `DLQSlowLeak` on the NSO gateway policy
(milo-os/activity#212). A `create` rule matches on verb/requestObject, so a
**rejected** create (409/422/admission-deny) still matches — but the apiserver
returns a `Status` object as `responseObject` with no `metadata.name`. CEL
raises `no such key: name`, the event goes to the DLQ, and retries fail
identically. Latent until the first rejected create of each kind.

## Fixed (create rules)

- `config/services/activity/policies/resourcemanager/` — project, organization
- `config/services/activity/policies/iam/` — role, group, serviceaccount
- `config/services/identity/policies/` — serviceaccount

## Remediation

Merge + milo release → the `milo-activity-policies` Flux Kustomization
re-applies the corrected CRs; processor retries any DLQ backlog. No `kubectl`.

## Related

- NSO fix (gateway + 5 more): datum-cloud/network-services-operator#230
- billing fix: milo-os/billing (separate PR)
- Runbook fix: milo-os/activity#213 · Investigation: milo-os/activity#212