### PR TITLE
fix(quota): default a namespace for cluster-scoped target ResourceClaims

### DIFF
--- a/pkg/quota/admission/config.go
+++ b/pkg/quota/admission/config.go
@@ -65,15 +65,27 @@ func DefaultWatchManagerConfig() *WatchManagerConfig {
 	}
 }
 
+// DefaultClusterScopedClaimNamespace is where ResourceClaims for cluster-scoped
+// target resources are created. Cluster-scoped resources have no namespace to
+// inherit, and ResourceClaims are namespaced, so they need a fixed home.
+const DefaultClusterScopedClaimNamespace = "milo-system"
+
 // AdmissionPluginConfig holds configuration for the ClaimCreationPlugin
 type AdmissionPluginConfig struct {
 	// WatchManager configuration
 	WatchManager *WatchManagerConfig
+
+	// ClusterScopedClaimNamespace is the namespace used for ResourceClaims when
+	// the triggering resource is cluster-scoped and the ClaimCreationPolicy does
+	// not pin spec.target.resourceClaimTemplate.metadata.namespace. Defaults to
+	// DefaultClusterScopedClaimNamespace.
+	ClusterScopedClaimNamespace string
 }
 
 // DefaultAdmissionPluginConfig returns the default configuration for the admission plugin
 func DefaultAdmissionPluginConfig() *AdmissionPluginConfig {
 	return &AdmissionPluginConfig{
-		WatchManager: DefaultWatchManagerConfig(),
+		WatchManager:                DefaultWatchManagerConfig(),
+		ClusterScopedClaimNamespace: DefaultClusterScopedClaimNamespace,
 	}
 }

--- a/pkg/quota/admission/errors.go
+++ b/pkg/quota/admission/errors.go
@@ -41,6 +41,13 @@ const (
 	// startup failures, dynamic client errors, and anything else that is not
 	// attributable to quota capacity.
 	claimFailureInternal
+
+	// claimFailureMisconfigured indicates the ClaimCreationPolicy cannot enforce
+	// quota for the triggering resource as written — e.g. it targets a
+	// cluster-scoped resource but does not pin a ResourceClaim namespace. The
+	// request can't succeed until an operator corrects the policy, so it is kept
+	// distinct from transient internal errors (which advise "try again").
+	claimFailureMisconfigured
 )
 
 // claimFailure is the structured error returned from the claim creation/wait
@@ -99,4 +106,11 @@ func newConflictFailure(message string, cause error) *claimFailure {
 // (template render, watch manager, dynamic client, etc).
 func newInternalFailure(cause error) *claimFailure {
 	return &claimFailure{kind: claimFailureInternal, cause: cause}
+}
+
+// newMisconfiguredFailure constructs a claimFailure for a ClaimCreationPolicy
+// that cannot enforce quota as written. cause carries the operator-facing
+// detail (policy name, offending field) for logs and traces.
+func newMisconfiguredFailure(reason string, cause error) *claimFailure {
+	return &claimFailure{kind: claimFailureMisconfigured, reason: reason, cause: cause}
 }

--- a/pkg/quota/admission/plugin.go
+++ b/pkg/quota/admission/plugin.go
@@ -589,6 +589,8 @@ func admissionOutcomeFor(kind claimFailureKind) string {
 		return "timeout"
 	case claimFailureConflict:
 		return "conflict"
+	case claimFailureMisconfigured:
+		return "policy_misconfigured"
 	default:
 		return "internal_error"
 	}
@@ -622,6 +624,9 @@ func userFacingClaimError(f *claimFailure) error {
 		}
 		//lint:ignore ST1005 user-facing message
 		return fmt.Errorf("We're still cleaning up from a previous attempt to create this resource. Please try again in a few seconds.")
+	case claimFailureMisconfigured:
+		//lint:ignore ST1005 user-facing message
+		return fmt.Errorf("Quota enforcement for this resource type is misconfigured and can't be applied. This needs a fix from the service provider — please contact support.")
 	default:
 		//lint:ignore ST1005 user-facing message
 		return fmt.Errorf("Something went wrong while checking your quota for this request. Please try again — if this keeps happening, contact support.")
@@ -657,6 +662,27 @@ func (p *ResourceQuotaEnforcementPlugin) createAndWaitForResourceClaim(ctx conte
 		return newInternalFailure(fmt.Errorf("failed to determine claim name: %w", err))
 	}
 	namespace := p.getClaimNamespace(policy, evalContext)
+	if namespace == "" {
+		// A ResourceClaim is namespaced, but a cluster-scoped target resource has
+		// no namespace to inherit and ClaimCreationPolicy is itself cluster
+		// scoped. Default to the configured cluster-scoped claim namespace so
+		// quota still enforces; a policy can override per-resource by pinning
+		// spec.target.resourceClaimTemplate.metadata.namespace (literal or CEL).
+		namespace = p.config.ClusterScopedClaimNamespace
+		if namespace == "" {
+			// Only reachable if the default was explicitly cleared. Fail with an
+			// actionable reason instead of the opaque downstream "the server
+			// could not find the requested resource".
+			err := fmt.Errorf("ClaimCreationPolicy %q resolved an empty ResourceClaim namespace for cluster-scoped resource %s and no cluster-scoped claim namespace is configured; set spec.target.resourceClaimTemplate.metadata.namespace or AdmissionPluginConfig.ClusterScopedClaimNamespace", policy.Name, attrs.GetResource().GroupResource())
+			span.RecordError(err)
+			span.SetStatus(codes.Error, "Empty claim namespace for cluster-scoped resource")
+			return newMisconfiguredFailure("EmptyClaimNamespace", err)
+		}
+		p.logger.V(2).Info("Defaulting ResourceClaim namespace for cluster-scoped resource",
+			"namespace", namespace,
+			"policy", policy.Name,
+			"resource", attrs.GetResource().GroupResource().String())
+	}
 
 	span.SetAttributes(
 		attribute.String("claim.name", claimName),

--- a/pkg/quota/admission/plugin_test.go
+++ b/pkg/quota/admission/plugin_test.go
@@ -22,9 +22,9 @@ import (
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
+	quotav1alpha1 "go.miloapis.com/milo/pkg/apis/quota/v1alpha1"
 	"go.miloapis.com/milo/pkg/quota/engine"
 	"go.miloapis.com/milo/pkg/quota/validation"
-	quotav1alpha1 "go.miloapis.com/milo/pkg/apis/quota/v1alpha1"
 	milorequest "go.miloapis.com/milo/pkg/request"
 )
 
@@ -1918,4 +1918,101 @@ func TestUserFacingClaimError(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestClusterScopedClaimNamespace covers a ClaimCreationPolicy that targets a
+// cluster-scoped resource (no namespace) without pinning
+// spec.target.resourceClaimTemplate.metadata.namespace. With the configured
+// default the ResourceClaim namespace is filled in and quota enforces; only
+// when that default is explicitly cleared does admission fail — with an
+// actionable misconfiguration error rather than the opaque downstream "the
+// server could not find the requested resource".
+func TestClusterScopedClaimNamespace(t *testing.T) {
+	clusterGVK := schema.GroupVersionKind{Group: "example.com", Version: "v1", Kind: "ClusterWidget"}
+
+	newPolicy := func() *quotav1alpha1.ClaimCreationPolicy {
+		return &quotav1alpha1.ClaimCreationPolicy{
+			ObjectMeta: metav1.ObjectMeta{Name: "clusterwidget-policy"},
+			Spec: quotav1alpha1.ClaimCreationPolicySpec{
+				Trigger: quotav1alpha1.ClaimTriggerSpec{
+					Resource: quotav1alpha1.ClaimTriggerResource{APIVersion: "example.com/v1", Kind: "ClusterWidget"},
+				},
+				Disabled: ptr.To(false),
+				Target: quotav1alpha1.ClaimTargetSpec{
+					ResourceClaimTemplate: quotav1alpha1.ResourceClaimTemplate{
+						// No Metadata.Namespace — cluster-scoped target relies on the default.
+						Metadata: quotav1alpha1.ObjectMetaTemplate{},
+						Spec: quotav1alpha1.ResourceClaimSpec{
+							ConsumerRef: quotav1alpha1.ConsumerRef{APIGroup: "resourcemanager.miloapis.com", Kind: "Organization", Name: "test-org"},
+							Requests:    []quotav1alpha1.ResourceRequest{{ResourceType: "example.com/ClusterWidget", Amount: 1}},
+						},
+					},
+				},
+			},
+			Status: quotav1alpha1.ClaimCreationPolicyStatus{
+				Conditions: []metav1.Condition{{Type: quotav1alpha1.ClaimCreationPolicyReady, Status: metav1.ConditionTrue, Reason: "TestReady"}},
+			},
+		}
+	}
+
+	newAttrs := func() *testAdmissionAttributes {
+		obj := &unstructured.Unstructured{Object: map[string]interface{}{
+			"apiVersion": "example.com/v1",
+			"kind":       "ClusterWidget",
+			"metadata":   map[string]interface{}{"name": "widget-1"}, // cluster-scoped: no namespace
+		}}
+		return &testAdmissionAttributes{
+			operation: admission.Create,
+			object:    obj,
+			gvk:       clusterGVK,
+			name:      obj.GetName(),
+			namespace: "", // cluster-scoped
+			userInfo:  &user.DefaultInfo{Name: "test-user"},
+		}
+	}
+
+	newPlugin := func(cfg *AdmissionPluginConfig, dyn dynamic.Interface, policy *quotav1alpha1.ClaimCreationPolicy) *ResourceQuotaEnforcementPlugin {
+		logger := zap.New(zap.UseDevMode(true))
+		celEngine, err := engine.NewCELEngine()
+		if err != nil {
+			t.Fatalf("Failed to create CEL engine: %v", err)
+		}
+		p := &ResourceQuotaEnforcementPlugin{
+			Handler:        admission.NewHandler(admission.Create),
+			dynamicClient:  dyn,
+			policyEngine:   &testPolicyEngine{policy: policy, gvk: clusterGVK},
+			templateEngine: engine.NewTemplateEngine(celEngine, logger.WithName("template")),
+			config:         cfg,
+			logger:         logger.WithName("plugin"),
+		}
+		p.watchManagers.Store("", &testWatchManager{behavior: "grant"})
+		return p
+	}
+
+	t.Run("defaults to configured namespace and enforces", func(t *testing.T) {
+		scheme := runtime.NewScheme()
+		quotav1alpha1.AddToScheme(scheme)
+		dyn := &fakeGrantingDynamicClient{FakeDynamicClient: fake.NewSimpleDynamicClient(scheme)}
+		plugin := newPlugin(DefaultAdmissionPluginConfig(), dyn, newPolicy())
+
+		if err := plugin.Validate(context.Background(), newAttrs(), nil); err != nil {
+			t.Fatalf("expected admission to succeed via the default cluster-scoped namespace, got: %v", err)
+		}
+	})
+
+	t.Run("misconfigured when default explicitly cleared", func(t *testing.T) {
+		scheme := runtime.NewScheme()
+		quotav1alpha1.AddToScheme(scheme)
+		cfg := DefaultAdmissionPluginConfig()
+		cfg.ClusterScopedClaimNamespace = ""
+		plugin := newPlugin(cfg, fake.NewSimpleDynamicClient(scheme), newPolicy())
+
+		err := plugin.Validate(context.Background(), newAttrs(), nil)
+		if err == nil {
+			t.Fatal("expected admission to fail when no cluster-scoped claim namespace is configured, got nil")
+		}
+		if !contains(err.Error(), "misconfigured") {
+			t.Errorf("expected an actionable misconfiguration error, got: %v", err)
+		}
+	})
 }


### PR DESCRIPTION
## Problem

Quota couldn't be enforced on **cluster-scoped resources**. Creating one that a `ClaimCreationPolicy` targeted was rejected with a misleading, transient-looking error ("Something went wrong while checking your quota… try again"), and retrying never worked.

## Cause

The ResourceClaim that backs enforcement is namespaced, but a cluster-scoped resource has no namespace to give it — so the claim couldn't be created.

## Fix

Default the claim's namespace to a configurable `ClusterScopedClaimNamespace` (default `milo-system`), so quota enforces on cluster-scoped resources out of the box. A policy can still pin a specific namespace via `spec.target.resourceClaimTemplate.metadata.namespace`. If an operator clears the default, admission fails with a clear, actionable message instead of the opaque one.

## Notes

Found while enabling quota for IPAM's cluster-scoped `IPPool`; namespaced resources were unaffected.
