### PR TITLE
feat(iam): re-home audit-log-querier inheritance to activity service

### DIFF
--- a/config/services/activity/kustomization.yaml
+++ b/config/services/activity/kustomization.yaml
@@ -6,5 +6,8 @@
 apiVersion: kustomize.config.k8s.io/v1alpha1
 kind: Component
 
+resources:
+  - roles/iam-user-self-manage-audit-log-querier.yaml
+
 components:
   - policies

--- a/config/services/activity/roles/iam-user-self-manage-audit-log-querier.yaml
+++ b/config/services/activity/roles/iam-user-self-manage-audit-log-querier.yaml
@@ -1,20 +1,5 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 
-# Grants users the ability to query their own audit logs by inheriting the
-# activity.miloapis.com-audit-log-querier Role into iam-user-self-manage.
-#
-# This inheritance ships with the activity service overlay rather than the core
-# control-plane role bundle on purpose: the audit-log-querier Role is provided
-# by the activity stack, so referencing it from the foundational layer would
-# force the core control plane to depend on activity being up first (an
-# inverted dependency). Keeping it here means the core role bundle has zero
-# activity coupling, and this entry is only applied once activity is present.
-#
-# Under server-side apply this partial Role merges its single inheritedRoles
-# entry into the iam-user-self-manage Role owned by the core role bundle.
-# inheritedRoles is a map-type list keyed by name, so this overlay owns just
-# this entry while the core bundle continues to own launchStage and
-# includedPermissions.
 apiVersion: iam.miloapis.com/v1alpha1
 kind: Role
 metadata:

--- a/config/services/activity/roles/iam-user-self-manage-audit-log-querier.yaml
+++ b/config/services/activity/roles/iam-user-self-manage-audit-log-querier.yaml
@@ -1,0 +1,24 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+
+# Grants users the ability to query their own audit logs by inheriting the
+# activity.miloapis.com-audit-log-querier Role into iam-user-self-manage.
+#
+# This inheritance ships with the activity service overlay rather than the core
+# control-plane role bundle on purpose: the audit-log-querier Role is provided
+# by the activity stack, so referencing it from the foundational layer would
+# force the core control plane to depend on activity being up first (an
+# inverted dependency). Keeping it here means the core role bundle has zero
+# activity coupling, and this entry is only applied once activity is present.
+#
+# Under server-side apply this partial Role merges its single inheritedRoles
+# entry into the iam-user-self-manage Role owned by the core role bundle.
+# inheritedRoles is a map-type list keyed by name, so this overlay owns just
+# this entry while the core bundle continues to own launchStage and
+# includedPermissions.
+apiVersion: iam.miloapis.com/v1alpha1
+kind: Role
+metadata:
+  name: iam-user-self-manage
+spec:
+  inheritedRoles:
+    - name: activity.miloapis.com-audit-log-querier


### PR DESCRIPTION
## Summary

Closes #676.

Moves the `iam-user-self-manage` → `activity.miloapis.com-audit-log-querier` role inheritance out of the foundational control-plane layer and into the **activity service** overlay (`config/services/activity`), which is only applied once the activity stack is present. The core role bundle now has **zero activity coupling**.

### Why

The `activity.miloapis.com-audit-log-querier` Role is shipped by the activity service. Referencing it from the core role bundle forced the foundational milo control plane to depend on activity rolling out first — an inverted dependency that pulled the foundation into datum-cloud/infra#2939.

## Changes

- **New:** `config/services/activity/roles/iam-user-self-manage-audit-log-querier.yaml` — a partial `Role` manifest that, under server-side apply, merges a single `inheritedRoles` entry into the `iam-user-self-manage` Role.
- **Edit:** `config/services/activity/kustomization.yaml` — wires the new resource into the activity overlay.

## Validation

- `kustomize build config/services/activity` → rc=0; renders the merged `Role` with the `activity.miloapis.com-audit-log-querier` inherited entry.
- `kustomize build config/roles` → 0 references to `audit-log-querier` (core layer is clean).

## Coordination

- Unblocks: datum-cloud/infra#2953 (un-draft after a new bundle is published, then cold-start validate bootstrap ordering).
- Part of: datum-cloud/infra#2943, datum-cloud/infra#2939.
