### PR TITLE
feat(iam): re-home audit-log-querier grant to a standalone activity role (replaces #677)

### DIFF
--- a/cmd/milo/controller-manager/controllermanager.go
+++ b/cmd/milo/controller-manager/controllermanager.go
@@ -518,7 +518,7 @@ func Run(ctx context.Context, c *config.CompletedConfig, opts *Options) error {
 				logger.Error(err, "Error setting up organizationmembership webhook")
 				klog.FlushAndExit(klog.ExitFlushTimeout, 1)
 			}
-			if err := iamv1alpha1webhook.SetupUserWebhooksWithManager(ctrl, SystemNamespace, "iam-user-self-manage"); err != nil {
+			if err := iamv1alpha1webhook.SetupUserWebhooksWithManager(ctrl, SystemNamespace, "iam-user-self-manage", "activity-self-audit-log-querier"); err != nil {
 				logger.Error(err, "Error setting up user webhook")
 				klog.FlushAndExit(klog.ExitFlushTimeout, 1)
 			}

--- a/config/services/activity/kustomization.yaml
+++ b/config/services/activity/kustomization.yaml
@@ -6,5 +6,8 @@
 apiVersion: kustomize.config.k8s.io/v1alpha1
 kind: Component
 
+resources:
+  - roles/activity-self-audit-log-querier.yaml
+
 components:
   - policies

--- a/config/services/activity/roles/activity-self-audit-log-querier.yaml
+++ b/config/services/activity/roles/activity-self-audit-log-querier.yaml
@@ -1,0 +1,18 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+
+# Self-scoped audit-log query capability, owned entirely by the activity
+# service overlay. A distinct Role (not a partial patch of iam-user-self-manage),
+# so it is applied by a single field manager and never collides with the core
+# role bundle. Granted per-user, scoped to the user's own User resource, by the
+# user webhook (mirrors the existing user-self-manage PolicyBinding).
+apiVersion: iam.miloapis.com/v1alpha1
+kind: Role
+metadata:
+  name: activity-self-audit-log-querier
+  annotations:
+    kubernetes.io/display-name: Self Audit Log Querier
+    kubernetes.io/description: "Allows a user to query their own audit logs."
+spec:
+  launchStage: Beta
+  inheritedRoles:
+    - name: activity.miloapis.com-audit-log-querier

--- a/internal/controllers/iam/user_controller.go
+++ b/internal/controllers/iam/user_controller.go
@@ -224,6 +224,24 @@ func (r *UserController) ensureOwnerReferences(ctx context.Context, user *iamv1a
 		log.Info("Updated PolicyBinding with owner reference", "user", user.Name)
 	}
 
+	// Update self audit-log PolicyBinding (only present when the activity service
+	// overlay is deployed; otherwise the webhook skips creating it).
+	auditLogPolicyBindingName := fmt.Sprintf("user-self-audit-log-%s", user.Name)
+	auditLogPolicyBinding := &iamv1alpha1.PolicyBinding{}
+	err = r.Client.Get(ctx, types.NamespacedName{Name: auditLogPolicyBindingName, Namespace: "milo-system"}, auditLogPolicyBinding)
+	if apierrors.IsNotFound(err) {
+		// Binding absent: activity overlay not deployed, or webhook hasn't created it yet.
+		log.Info("Self audit-log PolicyBinding not found, skipping", "user", user.Name, "policyBinding", auditLogPolicyBindingName)
+	} else if err != nil {
+		return fmt.Errorf("failed to get self audit-log policy binding: %w", err)
+	} else if !hasOwnerReference(auditLogPolicyBinding.OwnerReferences, ownerRef) {
+		auditLogPolicyBinding.OwnerReferences = append(auditLogPolicyBinding.OwnerReferences, ownerRef)
+		if err := r.Client.Update(ctx, auditLogPolicyBinding); err != nil {
+			return fmt.Errorf("failed to update self audit-log policy binding with owner reference: %w", err)
+		}
+		log.Info("Updated self audit-log PolicyBinding with owner reference", "user", user.Name)
+	}
+
 	// Update UserPreference
 	userPreferenceName := fmt.Sprintf("userpreference-%s", user.Name)
 	userPreference := &iamv1alpha1.UserPreference{}

--- a/internal/webhooks/iam/v1alpha1/user_webhook.go
+++ b/internal/webhooks/iam/v1alpha1/user_webhook.go
@@ -26,7 +26,7 @@ var userlog = logf.Log.WithName("user-resource")
 // +kubebuilder:webhook:path=/validate-iam-miloapis-com-v1alpha1-user,mutating=false,failurePolicy=fail,sideEffects=NoneOnDryRun,groups=iam.miloapis.com,resources=users,verbs=create;update,versions=v1alpha1,name=vuser.iam.miloapis.com,admissionReviewVersions={v1,v1beta1},serviceName=milo-controller-manager,servicePort=9443,serviceNamespace=milo-system
 
 // SetupWebhooksWithManager sets up all iam.miloapis.com webhooks
-func SetupUserWebhooksWithManager(mgr ctrl.Manager, systemNamespace string, userSelfManageRoleName string) error {
+func SetupUserWebhooksWithManager(mgr ctrl.Manager, systemNamespace string, userSelfManageRoleName string, selfAuditLogRoleName string) error {
 	userlog.Info("Setting up iam.miloapis.com user webhooks")
 
 	return ctrl.NewWebhookManagedBy(mgr, &iamv1alpha1.User{}).
@@ -36,6 +36,7 @@ func SetupUserWebhooksWithManager(mgr ctrl.Manager, systemNamespace string, user
 			scheme:                 mgr.GetScheme(),
 			systemNamespace:        systemNamespace,
 			userSelfManageRoleName: userSelfManageRoleName,
+			selfAuditLogRoleName:   selfAuditLogRoleName,
 		}).
 		Complete()
 }
@@ -48,6 +49,11 @@ type UserValidator struct {
 	decoder                admission.Decoder
 	systemNamespace        string
 	userSelfManageRoleName string
+	// selfAuditLogRoleName grants self-scoped audit-log query access. The role is
+	// shipped by the activity service overlay; when activity is not deployed this
+	// is empty and the binding is skipped, keeping the core control plane free of
+	// activity coupling.
+	selfAuditLogRoleName string
 }
 
 func (v *UserValidator) ValidateCreate(ctx context.Context, user *iamv1alpha1.User) (admission.Warnings, error) {
@@ -65,6 +71,11 @@ func (v *UserValidator) ValidateCreate(ctx context.Context, user *iamv1alpha1.Us
 	if err := v.createSelfManagePolicyBinding(ctx, user); err != nil {
 		userlog.Error(err, "Failed to create owner policy binding")
 		return nil, fmt.Errorf("failed to create owner policy binding: %w", err)
+	}
+
+	if err := v.createSelfAuditLogPolicyBinding(ctx, user); err != nil {
+		userlog.Error(err, "Failed to create self audit-log policy binding")
+		return nil, fmt.Errorf("failed to create self audit-log policy binding: %w", err)
 	}
 
 	userPreferences, err := v.createUserPreference(ctx, user)
@@ -237,6 +248,53 @@ func (v *UserValidator) createSelfManagePolicyBinding(ctx context.Context, user 
 
 	if err := v.client.Create(ctx, policyBinding); err != nil {
 		return fmt.Errorf("failed to create policy binding resource: %w", err)
+	}
+
+	return nil
+}
+
+// createSelfAuditLogPolicyBinding grants the user self-scoped audit-log query
+// access. The role lives in the activity service overlay; when activity is not
+// deployed, selfAuditLogRoleName is empty and this is skipped, so the core
+// control plane carries zero activity coupling. The binding is scoped to the
+// user's own User resource, mirroring the self-manage binding.
+func (v *UserValidator) createSelfAuditLogPolicyBinding(ctx context.Context, user *iamv1alpha1.User) error {
+	if v.selfAuditLogRoleName == "" {
+		return nil
+	}
+
+	userlog.Info("Attempting to create self audit-log PolicyBinding for new user", "user", user.Name)
+
+	policyBinding := &iamv1alpha1.PolicyBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf("user-self-audit-log-%s", user.Name),
+			Namespace: v.systemNamespace,
+		},
+		Spec: iamv1alpha1.PolicyBindingSpec{
+			RoleRef: iamv1alpha1.RoleReference{
+				Name:      v.selfAuditLogRoleName,
+				Namespace: v.systemNamespace,
+			},
+			Subjects: []iamv1alpha1.Subject{
+				{
+					Kind: "User",
+					Name: user.Name,
+					UID:  string(user.GetUID()),
+				},
+			},
+			ResourceSelector: iamv1alpha1.ResourceSelector{
+				ResourceRef: &iamv1alpha1.ResourceReference{
+					APIGroup: iamv1alpha1.SchemeGroupVersion.Group,
+					Kind:     "User",
+					Name:     user.Name,
+					UID:      string(user.GetUID()),
+				},
+			},
+		},
+	}
+
+	if err := v.client.Create(ctx, policyBinding); err != nil {
+		return fmt.Errorf("failed to create self audit-log policy binding resource: %w", err)
 	}
 
 	return nil


### PR DESCRIPTION
## Summary

**Replaces #677.** Closes #676.

Delivers the "users can query their own audit logs" capability from the **activity service** overlay *without* mutating the shared `iam-user-self-manage` Role, keeping the foundational milo control plane free of any activity dependency.

## Why #677 doesn't work

#677 added a partial `Role/iam-user-self-manage` manifest (only `spec.inheritedRoles`) to the activity overlay and relied on server-side apply to merge that single entry into the core role.

That assumption fails under the actual GitOps setup (datum-cloud/infra):

- The **core role** is applied by the `milo-core-control-plane-crds` Flux Kustomization (`./crd/overlays/core-control-plane` into `../../../roles`).
- The **partial overlay** would be applied by `milo-activity-policies` (`./services/activity`).
- Flux's `kustomize-controller` server-side-applies **every** Kustomization under a **single shared field manager** (`kustomize-controller`). There is no per-Kustomization manager and no field-manager override on the Kustomization spec.

With one shared manager, each apply re-declares its full field set, so SSA prunes any field that manager owned but no longer lists. The two Kustomizations therefore **prune each other's fields on every reconcile** (`interval: 1h` each). The role flip-flops:

| After reconcile of… | Result |
|---|---|
| `milo-core-control-plane-crds` | `includedPermissions` present, **audit inheritance gone** |
| `milo-activity-policies` | audit inheritance present, **all self-manage permissions gone** |

`inheritedRoles` being `listType=map` only enables clean merge across **distinct** field managers owning distinct keys, which Flux does not provide here. (The companion infra PR's premise that `inheritedRoles` is "an atomic list" is also incorrect, it is map-type, but the shared-field-manager problem stands regardless.)

## What this PR does instead

- **New:** `config/services/activity/roles/activity-self-audit-log-querier.yaml`, a standalone `Role` that inherits `activity.miloapis.com-audit-log-querier`. A distinct object with a single owner means no cross-Kustomization field contention.
- **Edit:** `config/services/activity/kustomization.yaml` wires the role into the activity overlay.
- **Webhook** (`user_webhook.go`): grants the role **per-user, scoped to the user's own `User` resource**, mirroring the existing `user-self-manage` PolicyBinding, so self-audit access stays self-scoped. Gated on a configurable role name (empty means skip), so the core control plane carries **zero activity coupling** when activity is not deployed.
- **Controller** (`user_controller.go`): attaches an owner reference to the binding for GC on user deletion, `IsNotFound`-guarded so it is inert when the activity overlay is absent.

### Why not a static group binding

A single `PolicyBinding` to `system:authenticated` (like `organization-creator-policy`) needs no per-user code, but only `resourceKind: User` is available for a `Group` subject, which would grant **every** user query access to **all** users' audit logs. Rejected as a scope regression.

## Validation

- `go build` on edited packages is clean.
- `task generate:code` produces no manifest diff (no new API types or markers).
- Full builds and tests via CI.

## Coordination

- Part of: datum-cloud/infra#2943, datum-cloud/infra#2939.
- Pairs with: datum-cloud/infra#2953 (its "atomic list" justification should be corrected to "map-type, but shared Flux field manager").
