### PR TITLE
fix: guard create rules on 2xx instead of name fallbacks

### DIFF
--- a/config/services/activity/policies/iam/group-policy.yaml
+++ b/config/services/activity/policies/iam/group-policy.yaml
@@ -24,8 +24,8 @@ spec:
   # so controller reconciliation doesn't generate activity noise.
   auditRules:
     - name: create
-      match: "!audit.user.username.startsWith('system:') && audit.verb == 'create'"
-      summary: "{{ actor }} created group {{ has(audit.responseObject.metadata.name) ? link(audit.responseObject.metadata.name, audit.objectRef) : has(audit.objectRef.name) ? link(audit.objectRef.name, audit.objectRef) : (has(audit.responseObject.details) && has(audit.responseObject.details.name)) ? link(audit.responseObject.details.name, audit.objectRef) : link('a group', audit.objectRef) }}"
+      match: "!audit.user.username.startsWith('system:') && audit.verb == 'create' && audit.responseStatus.code >= 200 && audit.responseStatus.code < 300"
+      summary: "{{ actor }} created group {{ link(audit.responseObject.metadata.name, audit.objectRef) }}"
 
     - name: delete
       match: "!audit.user.username.startsWith('system:') && audit.verb == 'delete'"

--- a/config/services/activity/policies/iam/role-policy.yaml
+++ b/config/services/activity/policies/iam/role-policy.yaml
@@ -11,8 +11,8 @@ spec:
 
   auditRules:
     - name: create
-      match: "!audit.user.username.startsWith('system:') && audit.verb == 'create'"
-      summary: "{{ actor }} created role {{ has(audit.responseObject.metadata.name) ? link(audit.responseObject.metadata.name, audit.objectRef) : has(audit.objectRef.name) ? link(audit.objectRef.name, audit.objectRef) : (has(audit.responseObject.details) && has(audit.responseObject.details.name)) ? link(audit.responseObject.details.name, audit.objectRef) : link('a role', audit.objectRef) }}"
+      match: "!audit.user.username.startsWith('system:') && audit.verb == 'create' && audit.responseStatus.code >= 200 && audit.responseStatus.code < 300"
+      summary: "{{ actor }} created role {{ link(audit.responseObject.metadata.name, audit.objectRef) }}"
 
     - name: delete
       match: "!audit.user.username.startsWith('system:') && audit.verb == 'delete'"

--- a/config/services/activity/policies/iam/serviceaccount-policy.yaml
+++ b/config/services/activity/policies/iam/serviceaccount-policy.yaml
@@ -25,8 +25,8 @@ spec:
   # so controller reconciliation doesn't generate activity noise.
   auditRules:
     - name: create
-      match: "!audit.user.username.startsWith('system:') && audit.verb == 'create'"
-      summary: "{{ actor }} created service account {{ has(audit.responseObject.metadata.name) ? link(audit.responseObject.metadata.name, audit.objectRef) : has(audit.objectRef.name) ? link(audit.objectRef.name, audit.objectRef) : (has(audit.responseObject.details) && has(audit.responseObject.details.name)) ? link(audit.responseObject.details.name, audit.objectRef) : link('a service account', audit.objectRef) }}"
+      match: "!audit.user.username.startsWith('system:') && audit.verb == 'create' && audit.responseStatus.code >= 200 && audit.responseStatus.code < 300"
+      summary: "{{ actor }} created service account {{ link(audit.responseObject.metadata.name, audit.objectRef) }}"
 
     - name: delete
       match: "!audit.user.username.startsWith('system:') && audit.verb == 'delete'"

--- a/config/services/activity/policies/resourcemanager/organization-policy.yaml
+++ b/config/services/activity/policies/resourcemanager/organization-policy.yaml
@@ -25,8 +25,8 @@ spec:
   # so controller reconciliation doesn't generate activity noise.
   auditRules:
     - name: create
-      match: "!audit.user.username.startsWith('system:') && audit.verb == 'create'"
-      summary: "{{ actor }} created organization {{ has(audit.responseObject.metadata.name) ? link(audit.responseObject.metadata.name, audit.objectRef) : has(audit.objectRef.name) ? link(audit.objectRef.name, audit.objectRef) : (has(audit.responseObject.details) && has(audit.responseObject.details.name)) ? link(audit.responseObject.details.name, audit.objectRef) : link('an organization', audit.objectRef) }}"
+      match: "!audit.user.username.startsWith('system:') && audit.verb == 'create' && audit.responseStatus.code >= 200 && audit.responseStatus.code < 300"
+      summary: "{{ actor }} created organization {{ link(audit.responseObject.metadata.name, audit.objectRef) }}"
 
     - name: delete
       match: "!audit.user.username.startsWith('system:') && audit.verb == 'delete'"

--- a/config/services/activity/policies/resourcemanager/project-policy.yaml
+++ b/config/services/activity/policies/resourcemanager/project-policy.yaml
@@ -24,8 +24,8 @@ spec:
   # so controller reconciliation doesn't generate activity noise.
   auditRules:
     - name: create
-      match: "!audit.user.username.startsWith('system:') && audit.verb == 'create'"
-      summary: "{{ actor }} created project {{ has(audit.responseObject.metadata.name) ? link(audit.responseObject.metadata.name, audit.objectRef) : has(audit.objectRef.name) ? link(audit.objectRef.name, audit.objectRef) : (has(audit.responseObject.details) && has(audit.responseObject.details.name)) ? link(audit.responseObject.details.name, audit.objectRef) : link('a project', audit.objectRef) }}"
+      match: "!audit.user.username.startsWith('system:') && audit.verb == 'create' && audit.responseStatus.code >= 200 && audit.responseStatus.code < 300"
+      summary: "{{ actor }} created project {{ link(audit.responseObject.metadata.name, audit.objectRef) }}"
 
     - name: delete
       match: "!audit.user.username.startsWith('system:') && audit.verb == 'delete'"

--- a/config/services/identity/policies/serviceaccount-policy.yaml
+++ b/config/services/identity/policies/serviceaccount-policy.yaml
@@ -25,8 +25,8 @@ spec:
   # so controller reconciliation doesn't generate activity noise.
   auditRules:
     - name: create
-      match: "!audit.user.username.startsWith('system:') && audit.verb == 'create'"
-      summary: "{{ actor }} created service account {{ has(audit.responseObject.metadata.name) ? link(audit.responseObject.metadata.name, audit.objectRef) : has(audit.objectRef.name) ? link(audit.objectRef.name, audit.objectRef) : (has(audit.responseObject.details) && has(audit.responseObject.details.name)) ? link(audit.responseObject.details.name, audit.objectRef) : link('a service account', audit.objectRef) }}"
+      match: "!audit.user.username.startsWith('system:') && audit.verb == 'create' && audit.responseStatus.code >= 200 && audit.responseStatus.code < 300"
+      summary: "{{ actor }} created service account {{ link(audit.responseObject.metadata.name, audit.objectRef) }}"
 
     - name: delete
       match: "!audit.user.username.startsWith('system:') && audit.verb == 'delete'"


### PR DESCRIPTION
## What

Follow-up to #672. Replace the `has()`-chained summary fallbacks with a
success guard on the six ActivityPolicy create rules.

## Why

Per Scot's review on [milo-os/billing#69](https://github.com/milo-os/billing/pull/69#issuecomment-4849357361): guard write rules to only trigger on successful requests, rather than defensively dereferencing fields that a rejected create never populates.

Rejected creates (the DLQ-leak source, milo-os/activity#212) return 4xx. Guarding the match on 2xx means they match no rule and never deref an absent `responseObject.metadata.name` — root-cause fix vs the `has()` band-aid #672 shipped.

## Fix

- Add `audit.responseStatus.code >= 200 && audit.responseStatus.code < 300` to the create match in group / role / serviceaccount (iam + identity) / organization / project policies
- Revert create summaries to the simple `link(audit.responseObject.metadata.name, audit.objectRef)` form; a 2xx create always has that field

Failed creates emit no "created" activity by design; they remain queryable via `responseStatus.code >= 400` in audit query.

## Related

- Sibling fixes: milo-os/billing#69 · datum-cloud/network-services-operator#230
- Runbook milo-os/activity#213 · Investigation milo-os/activity#212