### PR TITLE
feat: Extend bootstrap resource metrics for IAM

### DIFF
--- a/config/resources-metrics/iam/policy_bindings.yaml
+++ b/config/resources-metrics/iam/policy_bindings.yaml
@@ -8,6 +8,7 @@ spec:
       labelsFromPath:
         name: [metadata, name]
         namespace: [metadata, namespace]
+        role_name: [spec, roleRef, name]
       metricNamePrefix: milo_policy_bindings
       metrics:
         - name: "info"

--- a/config/resources-metrics/iam/users.yaml
+++ b/config/resources-metrics/iam/users.yaml
@@ -8,6 +8,7 @@ spec:
       labelsFromPath:
         name: [metadata, name]
         namespace: [metadata, namespace]
+        email: [spec, email]
       metricNamePrefix: milo_users
       metrics:
         - name: "info"
@@ -16,8 +17,29 @@ spec:
             info:
               labelsFromPath:
                 "uid": [metadata, uid]
+                email: [spec, email]
+                state: [status, state]
         - name: "created_timestamp"
           each:
             type: Gauge
             gauge:
               path: [metadata, creationTimestamp]
+        - name: "status_condition"
+          each:
+            type: Gauge
+            gauge:
+              path: [status, conditions]
+              labelsFromPath:
+                type: ["type"]
+                reason: ["reason"]
+              valueFrom: ["status"]
+        - name: "status_condition_last_transition_time"
+          each:
+            type: Gauge
+            gauge:
+              path: [status, conditions]
+              labelsFromPath:
+                type: ["type"]
+                reason: ["reason"]
+                status: ["status"]
+              valueFrom: ["lastTransitionTime"]

--- a/config/telemetry/recording-rules/bootstrap/kustomization.yaml
+++ b/config/telemetry/recording-rules/bootstrap/kustomization.yaml
@@ -1,6 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1alpha1
 kind: Component
 
-components:
-  - ./quota
-  - ./bootstrap
+resources:
+  - recording-rules.yaml

--- a/config/telemetry/recording-rules/bootstrap/recording-rules.yaml
+++ b/config/telemetry/recording-rules/bootstrap/recording-rules.yaml
@@ -1,0 +1,138 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: miloapis.com-bootstrap-recording-rules
+  labels:
+    app.kubernetes.io/name: milo
+    app.kubernetes.io/component: bootstrap
+    app.kubernetes.io/part-of: milo
+    monitoring.coreos.com/prometheus: kube-prometheus
+spec:
+  groups:
+    - name: bootstrap.latency.1m
+      interval: 1m
+      rules:
+        - record: miloapis.com:bootstrap:user_ready_latency_seconds
+          expr: |
+            clamp_min(
+              clamp_max(
+                max by (email) (milo_users_status_condition_last_transition_time{type="Ready"})
+                - on(email) max by (email) (milo_users_created_timestamp),
+                86400
+              ),
+              0
+            )
+
+        - record: miloapis.com:bootstrap:org_onboarding_ready_latency_seconds
+          expr: |
+            clamp_min(
+              clamp_max(
+                sum by (resource_name) (milo_organizations_status_condition_last_transition_time{type="OnboardingComplete",reason="Ready"})
+                - sum by (resource_name) (milo_organizations_created_timestamp),
+                86400
+              ),
+              0
+            )
+
+        - record: miloapis.com:bootstrap:org_member_owner_binding_ready_latency_seconds
+          expr: |
+            clamp_min(
+              clamp_max(
+                sum by (resource_namespace) (
+                  milo_policy_bindings_status_condition_last_transition_time{resource_namespace=~"organization-.*",resource_name=~"member-.*",role_name="owner",type="Ready"}
+                )
+                - sum by (resource_namespace) (
+                  milo_policy_bindings_created_timestamp{resource_namespace=~"organization-.*",resource_name=~"member-.*",role_name="owner"}
+                ),
+                86400
+              ),
+              0
+            )
+
+        - record: miloapis.com:bootstrap:project_ready_latency_seconds
+          expr: |
+            clamp_min(
+              clamp_max(
+                sum by (resource_name) (milo_projects_status_condition_last_transition_time{type="Ready"})
+                - sum by (resource_name) (milo_projects_created_timestamp),
+                86400
+              ),
+              0
+            )
+
+        - record: miloapis.com:bootstrap:project_owner_binding_ready_latency_seconds
+          expr: |
+            clamp_min(
+              clamp_max(
+                sum by (resource_namespace) (
+                  milo_policy_bindings_status_condition_last_transition_time{resource_namespace=~"organization-.*",resource_name=~"project-.*",role_name="owner",type="Ready"}
+                )
+                - sum by (resource_namespace) (
+                  milo_policy_bindings_created_timestamp{resource_namespace=~"organization-.*",resource_name=~"project-.*",role_name="owner"}
+                ),
+                86400
+              ),
+              0
+            )
+
+        - record: miloapis.com:bootstrap:org_to_project_owner_binding_latency_seconds
+          expr: |
+            clamp_min(
+              clamp_max(
+                sum by (resource_namespace) (
+                  milo_policy_bindings_status_condition_last_transition_time{resource_namespace=~"organization-.*",resource_name=~"project-.*",role_name="owner",type="Ready"}
+                )
+                - on(resource_namespace) group_left()
+                label_replace(
+                  sum by (resource_name) (milo_organizations_created_timestamp),
+                  "resource_namespace", "organization-$1", "resource_name", "(.+)"
+                ),
+                86400
+              ),
+              0
+            )
+
+    - name: bootstrap.latency.quantiles.1m
+      interval: 1m
+      rules:
+        - record: miloapis.com:bootstrap:user_ready_latency_seconds:p50
+          expr: quantile(0.50, miloapis.com:bootstrap:user_ready_latency_seconds) or vector(0)
+        - record: miloapis.com:bootstrap:user_ready_latency_seconds:p95
+          expr: quantile(0.95, miloapis.com:bootstrap:user_ready_latency_seconds) or vector(0)
+        - record: miloapis.com:bootstrap:user_ready_latency_seconds:p99
+          expr: quantile(0.99, miloapis.com:bootstrap:user_ready_latency_seconds) or vector(0)
+
+        - record: miloapis.com:bootstrap:org_onboarding_ready_latency_seconds:p50
+          expr: quantile(0.50, miloapis.com:bootstrap:org_onboarding_ready_latency_seconds) or vector(0)
+        - record: miloapis.com:bootstrap:org_onboarding_ready_latency_seconds:p95
+          expr: quantile(0.95, miloapis.com:bootstrap:org_onboarding_ready_latency_seconds) or vector(0)
+        - record: miloapis.com:bootstrap:org_onboarding_ready_latency_seconds:p99
+          expr: quantile(0.99, miloapis.com:bootstrap:org_onboarding_ready_latency_seconds) or vector(0)
+
+        - record: miloapis.com:bootstrap:org_member_owner_binding_ready_latency_seconds:p50
+          expr: quantile(0.50, miloapis.com:bootstrap:org_member_owner_binding_ready_latency_seconds) or vector(0)
+        - record: miloapis.com:bootstrap:org_member_owner_binding_ready_latency_seconds:p95
+          expr: quantile(0.95, miloapis.com:bootstrap:org_member_owner_binding_ready_latency_seconds) or vector(0)
+        - record: miloapis.com:bootstrap:org_member_owner_binding_ready_latency_seconds:p99
+          expr: quantile(0.99, miloapis.com:bootstrap:org_member_owner_binding_ready_latency_seconds) or vector(0)
+
+        - record: miloapis.com:bootstrap:project_ready_latency_seconds:p50
+          expr: quantile(0.50, miloapis.com:bootstrap:project_ready_latency_seconds) or vector(0)
+        - record: miloapis.com:bootstrap:project_ready_latency_seconds:p95
+          expr: quantile(0.95, miloapis.com:bootstrap:project_ready_latency_seconds) or vector(0)
+        - record: miloapis.com:bootstrap:project_ready_latency_seconds:p99
+          expr: quantile(0.99, miloapis.com:bootstrap:project_ready_latency_seconds) or vector(0)
+
+        - record: miloapis.com:bootstrap:project_owner_binding_ready_latency_seconds:p50
+          expr: quantile(0.50, miloapis.com:bootstrap:project_owner_binding_ready_latency_seconds) or vector(0)
+        - record: miloapis.com:bootstrap:project_owner_binding_ready_latency_seconds:p95
+          expr: quantile(0.95, miloapis.com:bootstrap:project_owner_binding_ready_latency_seconds) or vector(0)
+        - record: miloapis.com:bootstrap:project_owner_binding_ready_latency_seconds:p99
+          expr: quantile(0.99, miloapis.com:bootstrap:project_owner_binding_ready_latency_seconds) or vector(0)
+
+        - record: miloapis.com:bootstrap:org_to_project_owner_binding_latency_seconds:p50
+          expr: quantile(0.50, miloapis.com:bootstrap:org_to_project_owner_binding_latency_seconds) or vector(0)
+        - record: miloapis.com:bootstrap:org_to_project_owner_binding_latency_seconds:p95
+          expr: quantile(0.95, miloapis.com:bootstrap:org_to_project_owner_binding_latency_seconds) or vector(0)
+        - record: miloapis.com:bootstrap:org_to_project_owner_binding_latency_seconds:p99
+          expr: quantile(0.99, miloapis.com:bootstrap:org_to_project_owner_binding_latency_seconds) or vector(0)


### PR DESCRIPTION
## Summary

The bootstrap E2E Grafana panels need a few metric fields that were not in milo's `resources-metrics` bundle yet: User condition transition times and PolicyBinding `role_name` labels. Infra had started carrying those as local ConfigMaps, which works but puts Milo-specific CR config in the wrong repo.

This adds the missing fields to the existing IAM metrics in `config/resources-metrics/iam/`, plus recording rules that precompute bootstrap stage latencies and fleet P50/P95/P99 quantiles. Grafana can query `miloapis.com:bootstrap:*` instead of repeating joins and clamp logic in every panel.

- `milo_users` now exports `status_condition` and `status_condition_last_transition_time`, with `email` on the series
- `milo_policy_bindings` metrics carry `role_name` so org and project owner bindings are easy to filter
- Recording rules under `config/telemetry/recording-rules/bootstrap/` publish per-entity latencies and `:p50`/`:p95`/`:p99` fleet quantiles

## Test plan

- [x] `kustomize build config/resources-metrics/iam`
- [x] `kustomize build config/telemetry/recording-rules`
- [ ] After the bundle publishes, confirm new series show up in Victoria Metrics on staging
- [ ] Check `milo_users_status_condition_last_transition_time` has an `email` label
- [ ] Check `milo_policy_bindings_*` in `organization-*` namespaces include `role_name`
- [ ] Confirm `miloapis.com:bootstrap:user_ready_latency_seconds:p95` appears after `milo-recording-rules` reconciles

Related to datum-cloud/infra#3292