### PR TITLE
fix: self-delete OrganizationMembership when its Organization is gone

### DIFF
--- a/internal/controllers/resourcemanager/organization_membership_controller.go
+++ b/internal/controllers/resourcemanager/organization_membership_controller.go
@@ -104,6 +104,26 @@ func (r *OrganizationMembershipController) Reconcile(ctx context.Context, req ct
 	if err := r.Client.Get(ctx, organizationKey, &organization); err != nil {
 		if apierrors.IsNotFound(err) {
 			logger.Info("referenced organization not found", "organization", organizationMembership.Spec.OrganizationRef.Name)
+
+			// Two-pass self-delete: if we already set OrganizationNotFound on a
+			// previous reconcile, delete the membership now so it does not linger
+			// after the owning Organization is gone. The second reconcile is
+			// triggered by the status condition update below, which re-enqueues
+			// the membership. This mirrors the UserNotFound self-delete below;
+			// without it, memberships (and the PolicyBindings they own) are
+			// orphaned forever once their Organization is deleted, since nothing
+			// else garbage collects them.
+			existingCondition := apimeta.FindStatusCondition(organizationMembership.Status.Conditions, OrganizationMembershipReady)
+			if existingCondition != nil && existingCondition.Reason == OrganizationNotFoundReason {
+				logger.Info("deleting OrganizationMembership because referenced organization no longer exists",
+					"membership", organizationMembership.Name,
+					"organization", organizationMembership.Spec.OrganizationRef.Name)
+				if err := r.Client.Delete(ctx, &organizationMembership); err != nil && !apierrors.IsNotFound(err) {
+					return ctrl.Result{}, fmt.Errorf("failed to self-delete organization membership: %w", err)
+				}
+				return ctrl.Result{}, nil
+			}
+
 			readyCondition.Status = metav1.ConditionFalse
 			readyCondition.Reason = OrganizationNotFoundReason
 			readyCondition.Message = fmt.Sprintf("Organization '%s' does not exist. Please ensure the organization name is correct and the organization has been created.", organizationMembership.Spec.OrganizationRef.Name)

--- a/internal/controllers/resourcemanager/organization_membership_controller_test.go
+++ b/internal/controllers/resourcemanager/organization_membership_controller_test.go
@@ -8,10 +8,12 @@ import (
 	iamv1alpha1 "go.miloapis.com/milo/pkg/apis/iam/v1alpha1"
 	resourcemanagerv1alpha1 "go.miloapis.com/milo/pkg/apis/resourcemanager/v1alpha1"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
@@ -338,5 +340,135 @@ func TestOrganizationMembershipController_GetRoleKey(t *testing.T) {
 				t.Errorf("Expected role key '%s', got '%s'", tt.expected, key)
 			}
 		})
+	}
+}
+
+// TestOrganizationMembershipController_Reconcile_OrganizationNotFound_SelfDeletes verifies
+// the two-pass self-delete: the first reconcile against a membership whose Organization no
+// longer exists only records the failure, and the membership self-deletes on the reconcile
+// that finds the same reason already recorded from last time.
+func TestOrganizationMembershipController_Reconcile_OrganizationNotFound_SelfDeletes(t *testing.T) {
+	ctx := context.TODO()
+	scheme := getTestScheme()
+
+	user := &iamv1alpha1.User{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-user",
+			UID:  types.UID("user-uid"),
+		},
+		Spec: iamv1alpha1.UserSpec{
+			Email: "test@example.com",
+		},
+	}
+
+	// No Organization object is created, simulating one that has been deleted.
+	membership := &resourcemanagerv1alpha1.OrganizationMembership{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-membership",
+			Namespace: "organization-missing-org",
+			UID:       types.UID("membership-uid"),
+		},
+		Spec: resourcemanagerv1alpha1.OrganizationMembershipSpec{
+			OrganizationRef: resourcemanagerv1alpha1.OrganizationReference{
+				Name: "missing-org",
+			},
+			UserRef: resourcemanagerv1alpha1.MemberReference{
+				Name: "test-user",
+			},
+		},
+	}
+
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(user, membership).
+		WithStatusSubresource(membership).
+		Build()
+
+	controller := &OrganizationMembershipController{Client: c}
+	req := ctrl.Request{NamespacedName: types.NamespacedName{Name: membership.Name, Namespace: membership.Namespace}}
+
+	// First reconcile: organization not found. Should only record the condition -
+	// the membership must still exist afterwards.
+	if _, err := controller.Reconcile(ctx, req); err != nil {
+		t.Fatalf("first reconcile failed: %v", err)
+	}
+
+	var got resourcemanagerv1alpha1.OrganizationMembership
+	if err := c.Get(ctx, req.NamespacedName, &got); err != nil {
+		t.Fatalf("expected membership to still exist after first reconcile: %v", err)
+	}
+	cond := apimeta.FindStatusCondition(got.Status.Conditions, OrganizationMembershipReady)
+	if cond == nil || cond.Reason != OrganizationNotFoundReason {
+		t.Fatalf("expected Ready condition reason %q after first reconcile, got %+v", OrganizationNotFoundReason, cond)
+	}
+
+	// Second reconcile: the same reason is already recorded from last time, so the
+	// membership should self-delete.
+	if _, err := controller.Reconcile(ctx, req); err != nil {
+		t.Fatalf("second reconcile failed: %v", err)
+	}
+	if err := c.Get(ctx, req.NamespacedName, &got); !apierrors.IsNotFound(err) {
+		t.Fatalf("expected membership to be deleted after second reconcile, got err=%v", err)
+	}
+}
+
+// TestOrganizationMembershipController_Reconcile_UserNotFound_SelfDeletes covers the
+// pre-existing UserNotFound self-delete path, which had no test coverage prior to this
+// change. Same two-pass shape as the OrganizationNotFound case above.
+func TestOrganizationMembershipController_Reconcile_UserNotFound_SelfDeletes(t *testing.T) {
+	ctx := context.TODO()
+	scheme := getTestScheme()
+
+	organization := &resourcemanagerv1alpha1.Organization{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-org",
+			UID:  types.UID("org-uid"),
+		},
+	}
+
+	// No User object is created, simulating one that has been deleted.
+	membership := &resourcemanagerv1alpha1.OrganizationMembership{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-membership",
+			Namespace: "organization-test-org",
+			UID:       types.UID("membership-uid"),
+		},
+		Spec: resourcemanagerv1alpha1.OrganizationMembershipSpec{
+			OrganizationRef: resourcemanagerv1alpha1.OrganizationReference{
+				Name: "test-org",
+			},
+			UserRef: resourcemanagerv1alpha1.MemberReference{
+				Name: "missing-user",
+			},
+		},
+	}
+
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(organization, membership).
+		WithStatusSubresource(membership).
+		Build()
+
+	controller := &OrganizationMembershipController{Client: c}
+	req := ctrl.Request{NamespacedName: types.NamespacedName{Name: membership.Name, Namespace: membership.Namespace}}
+
+	if _, err := controller.Reconcile(ctx, req); err != nil {
+		t.Fatalf("first reconcile failed: %v", err)
+	}
+
+	var got resourcemanagerv1alpha1.OrganizationMembership
+	if err := c.Get(ctx, req.NamespacedName, &got); err != nil {
+		t.Fatalf("expected membership to still exist after first reconcile: %v", err)
+	}
+	cond := apimeta.FindStatusCondition(got.Status.Conditions, OrganizationMembershipReady)
+	if cond == nil || cond.Reason != UserNotFoundReason {
+		t.Fatalf("expected Ready condition reason %q after first reconcile, got %+v", UserNotFoundReason, cond)
+	}
+
+	if _, err := controller.Reconcile(ctx, req); err != nil {
+		t.Fatalf("second reconcile failed: %v", err)
+	}
+	if err := c.Get(ctx, req.NamespacedName, &got); !apierrors.IsNotFound(err) {
+		t.Fatalf("expected membership to be deleted after second reconcile, got err=%v", err)
 	}
 }


### PR DESCRIPTION
## Summary

`OrganizationMembershipController` already self-deletes a membership once
its `User` is gone (`UserNotFoundReason`), via a two-pass check: the first
reconcile records the failure reason, the second reconcile - triggered by
that status write re-enqueuing the object - sees the same reason still set
and deletes for real.

There was no equivalent for the referenced `Organization` being gone
(`OrganizationNotFoundReason`). Deleting an Organization left its
memberships permanently stuck reporting `OrganizationNotFound`, and since
nothing ever deleted the membership, the owner `PolicyBinding` it manages
(owned by the membership, not the Organization) was never garbage
collected either.

This showed up as part of a live staging incident: `PolicyBindingsNotReady`
and `OrganizationMembershipsNotReady` were both firing, with several
memberships/bindings that had been silently orphaned for months.

- Add the same two-pass self-delete for `OrganizationNotFoundReason`,
  mirroring the existing `UserNotFoundReason` path.
- Add `Reconcile`-level test coverage for **both** self-delete paths -
  neither had any test coverage before this change.

## Test plan

- [x] `go test ./internal/controllers/resourcemanager/...` - new and
  existing tests pass
- [x] `go build ./...` - builds clean
- [x] `gofmt -l` - clean

Related to a companion fix for a second, unrelated orphaned-`PolicyBinding`
class (project-owner bindings surviving their creating `User`'s deletion) -
coming as a separate PR since the two bugs share no files.