### PR TITLE
fix: garbage collect project-owner PolicyBinding on creator deletion

### DIFF
--- a/cmd/milo/controller-manager/controllermanager.go
+++ b/cmd/milo/controller-manager/controllermanager.go
@@ -526,6 +526,14 @@ func Run(ctx context.Context, c *config.CompletedConfig, opts *Options) error {
 				klog.FlushAndExit(klog.ExitFlushTimeout, 1)
 			}
 
+			subjectBindingReaperCtrl := resourcemanagercontroller.SubjectBindingReaperController{
+				Client: ctrl.GetClient(),
+			}
+			if err := subjectBindingReaperCtrl.SetupWithManager(ctrl); err != nil {
+				logger.Error(err, "Error setting up subject binding reaper controller")
+				klog.FlushAndExit(klog.ExitFlushTimeout, 1)
+			}
+
 			groupCtrl := iamcontroller.GroupController{
 				Client: ctrl.GetClient(),
 			}

--- a/internal/controllers/resourcemanager/subject_binding_reaper_controller.go
+++ b/internal/controllers/resourcemanager/subject_binding_reaper_controller.go
@@ -1,0 +1,68 @@
+package resourcemanager
+
+import (
+	"context"
+	"fmt"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	iamv1alpha1 "go.miloapis.com/milo/pkg/apis/iam/v1alpha1"
+	resourcemanagerv1alpha "go.miloapis.com/milo/pkg/apis/resourcemanager/v1alpha1"
+)
+
+// SubjectBindingReaperController deletes PolicyBindings whose sole subject
+// was a User that no longer exists. It exists to clean up the PolicyBinding
+// that ProjectValidator's mutating webhook creates for a project's creator
+// (see internal/webhooks/resourcemanager/v1alpha1/project_webhook.go): that
+// binding is owned by the Project, not the User, so nothing previously
+// reacted when the creating User was later deleted while the Project lived
+// on, leaving the binding permanently stuck reporting SubjectValidationFailed.
+type SubjectBindingReaperController struct {
+	Client client.Client
+}
+
+// +kubebuilder:rbac:groups=iam.miloapis.com,resources=users,verbs=get;list;watch
+// +kubebuilder:rbac:groups=iam.miloapis.com,resources=policybindings,verbs=get;list;watch;delete
+
+func (r *SubjectBindingReaperController) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	logger := log.FromContext(ctx)
+
+	var user iamv1alpha1.User
+	if err := r.Client.Get(ctx, client.ObjectKey{Name: req.Name}, &user); err == nil {
+		// User still exists — nothing to reap.
+		return ctrl.Result{}, nil
+	} else if !apierrors.IsNotFound(err) {
+		return ctrl.Result{}, fmt.Errorf("failed to get user: %w", err)
+	}
+
+	var bindings iamv1alpha1.PolicyBindingList
+	if err := r.Client.List(ctx, &bindings, client.MatchingLabels{
+		resourcemanagerv1alpha.SubjectUserNameLabel: req.Name,
+	}); err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to list policy bindings for deleted user: %w", err)
+	}
+
+	for i := range bindings.Items {
+		binding := &bindings.Items[i]
+		logger.Info("deleting policy binding for deleted user subject",
+			"policyBinding", binding.Name,
+			"namespace", binding.Namespace,
+			"user", req.Name)
+		if err := r.Client.Delete(ctx, binding); err != nil && !apierrors.IsNotFound(err) {
+			return ctrl.Result{}, fmt.Errorf("failed to delete orphaned policy binding %s/%s: %w", binding.Namespace, binding.Name, err)
+		}
+	}
+
+	return ctrl.Result{}, nil
+}
+
+// SetupWithManager sets up the controller with the Manager.
+func (r *SubjectBindingReaperController) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&iamv1alpha1.User{}).
+		Named("subject-binding-reaper").
+		Complete(r)
+}

--- a/internal/controllers/resourcemanager/subject_binding_reaper_controller_test.go
+++ b/internal/controllers/resourcemanager/subject_binding_reaper_controller_test.go
@@ -1,0 +1,125 @@
+package resourcemanager
+
+import (
+	"context"
+	"testing"
+
+	iamv1alpha1 "go.miloapis.com/milo/pkg/apis/iam/v1alpha1"
+	resourcemanagerv1alpha1 "go.miloapis.com/milo/pkg/apis/resourcemanager/v1alpha1"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func newSubjectBinding(name, userName, userUID string) *iamv1alpha1.PolicyBinding {
+	return &iamv1alpha1.PolicyBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: "organization-test-org",
+			Labels: map[string]string{
+				resourcemanagerv1alpha1.SubjectUserNameLabel: userName,
+			},
+		},
+		Spec: iamv1alpha1.PolicyBindingSpec{
+			RoleRef: iamv1alpha1.RoleReference{
+				Name: "owner",
+			},
+			Subjects: []iamv1alpha1.Subject{
+				{Kind: "User", Name: userName, UID: userUID},
+			},
+			ResourceSelector: iamv1alpha1.ResourceSelector{
+				ResourceRef: &iamv1alpha1.ResourceReference{
+					APIGroup: "resourcemanager.miloapis.com",
+					Kind:     "Project",
+					Name:     "some-project",
+					UID:      "project-uid",
+				},
+			},
+		},
+	}
+}
+
+// TestSubjectBindingReaperController_Reconcile_UserDeleted_ReapsOnlyItsBindings verifies that
+// when a User no longer exists, bindings labeled for that user are deleted, while a binding
+// labeled for a different, still-existing user is left alone.
+func TestSubjectBindingReaperController_Reconcile_UserDeleted_ReapsOnlyItsBindings(t *testing.T) {
+	ctx := context.TODO()
+	scheme := getTestScheme()
+
+	// alice has no User object, simulating deletion.
+	aliceBinding := newSubjectBinding("project-foo-owner-abc", "alice", "alice-uid")
+
+	bob := &iamv1alpha1.User{
+		ObjectMeta: metav1.ObjectMeta{Name: "bob", UID: types.UID("bob-uid")},
+		Spec:       iamv1alpha1.UserSpec{Email: "bob@example.com"},
+	}
+	bobBinding := newSubjectBinding("project-bar-owner-def", "bob", "bob-uid")
+
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(bob, aliceBinding, bobBinding).
+		Build()
+
+	controller := &SubjectBindingReaperController{Client: c}
+
+	// Simulate the reconcile triggered by alice's deletion.
+	req := ctrl.Request{NamespacedName: types.NamespacedName{Name: "alice"}}
+	if _, err := controller.Reconcile(ctx, req); err != nil {
+		t.Fatalf("reconcile failed: %v", err)
+	}
+
+	if err := c.Get(ctx, types.NamespacedName{Name: aliceBinding.Name, Namespace: aliceBinding.Namespace}, &iamv1alpha1.PolicyBinding{}); !apierrors.IsNotFound(err) {
+		t.Fatalf("expected alice's binding to be deleted, got err=%v", err)
+	}
+
+	if err := c.Get(ctx, types.NamespacedName{Name: bobBinding.Name, Namespace: bobBinding.Namespace}, &iamv1alpha1.PolicyBinding{}); err != nil {
+		t.Fatalf("expected bob's binding to be untouched (bob still exists), got err=%v", err)
+	}
+}
+
+// TestSubjectBindingReaperController_Reconcile_UserStillExists_LeavesBindingAlone verifies
+// that a reconcile for a User that still exists does not touch any bindings labeled for them.
+func TestSubjectBindingReaperController_Reconcile_UserStillExists_LeavesBindingAlone(t *testing.T) {
+	ctx := context.TODO()
+	scheme := getTestScheme()
+
+	alice := &iamv1alpha1.User{
+		ObjectMeta: metav1.ObjectMeta{Name: "alice", UID: types.UID("alice-uid")},
+		Spec:       iamv1alpha1.UserSpec{Email: "alice@example.com"},
+	}
+	aliceBinding := newSubjectBinding("project-foo-owner-abc", "alice", "alice-uid")
+
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(alice, aliceBinding).
+		Build()
+
+	controller := &SubjectBindingReaperController{Client: c}
+
+	req := ctrl.Request{NamespacedName: types.NamespacedName{Name: "alice"}}
+	if _, err := controller.Reconcile(ctx, req); err != nil {
+		t.Fatalf("reconcile failed: %v", err)
+	}
+
+	if err := c.Get(ctx, types.NamespacedName{Name: aliceBinding.Name, Namespace: aliceBinding.Namespace}, &iamv1alpha1.PolicyBinding{}); err != nil {
+		t.Fatalf("expected alice's binding to still exist while alice exists, got err=%v", err)
+	}
+}
+
+// TestSubjectBindingReaperController_Reconcile_NoBindingsLabeled_NoOp verifies a reconcile
+// for a deleted user with no labeled bindings at all is a no-op, not an error.
+func TestSubjectBindingReaperController_Reconcile_NoBindingsLabeled_NoOp(t *testing.T) {
+	ctx := context.TODO()
+	scheme := getTestScheme()
+
+	c := fake.NewClientBuilder().WithScheme(scheme).Build()
+	controller := &SubjectBindingReaperController{Client: c}
+
+	req := ctrl.Request{NamespacedName: types.NamespacedName{Name: "nobody"}}
+	if _, err := controller.Reconcile(ctx, req); err != nil {
+		t.Fatalf("expected no-op reconcile to succeed, got err=%v", err)
+	}
+}

--- a/internal/webhooks/resourcemanager/v1alpha1/project_webhook.go
+++ b/internal/webhooks/resourcemanager/v1alpha1/project_webhook.go
@@ -229,6 +229,12 @@ func (v *ProjectValidator) createOwnerPolicyBinding(ctx context.Context, project
 			// TODO: Will need to re-consider this when the folder type can be
 			//       introduced as a parent. Maybe we have an Owner field in the spec?
 			Namespace: fmt.Sprintf("organization-%s", project.Spec.OwnerRef.Name),
+			Labels: map[string]string{
+				// Lets the subject-binding reaper controller find this binding
+				// when foundUser is deleted; the OwnerReference below only
+				// covers cleanup when the Project itself is deleted.
+				v1alpha1.SubjectUserNameLabel: foundUser.Name,
+			},
 			OwnerReferences: []metav1.OwnerReference{
 				{
 					APIVersion: v1alpha1.GroupVersion.String(),

--- a/pkg/apis/resourcemanager/v1alpha1/labels.go
+++ b/pkg/apis/resourcemanager/v1alpha1/labels.go
@@ -7,4 +7,9 @@ const (
 	ProjectNameLabel      = LabelNamespace + "/project-name"
 	ProjectUIDLabel       = LabelNamespace + "/project-uid"
 	OwnerNameLabel        = LabelNamespace + "/owner-name"
+
+	// SubjectUserNameLabel records the name of the User subject a PolicyBinding
+	// was created for. It lets a controller find and reap PolicyBindings whose
+	// sole subject no longer exists once the referenced User is deleted.
+	SubjectUserNameLabel = LabelNamespace + "/subject-user-name"
 )


### PR DESCRIPTION
## Summary

The project-owner `PolicyBinding` created by `ProjectValidator`'s
admission webhook
(`internal/webhooks/resourcemanager/v1alpha1/project_webhook.go`) is
owned by the `Project`, not by the creating `User`. The webhook only runs
once, at `Project` creation - it has no ongoing relationship to what it
created. So if the creating `User` is later deleted while the `Project`
lives on, nothing ever reacts: the binding stays stuck reporting
`SubjectValidationFailed` indefinitely, because Kubernetes only garbage
collects a dependent once *none* of its owners exist, and the Project is
still there.

Fix in two parts, since there was no existing mechanism to hook into:

- Label the binding with the subject's username at creation time
  (`resourcemanager.miloapis.com/subject-user-name`), making it findable
  by subject.
- Add `SubjectBindingReaperController`, which watches `User` deletes and
  reaps any `PolicyBinding` labeled for that now-gone user.

Discovered investigating the staging `PolicyBindingsNotReady` alert,
alongside an unrelated `OrganizationMembership` self-delete gap (#712) -
separate PR since the two bugs share no files.

## Test plan

- [x] New `subject_binding_reaper_controller_test.go`: user deleted reaps
  only its own labeled bindings, still-existing user leaves bindings
  untouched, no-labeled-bindings reconcile is a no-op
- [x] `go build ./...` - builds clean
- [x] `go test ./internal/controllers/resourcemanager/... ./internal/webhooks/resourcemanager/...` - pass
- [x] `gofmt -l` - clean