### PR TITLE
chore: commit PolicyBinding/OrganizationMembership readiness alerts

### DIFF
--- a/config/telemetry/alerts/iam/kustomization.yaml
+++ b/config/telemetry/alerts/iam/kustomization.yaml
@@ -2,5 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1alpha1
 kind: Component
 
 resources:
-  - projects.yaml
-  - organization-memberships.yaml
+  - policy-bindings.yaml

--- a/config/telemetry/alerts/iam/policy-bindings.yaml
+++ b/config/telemetry/alerts/iam/policy-bindings.yaml
@@ -1,0 +1,33 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: iam.miloapis.com-alerting-rules
+  labels:
+    app.kubernetes.io/name: milo
+    app.kubernetes.io/component: iam-system
+    app.kubernetes.io/part-of: milo
+    monitoring.coreos.com/prometheus: kube-prometheus
+spec:
+  groups:
+    - name: iam.readiness
+      interval: 30s
+      rules:
+        - alert: PolicyBindingsNotReady
+          expr: iam_miloapis_com:policybindings:not_ready > 0
+          for: 2m
+          labels:
+            severity: critical
+            category: readiness
+            team: platform
+          annotations:
+            runbook_url: "https://github.com/milo-os/milo/blob/main/docs/runbooks/policy-bindings-not-ready.md"
+            summary: "{{ $value }} policy bindings are not ready"
+            description: |
+              Policy bindings are not in Ready state, breaking access control.
+
+              Not ready count: {{ $value }}
+
+              Actions needed:
+              1. Check binding status: kubectl get policybindings -o wide
+              2. Review authorization provider sync errors
+              3. Verify role and principal references are valid

--- a/config/telemetry/alerts/kustomization.yaml
+++ b/config/telemetry/alerts/kustomization.yaml
@@ -4,3 +4,4 @@ kind: Component
 components:
   - ./resources-manager
   - ./controller-manager
+  - ./iam

--- a/config/telemetry/alerts/resources-manager/organization-memberships.yaml
+++ b/config/telemetry/alerts/resources-manager/organization-memberships.yaml
@@ -1,0 +1,34 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: resourcemanager.miloapis.com-alerting-rules
+  labels:
+    app.kubernetes.io/name: milo
+    app.kubernetes.io/component: resourcemanager-system
+    app.kubernetes.io/part-of: milo
+    monitoring.coreos.com/prometheus: kube-prometheus
+spec:
+  groups:
+    - name: resourcemanager.readiness
+      interval: 30s
+      rules:
+        - alert: OrganizationMembershipsNotReady
+          expr: resourcemanager_miloapis_com:organizationmemberships:not_ready > 0
+          for: 5m
+          labels:
+            severity: warning
+            category: readiness
+            team: platform
+          annotations:
+            runbook_url: "https://github.com/milo-os/milo/blob/main/docs/runbooks/organization-memberships-not-ready.md"
+            summary: "{{ $value }} organization memberships are not ready"
+            description: |
+              Organization memberships are not in Ready state, affecting user access.
+
+              Not ready count: {{ $value }}
+              Organization namespace: {{ $labels.resource_namespace }}
+
+              Actions needed:
+              1. Check membership status: kubectl get organizationmemberships -n {{ $labels.resource_namespace }} -o wide
+              2. Review RBAC provisioning and role binding creation
+              3. Verify user references are valid

--- a/config/telemetry/recording-rules/iam/kustomization.yaml
+++ b/config/telemetry/recording-rules/iam/kustomization.yaml
@@ -2,5 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1alpha1
 kind: Component
 
 resources:
-  - projects.yaml
-  - organization-memberships.yaml
+  - recording-rules.yaml

--- a/config/telemetry/recording-rules/iam/recording-rules.yaml
+++ b/config/telemetry/recording-rules/iam/recording-rules.yaml
@@ -1,0 +1,17 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: iam.miloapis.com-recording-rules
+  labels:
+    app.kubernetes.io/name: milo
+    app.kubernetes.io/component: iam-system
+    app.kubernetes.io/part-of: milo
+    monitoring.coreos.com/prometheus: kube-prometheus
+spec:
+  groups:
+    - name: iam.readiness.1m
+      interval: 15s
+      rules:
+        - record: iam_miloapis_com:policybindings:not_ready
+          expr: |
+            count(milo_policy_bindings_status_condition{type="Ready"} == 0)

--- a/config/telemetry/recording-rules/kustomization.yaml
+++ b/config/telemetry/recording-rules/kustomization.yaml
@@ -4,3 +4,5 @@ kind: Component
 components:
   - ./quota
   - ./bootstrap
+  - ./iam
+  - ./resourcemanager

--- a/config/telemetry/recording-rules/resourcemanager/kustomization.yaml
+++ b/config/telemetry/recording-rules/resourcemanager/kustomization.yaml
@@ -2,5 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1alpha1
 kind: Component
 
 resources:
-  - projects.yaml
-  - organization-memberships.yaml
+  - recording-rules.yaml

--- a/config/telemetry/recording-rules/resourcemanager/recording-rules.yaml
+++ b/config/telemetry/recording-rules/resourcemanager/recording-rules.yaml
@@ -1,0 +1,24 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: resourcemanager.miloapis.com-recording-rules
+  labels:
+    app.kubernetes.io/name: milo
+    app.kubernetes.io/component: resourcemanager-system
+    app.kubernetes.io/part-of: milo
+    monitoring.coreos.com/prometheus: kube-prometheus
+spec:
+  groups:
+    - name: resourcemanager.readiness.1m
+      interval: 15s
+      rules:
+        # Grouped by resource_namespace (the "organization-<name>" namespace the
+        # membership lives in), which identifies the affected organization for
+        # the OrganizationMembershipsNotReady alert. Group by "organization_name"
+        # instead and every alert's Organization field renders blank -
+        # milo_organization_memberships_status_condition has no such label.
+        - record: resourcemanager_miloapis_com:organizationmemberships:not_ready
+          expr: |
+            count by (resource_namespace) (
+              milo_organization_memberships_status_condition{type="Ready"} == 0
+            )

--- a/docs/runbooks/organization-memberships-not-ready.md
+++ b/docs/runbooks/organization-memberships-not-ready.md
@@ -1,0 +1,98 @@
+# OrganizationMembershipsNotReady
+
+**Severity:** Warning · **Fires after:** 5m
+
+## What This Alert Means
+
+One or more `OrganizationMembership` resources have a `Ready` condition that
+is not `True`. The alert fires on
+`resourcemanager_miloapis_com:organizationmemberships:not_ready`, grouped by
+`resource_namespace` (the `organization-<name>` namespace the membership
+lives in), so the affected organization is directly visible in the alert's
+`Organization namespace` field.
+
+## Impact
+
+A membership stuck not-Ready means the role bindings it manages for that
+user (see `reconcileRoles` in
+`internal/controllers/resourcemanager/organization_membership_controller.go`)
+are not being kept in sync — new roles won't be applied and stale ones
+won't be removed. In practice, the dominant cause (see below) is a
+membership left behind after its Organization was deleted, which affects no
+one currently using the platform. Cross-check impact the same way as
+[policy-bindings-not-ready.md](policy-bindings-not-ready.md#impact) — this
+alert and that one usually fire together from the same root cause.
+
+## Investigation
+
+### 1. Find the affected membership(s)
+
+The alert's `Organization namespace` label names the namespace directly:
+
+```sh
+kubectl get organizationmemberships -n <organization-namespace-from-alert> -o wide
+```
+
+Or across all namespaces:
+
+```sh
+kubectl get organizationmemberships -A -o json | jq -r '
+  .items[]
+  | select(([.status.conditions[]? | select(.type=="Ready" and .status!="True")] | length) > 0)
+  | [.metadata.namespace, .metadata.name, (.status.conditions[] | select(.type=="Ready") | .reason)]
+  | @tsv'
+```
+
+### 2. Check the reason
+
+| Reason | Meaning |
+|---|---|
+| `OrganizationNotFound` | The referenced Organization was deleted. Self-deletes automatically — see Common Causes. |
+| `UserNotFound` | The referenced User was deleted. Self-deletes automatically (pre-existing behavior). |
+| `ReconcileError` | Transient API error reaching the Organization or User. Check controller logs. |
+
+### 3. If it's not resolving on its own
+
+`OrganizationNotFoundReason` and `UserNotFoundReason` both use a two-pass
+self-delete: the controller sets the reason on the first reconcile, then
+deletes the membership on the *next* reconcile that observes the same
+reason still set. If a membership has been sitting on one of these reasons
+for more than a couple of minutes, the controller isn't getting re-enqueued
+or isn't running — check `milo-controller-manager` health:
+
+```sh
+kubectl get pods -l app.kubernetes.io/name=milo-controller-manager
+kubectl logs -n <namespace> deploy/milo-controller-manager --tail=200 | grep -i organizationmembership
+```
+
+## Common Causes
+
+- **Organization deleted while a membership still referenced it.**
+  Previously, `OrganizationMembershipController` only self-deleted a
+  membership when its *User* went away (`UserNotFoundReason`) — there was
+  no equivalent for `OrganizationNotFoundReason`, so memberships (and the
+  PolicyBindings they own) were orphaned forever once their Organization
+  was deleted. The controller now applies the same two-pass self-delete to
+  `OrganizationNotFoundReason`. This is almost always the reason you'll see
+  this alert alongside `PolicyBindingsNotReady`.
+- **User deleted.** Pre-existing, working self-delete behavior —
+  investigate only if it isn't clearing within a couple of reconciles.
+
+## Resolution
+
+Resolution is automatic for both reasons above once
+`milo-controller-manager` is healthy and reconciling. If a membership has
+been stuck for longer than a few minutes on `OrganizationNotFound` or
+`UserNotFound`, restart the controller and re-check before investigating
+further:
+
+```sh
+kubectl rollout restart deploy/milo-controller-manager -n <namespace>
+```
+
+## Related
+
+- [policy-bindings-not-ready.md](policy-bindings-not-ready.md) — the
+  membership's owned PolicyBinding shows up here too until the membership
+  self-deletes.
+- [controller-manager-crash-looping.md](controller-manager-crash-looping.md)

--- a/docs/runbooks/policy-bindings-not-ready.md
+++ b/docs/runbooks/policy-bindings-not-ready.md
@@ -1,0 +1,121 @@
+# PolicyBindingsNotReady
+
+**Severity:** Critical · **Fires after:** 2m
+
+## What This Alert Means
+
+One or more `PolicyBinding` resources have a `Ready` condition that is not
+`True`. A `PolicyBinding` grants a subject (User, Group, or ServiceAccount) a
+role over some resource selector; while it is not Ready, the grant it
+describes is not in effect — the intended subject does not have the access
+the binding was meant to provide.
+
+The alert fires on `iam_miloapis_com:policybindings:not_ready`, a count of
+all `PolicyBinding` objects across the cluster with `status.conditions[type
+== Ready].status != "True"`. It does not identify *which* binding by itself
+— see Investigation below.
+
+## Impact
+
+Read the `reason` on the affected binding's `Ready` condition first (see
+Investigation) before assuming user-facing impact — in practice this alert
+is dominated by orphaned bindings left over from deleted Organizations,
+Projects, or Users (see Common Causes), which nothing is actively trying to
+use. Confirm real impact via:
+
+```promql
+sum by (allowed) (rate(openfga_check_result_count[10m]))
+increase(apiserver_authorization_decisions_total{decision="denied"}[1h])
+```
+
+If neither shows an anomaly relative to the same window a day earlier,
+treat this as accumulated readiness debt rather than an active incident,
+and prioritize accordingly.
+
+## Investigation
+
+### 1. Find the affected bindings and why
+
+```sh
+kubectl get policybindings -A -o json | jq -r '
+  .items[]
+  | select(([.status.conditions[]? | select(.type=="Ready" and .status!="True")] | length) > 0)
+  | [.metadata.namespace, .metadata.name, (.status.conditions[] | select(.type=="Ready") | .reason)]
+  | @tsv'
+```
+
+The `reason` tells you which failure mode you're in:
+
+| Reason | Meaning |
+|---|---|
+| `SubjectValidationFailed` | The bound User/Group/ServiceAccount no longer resolves (deleted, or UID mismatch). |
+| `ResourceSelectorValidationFailed` | The resource the binding selects (an Organization, Project, etc.) no longer exists. |
+| `RoleNotFoundForBinding` | `spec.roleRef` points at a Role that doesn't exist (in the given namespace). |
+
+### 2. Check whether it's a known, self-healing orphan
+
+Two orphan classes are handled automatically as of the fix for this
+runbook (see Common Causes) and should not persist:
+
+- A binding owned by an `OrganizationMembership` whose Organization was
+  deleted — the membership self-deletes (and cascades to the binding)
+  within one reconcile of being re-evaluated.
+- A binding labeled `resourcemanager.miloapis.com/subject-user-name` whose
+  User was deleted — the `subject-binding-reaper` controller deletes it on
+  the User's delete event.
+
+If a binding matches one of these shapes and is still present after a few
+minutes, the reaping controller itself may be unhealthy — check
+`milo-controller-manager` logs and restart count (see
+[controller-manager-crash-looping.md](controller-manager-crash-looping.md)).
+
+### 3. Anything else: check controller logs
+
+```sh
+kubectl logs -n <namespace> deploy/milo-controller-manager --tail=200 | grep -i policybinding
+```
+
+## Common Causes
+
+- **Organization deleted while an `OrganizationMembership` still referenced
+  it.** The membership's owned PolicyBinding has an `OwnerReference` to the
+  *membership*, not the Organization, so it was never garbage collected —
+  the membership just sat reporting `OrganizationNotFound` forever.
+  `OrganizationMembershipController` now self-deletes the membership on the
+  second reconcile that observes this (mirroring the pre-existing
+  `UserNotFound` self-delete), which cascades to the binding via its owner
+  reference.
+- **Project's creating User deleted while the Project still exists.** The
+  project-owner `PolicyBinding` created by `ProjectValidator`'s admission
+  webhook (`internal/webhooks/resourcemanager/v1alpha1/project_webhook.go`)
+  is owned by the `Project`, not the creating `User` — nothing reacted to
+  the User's deletion. The webhook now labels the binding with
+  `resourcemanager.miloapis.com/subject-user-name`, and a new
+  `SubjectBindingReaperController` watches `User` deletes and reaps any
+  binding labeled for that user.
+- **Manually-applied bindings.** A few bindings in `milo-system`
+  (`machineaccount-policy-binding`, `swells-instance-*-delete`) were
+  applied by hand rather than by a controller — nothing owns their
+  lifecycle at all. These need manual cleanup; `kubectl delete
+  policybinding` once you've confirmed the referenced principal/resource is
+  genuinely gone for good.
+- **Role renamed or removed** while bindings still reference the old name
+  (`RoleNotFoundForBinding`) — fix the `roleRef` or restore the Role.
+
+## Resolution
+
+- If the reason matches one of the two self-healing classes above and
+  hasn't cleared within a few minutes, restart `milo-controller-manager`
+  and re-check.
+- If it's a manually-applied binding with no owner, verify the referenced
+  principal/resource is really gone, then `kubectl delete policybinding
+  <name> -n <namespace>`.
+- If it's `RoleNotFoundForBinding`, fix or restore the Role.
+
+## Related
+
+- [organization-memberships-not-ready.md](organization-memberships-not-ready.md) —
+  fires from the same root cause (Organization deleted before its
+  memberships) and usually appears alongside this alert.
+- [controller-manager-crash-looping.md](controller-manager-crash-looping.md) —
+  if the self-healing controllers themselves aren't running.


### PR DESCRIPTION
## Summary

`PolicyBindingsNotReady` and `OrganizationMembershipsNotReady` were both
firing in staging, but neither the recording rules nor the alerting rules
behind them exist anywhere in this repo - someone applied them directly
to the cluster, bypassing GitOps entirely. This reconstructs them from the
exact live config so they're actually tracked, matching the pattern of
the existing `resourcemanager-projects` PrometheusRule
(`config/telemetry/alerts/resources-manager/projects.yaml`).

Also fixes a bug found in the process: the `OrganizationMembershipsNotReady`
recording rule grouped by an `organization_name` label that does not
exist on `milo_organization_memberships_status_condition` - every alert's
`Organization` field rendered blank as a result. It now groups by
`resource_namespace` (the `organization-<name>` namespace the membership
lives in), which does exist, so the alert names the affected organization
directly.

Adds the runbooks the alerts' `runbook_url` annotations point at:
- `docs/runbooks/policy-bindings-not-ready.md`
- `docs/runbooks/organization-memberships-not-ready.md`

These reference #712 and #713 as the resolution path for the two known
orphan classes that make up most of what these alerts currently catch.

## Test plan

- [x] `kustomize build` against a synthetic parent Kustomization - all
  four `PrometheusRule`s render with the expected content, matching what's
  currently live in staging
- [x] `go build ./...` - builds clean (no Go changes, just checking
  nothing else broke)