### PR TITLE
fix: Correct bootstrap latency PromQL joins

### DIFF
--- a/config/telemetry/recording-rules/bootstrap/recording-rules.yaml
+++ b/config/telemetry/recording-rules/bootstrap/recording-rules.yaml
@@ -12,6 +12,10 @@ spec:
     - name: bootstrap.latency.1m
       interval: 1m
       rules:
+        # Per-resource latency = last_transition_time - created_timestamp.
+        # Always subtract matching series (on / group_left), never sum()
+        # unix timestamps across resources — that produces N*epoch-scale
+        # values that clamp to the 86400s ceiling and show as "1 day".
         - record: miloapis.com:bootstrap:user_ready_latency_seconds
           expr: |
             clamp_min(
@@ -27,8 +31,10 @@ spec:
           expr: |
             clamp_min(
               clamp_max(
-                sum by (resource_name) (milo_organizations_status_condition_last_transition_time{type="OnboardingComplete",reason="Ready"})
-                - sum by (resource_name) (milo_organizations_created_timestamp),
+                max by (resource_name) (
+                  milo_organizations_status_condition_last_transition_time{type="OnboardingComplete",reason="Ready"}
+                )
+                - on(resource_name) max by (resource_name) (milo_organizations_created_timestamp),
                 86400
               ),
               0
@@ -38,10 +44,11 @@ spec:
           expr: |
             clamp_min(
               clamp_max(
-                sum by (resource_namespace) (
+                max by (resource_namespace, resource_name) (
                   milo_policy_bindings_status_condition_last_transition_time{resource_namespace=~"organization-.*",resource_name=~"member-.*",role_name="owner",type="Ready"}
                 )
-                - sum by (resource_namespace) (
+                - on(resource_namespace, resource_name) group_left()
+                max by (resource_namespace, resource_name) (
                   milo_policy_bindings_created_timestamp{resource_namespace=~"organization-.*",resource_name=~"member-.*",role_name="owner"}
                 ),
                 86400
@@ -53,8 +60,8 @@ spec:
           expr: |
             clamp_min(
               clamp_max(
-                sum by (resource_name) (milo_projects_status_condition_last_transition_time{type="Ready"})
-                - sum by (resource_name) (milo_projects_created_timestamp),
+                max by (resource_name) (milo_projects_status_condition_last_transition_time{type="Ready"})
+                - on(resource_name) max by (resource_name) (milo_projects_created_timestamp),
                 86400
               ),
               0
@@ -64,10 +71,11 @@ spec:
           expr: |
             clamp_min(
               clamp_max(
-                sum by (resource_namespace) (
+                max by (resource_namespace, resource_name) (
                   milo_policy_bindings_status_condition_last_transition_time{resource_namespace=~"organization-.*",resource_name=~"project-.*",role_name="owner",type="Ready"}
                 )
-                - sum by (resource_namespace) (
+                - on(resource_namespace, resource_name) group_left()
+                max by (resource_namespace, resource_name) (
                   milo_policy_bindings_created_timestamp{resource_namespace=~"organization-.*",resource_name=~"project-.*",role_name="owner"}
                 ),
                 86400
@@ -79,12 +87,12 @@ spec:
           expr: |
             clamp_min(
               clamp_max(
-                sum by (resource_namespace) (
+                max by (resource_namespace, resource_name) (
                   milo_policy_bindings_status_condition_last_transition_time{resource_namespace=~"organization-.*",resource_name=~"project-.*",role_name="owner",type="Ready"}
                 )
                 - on(resource_namespace) group_left()
                 label_replace(
-                  sum by (resource_name) (milo_organizations_created_timestamp),
+                  max by (resource_name) (milo_organizations_created_timestamp),
                   "resource_namespace", "organization-$1", "resource_name", "(.+)"
                 ),
                 86400


### PR DESCRIPTION
## Summary

The Organization Onboarding + OpenFGA dashboard was reporting flat "1 day" P50/P95/P99 for project binding and org → project binding stages. That was not real bootstrap latency.

The recording rules subtracted aggregates built with `sum()` over unix timestamps. For an org with N `project-*` owner PolicyBindings, `sum(last_transition_time) - org_created` is roughly `(N-1) * epoch`, which always hits the 86400s clamp and Grafana formats as "1 day".

This updates the rules to compute latency per resource: match created vs ready timestamps with `on` / `group_left`, collapse with `max by` on the identifying labels, then leave the existing quantile rules alone.

Note: Org create → Onboarding Ready can still land near the 1 day ceiling when many Ready orgs took a long time in the human billing funnel. That path is a different signal from system IAM provisioning; this PR fixes the broken binding math.

## Test plan

- [ ] Review PromQL for each stage (user, org onboarding, member binding, project ready, project binding, org → project binding)
- [ ] After Flux reconciles the VMRule, confirm staging dashboard binding panels are no longer stuck at exactly 1 day
- [ ] Confirm Project → Ready still looks like minutes/hours, not days
- [ ] Spot-check that orgs with multiple projects no longer dominate org → project binding percentiles

## Notes for reviewers

The interesting change is `org_to_project_owner_binding_latency_seconds` and the two PolicyBinding ready rules. Single-resource rules (user/org/project) only switch `sum` → `max` + explicit `on()` for consistency.