### PR TITLE
fix(test): allow non-operator users to delete project suspensions in validation tests

### DIFF
--- a/internal/webhooks/resourcemanager/v1alpha1/projectsuspension_webhook_test.go
+++ b/internal/webhooks/resourcemanager/v1alpha1/projectsuspension_webhook_test.go
@@ -181,8 +181,7 @@ func TestProjectSuspensionValidator_ValidateDelete(t *testing.T) {
 	}
 	ctxConsumer := admission.NewContextWithRequest(context.Background(), reqConsumer)
 	_, err := validator.ValidateDelete(ctxConsumer, ps)
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "only operators can lift/delete this suspension")
+	assert.NoError(t, err)
 
 	// Case 2: Operator deletes and project is present
 	reqOperator := admission.Request{


### PR DESCRIPTION
The logic of the delete admission webhook for ProjectSuspensions was updated, but the unit tests didn't receive a updated for the new logic.

This PR fix the unit tests logic.

Related to:
- https://github.com/milo-os/milo/pull/722#discussion_r3589569519