### PR TITLE
fix(multicluster): engage project clusters on every replica, not just the leader

### DIFF
--- a/cmd/milo/controller-manager/controllermanager.go
+++ b/cmd/milo/controller-manager/controllermanager.go
@@ -667,7 +667,12 @@ func Run(ctx context.Context, c *config.CompletedConfig, opts *Options) error {
 				klog.FlushAndExit(klog.ExitFlushTimeout, 1)
 			}
 
-			mcMgr, err := mcmanager.New(ctrlConfig, provider, mcmanager.Options{
+			// provider is passed through WithoutAutoStart/EngageAlways instead of
+			// directly to mcmanager.New so cluster engagement runs on every
+			// controller-manager replica, not only the elected leader -- see the
+			// TODO in pkg/multicluster-runtime/milo/nonleader.go
+			// (datum-cloud/compute#117).
+			mcMgr, err := mcmanager.New(ctrlConfig, miloprovider.WithoutAutoStart(provider), mcmanager.Options{
 				Scheme: Scheme,
 				Logger: logger.WithName("multicluster"),
 				Metrics: metricsserver.Options{
@@ -676,6 +681,11 @@ func Run(ctx context.Context, c *config.CompletedConfig, opts *Options) error {
 			})
 			if err != nil {
 				logger.Error(err, "Error creating multicluster manager")
+				klog.FlushAndExit(klog.ExitFlushTimeout, 1)
+			}
+
+			if err := miloprovider.EngageAlways(mcMgr, provider); err != nil {
+				logger.Error(err, "Error wiring multicluster quota provider engagement")
 				klog.FlushAndExit(klog.ExitFlushTimeout, 1)
 			}
 

--- a/pkg/multicluster-runtime/milo/nonleader.go
+++ b/pkg/multicluster-runtime/milo/nonleader.go
@@ -1,0 +1,71 @@
+package milo
+
+import (
+	"context"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/cluster"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	mcmanager "sigs.k8s.io/multicluster-runtime/pkg/manager"
+	"sigs.k8s.io/multicluster-runtime/pkg/multicluster"
+)
+
+// TODO(datum-cloud/compute#117): this file works around a bug in
+// sigs.k8s.io/multicluster-runtime, not something specific to this provider.
+// mcManager.Start auto-adds a ProviderRunnable's Start method as a plain
+// manager.RunnableFunc, which does not implement NeedLeaderElection.
+// controller-runtime's runnable-group router silently routes any Runnable
+// that isn't a LeaderElectionRunnable into the leader-election group "for
+// backwards compatibility" (pkg/manager/runnable_group.go). That leader-gates
+// cluster engagement: on every replica but the elected leader, Start never
+// runs, so Provider.mcAware stays nil forever and Reconcile requeues without
+// ever engaging a cluster. Any consumer running this provider with more than
+// one replica -- including our own controller-manager's quota system, see
+// cmd/milo/controller-manager/controllermanager.go -- silently only serves
+// multicluster requests correctly from the leader pod.
+//
+// The right fix is upstream in sigs.k8s.io/multicluster-runtime: the runnable
+// mcManager.Start adds for a ProviderRunnable should be forced non-leader-gated
+// the same way WithoutAutoStart/EngageAlways do here, since cluster engagement
+// is local per-pod cache/watch bookkeeping (like the manager's own informer
+// cache, which controller-runtime never leader-gates), not reconciliation that
+// needs deduplicating across replicas. Once that lands and is vendored here,
+// delete this file, drop the two call sites, and pass the provider directly to
+// mcmanager.New again.
+
+// WithoutAutoStart returns p as a multicluster.Provider that does not also
+// satisfy multicluster.ProviderRunnable, so mcmanager.New/mcManager.Start will
+// not auto-wire (and therefore not silently leader-gate) p.Start. Pass the
+// result to mcmanager.New in place of p, and call EngageAlways once mgr is
+// constructed to wire p.Start back in without the leader-gating.
+func WithoutAutoStart(p *Provider) multicluster.Provider {
+	return struct{ providerOnly }{p}
+}
+
+// providerOnly is multicluster.Provider without the Start method that
+// ProviderRunnable adds.
+type providerOnly interface {
+	Get(ctx context.Context, clusterName multicluster.ClusterName) (cluster.Cluster, error)
+	IndexField(ctx context.Context, obj client.Object, field string, extractValue client.IndexerFunc) error
+}
+
+// EngageAlways registers p's Start method with mgr's local manager, forced
+// into controller-runtime's always-running runnable group so cluster
+// discovery and engagement happen on every replica regardless of leader
+// election. Call once, after constructing mgr with WithoutAutoStart(p), and
+// before mgr.Start.
+func EngageAlways(mgr mcmanager.Manager, p *Provider) error {
+	return mgr.GetLocalManager().Add(nonLeaderGatedRunnable{
+		Runnable: manager.RunnableFunc(func(ctx context.Context) error {
+			return p.Start(ctx, mgr)
+		}),
+	})
+}
+
+// nonLeaderGatedRunnable forces a manager.Runnable into controller-runtime's
+// always-running runnable group, regardless of leader-election state.
+type nonLeaderGatedRunnable struct {
+	manager.Runnable
+}
+
+func (nonLeaderGatedRunnable) NeedLeaderElection() bool { return false }


### PR DESCRIPTION
## Why

In a real multi-replica deployment, whichever pod isn't currently elected leader silently fails every cross-cluster lookup for a project — permanently, not just during a brief startup window. For compute's admission webhook, that means requests routed to a non-leader pod get denied outright with "project not found" (tracked in datum-cloud/compute#117, where the corresponding fix is landing on the compute side).

Our own quota system relies on the same cross-cluster lookup mechanism internally, so it has the identical exposure. It isn't causing problems today only because that component currently runs a single replica in production — this closes the gap before it ever needs to scale out.

## What changes

Cluster lookups now stay correct on every replica, not just the leader. A pod no longer needs to be the leader to know about and connect to a project's cluster, which is what admission and quota checks depend on to work correctly in an HA deployment.

This is a targeted workaround rather than a root-cause fix — the underlying gap is in a shared upstream library, and a comment in the code flags exactly what needs to change there so this workaround can be removed once that's fixed properly.

Cross-reference: datum-cloud/compute#117