### PR TITLE
fix: Install infrastructure-group CRDs in the test-infra overlay

### DIFF
--- a/config/overlays/test-infra/kustomization.yaml
+++ b/config/overlays/test-infra/kustomization.yaml
@@ -14,6 +14,14 @@ resources:
   - ../../apiserver
   - ../../controller-manager/overlays/core-control-plane
 
+  # Infrastructure-group CRDs. milo-controller-manager runs with
+  # --control-plane-scope=core (see controller-manager/overlays/core-control-plane)
+  # and reconciles ProjectControlPlane, so its CRD must be installed or the
+  # controller loops on "no matches for kind ProjectControlPlane". Consumers of
+  # this overlay (resource-metrics, dns-operator) previously had to install it
+  # separately; include it here so the overlay stands up a working core CP.
+  - ../../crd/bases/infrastructure
+
   # Deploy argo-events (controller runs on infrastructure cluster)
   - ../../dependencies/argo-system
 


### PR DESCRIPTION
## Summary

`config/overlays/test-infra` deploys `milo-controller-manager` with `--control-plane-scope=core` (via `controller-manager/overlays/core-control-plane`), which reconciles `ProjectControlPlane` — but the overlay never installed the infrastructure-group CRD. So the controller loops on:

```
no matches for kind "ProjectControlPlane" in version "infrastructure.miloapis.com/v1alpha1"
```

and the core control plane never becomes usable until someone installs the CRD separately.

Both consumers that bring milo up from this overlay — [milo-os/resource-metrics](https://github.com/milo-os/resource-metrics) and [datum-cloud/dns-operator](https://github.com/datum-cloud/dns-operator) — currently carry an identical `milo-infra-crds` Flux `Kustomization` (on `path: crd/bases/infrastructure`) purely to work around this. Their config even comments "remove once milo's test-infra overlay includes infrastructure-group CRDs."

This adds `../../crd/bases/infrastructure` to the overlay's `resources` so it stands up a working core CP out of the box, and those downstream workarounds can be dropped.

## Test plan

- [x] `kustomize build --load-restrictor LoadRestrictionsNone config/overlays/test-infra` succeeds and now renders `CustomResourceDefinition/projectcontrolplanes.infrastructure.miloapis.com` (was absent).
- [ ] A cold `test-infra` bring-up reaches a Ready core control plane without a separate infra-CRD step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)