### PR TITLE
fix(iam): grant users RBAC to list their own passkeys

### DIFF
--- a/config/protected-resources/identity/kustomization.yaml
+++ b/config/protected-resources/identity/kustomization.yaml
@@ -4,4 +4,5 @@ kind: Kustomization
 resources:
   - session.yaml
   - useridentity.yaml
+  - passkey.yaml
   - serviceaccountkey.yaml

--- a/config/protected-resources/identity/passkey.yaml
+++ b/config/protected-resources/identity/passkey.yaml
@@ -1,0 +1,16 @@
+apiVersion: iam.miloapis.com/v1alpha1
+kind: ProtectedResource
+metadata:
+  name: identity.miloapis.com-passkey
+spec:
+  serviceRef:
+    name: "identity.miloapis.com"
+  kind: Passkey
+  plural: passkeys
+  singular: passkey
+  permissions:
+    - list
+    - get
+  parentResources:
+    - apiGroup: iam.miloapis.com
+      kind: User

--- a/config/roles/iam-user-self-manage.yaml
+++ b/config/roles/iam-user-self-manage.yaml
@@ -20,6 +20,8 @@ spec:
   - identity.miloapis.com/sessions.delete
   - identity.miloapis.com/useridentities.list
   - identity.miloapis.com/useridentities.get
+  - identity.miloapis.com/passkeys.list
+  - identity.miloapis.com/passkeys.get
   - iam.miloapis.com/userinvitations.get
   - iam.miloapis.com/userinvitations.list
   - iam.miloapis.com/userinvitations.watch

--- a/config/roles/identity-user-session-viewer.yaml
+++ b/config/roles/identity-user-session-viewer.yaml
@@ -4,7 +4,7 @@ metadata:
   name: identity-user-session-viewer
   annotations:
     kubernetes.io/display-name: Identity User-Session Viewer
-    kubernetes.io/description: "Allows viewing user sessions and user identities."
+    kubernetes.io/description: "Allows viewing user sessions, user identities, and passkeys."
 spec:
   launchStage: Beta
   includedPermissions:
@@ -12,3 +12,5 @@ spec:
   - identity.miloapis.com/sessions.get
   - identity.miloapis.com/useridentities.list
   - identity.miloapis.com/useridentities.get
+  - identity.miloapis.com/passkeys.list
+  - identity.miloapis.com/passkeys.get


### PR DESCRIPTION
## What

The `passkeys` identity resource shipped without its authorization plumbing. Portal users get a 403 listing their own passkeys, while the sibling sessions and useridentities cards work — because those resources have RBAC and passkeys did not.

- Add the `Passkey` **ProtectedResource** (`config/protected-resources/identity/passkey.yaml`) and register it in the identity kustomization — mirrors `session.yaml`/`useridentity.yaml`. Read-only (`list`, `get`); mutations stay in auth-ui.
- Grant `identity.miloapis.com/passkeys.list` + `.get` in **`iam-user-self-manage`** — the role bound to every user via the auto-created `user-self-manage-<user>` PolicyBinding, so this is what fixes the portal 403.
- Grant the same in **`identity-user-session-viewer`** (staff cross-user viewing) to keep the two roles consistent, exactly as they both already carry sessions/useridentities.

## Testing

`kustomize build` passes for `config/protected-resources`, `config/protected-resources/identity`, and `config/roles`; the new ProtectedResource renders.

Repro before this: `GET .../users/<id>/control-plane/apis/identity.miloapis.com/v1alpha1/passkeys` → `403 Forbidden: cannot list resource "passkeys"`.
