### PR TITLE
feat: initialize dedicated multicluster manager for note webhooks in controller-manager

### DIFF
--- a/cmd/milo/controller-manager/webhooks.go
+++ b/cmd/milo/controller-manager/webhooks.go
@@ -20,6 +20,7 @@ import (
 	"k8s.io/klog/v2"
 	controllerruntime "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/cluster"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	mcmanager "sigs.k8s.io/multicluster-runtime/pkg/manager"
@@ -29,6 +30,7 @@ import (
 	notesv1alpha1webhook "go.miloapis.com/milo/internal/webhooks/notes/v1alpha1"
 	notificationv1alpha1webhook "go.miloapis.com/milo/internal/webhooks/notification/v1alpha1"
 	resourcemanagerv1alpha1webhook "go.miloapis.com/milo/internal/webhooks/resourcemanager/v1alpha1"
+	miloprovider "go.miloapis.com/milo/pkg/multicluster-runtime/milo"
 	milowebhook "go.miloapis.com/milo/pkg/webhook"
 )
 
@@ -198,9 +200,56 @@ func startCoreControlPlaneWebhooks(
 		return fmt.Errorf("building webhook manager: %w", err)
 	}
 
-	if err := registerCoreControlPlaneWebhooksWithoutNotes(webhookMgr); err != nil {
+	// Note webhooks need a multicluster manager to resolve project control
+	// plane clients (e.g. to look up a Note's subject when it lives in a
+	// project cluster). Build one here, scoped to the webhook manager, so it
+	// runs on every replica alongside the rest of the core webhooks instead
+	// of only on the leader.
+	provider, err := miloprovider.New(webhookMgr, miloprovider.Options{
+		ClusterOptions: []cluster.Option{
+			func(o *cluster.Options) {
+				o.Scheme = Scheme
+			},
+		},
+		ProjectRestConfig: ctrlConfig,
+	})
+	if err != nil {
+		return fmt.Errorf("creating multicluster provider for webhooks: %w", err)
+	}
+
+	mcMgr, err := mcmanager.New(ctrlConfig, miloprovider.WithoutAutoStart(provider), mcmanager.Options{
+		Scheme: Scheme,
+		Logger: logger.WithName("multicluster-webhooks"),
+		Metrics: metricsserver.Options{
+			BindAddress: "0",
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("creating multicluster manager for webhooks: %w", err)
+	}
+
+	if err := miloprovider.EngageAlways(mcMgr, provider); err != nil {
+		return fmt.Errorf("wiring multicluster webhook provider engagement: %w", err)
+	}
+
+	// Engage local cluster before starting to prevent race conditions with
+	// informer initialization. Local cluster ("") hosts Notes attached to
+	// resources in the core control plane itself.
+	if err := mcMgr.Engage(ctx, "", mcMgr.GetLocalManager()); err != nil {
+		return fmt.Errorf("engaging local cluster for webhooks: %w", err)
+	}
+
+	if err := registerCoreControlPlaneWebhooks(webhookMgr, mcMgr); err != nil {
 		return err
 	}
+
+	go func() {
+		logger.Info("Starting webhook multicluster manager")
+		if err := mcMgr.Start(ctx); err != nil {
+			logger.Error(err, "Webhook multicluster manager failed; shutting down controller-manager")
+			klog.FlushAndExit(klog.ExitFlushTimeout, 1)
+		}
+	}()
 
 	go func() {
 		if err := wait.PollUntilContextCancel(ctx, 2*time.Second, true, func(ctx context.Context) (bool, error) {

--- a/cmd/milo/controller-manager/webhooks.go
+++ b/cmd/milo/controller-manager/webhooks.go
@@ -212,6 +212,11 @@ func startCoreControlPlaneWebhooks(
 			},
 		},
 		ProjectRestConfig: ctrlConfig,
+		// Distinct from the quota system's provider (controllermanager.go),
+		// which also runs in this process and registers its own
+		// projectcontrolplane controller under the default name.
+		// controller-runtime's controller names are global to the process.
+		ControllerName: "webhooks-projectcontrolplane",
 	})
 	if err != nil {
 		return fmt.Errorf("creating multicluster provider for webhooks: %w", err)

--- a/pkg/multicluster-runtime/milo/provider.go
+++ b/pkg/multicluster-runtime/milo/provider.go
@@ -57,6 +57,14 @@ type Options struct {
 	// LabelSelector is an optional selector to filter projects based on labels.
 	// When provided, only projects matching this selector will be reconciled.
 	LabelSelector *metav1.LabelSelector
+
+	// ControllerName names the underlying projectcontrolplane controller.
+	// controller-runtime registers controllers by name in a process-global
+	// metrics registry, so every New call within the same process (e.g. one
+	// provider for webhooks and another for the quota system) needs a
+	// distinct name. Defaults to "projectcontrolplane" for compatibility with
+	// existing callers.
+	ControllerName string
 }
 
 // New creates a new Datum cluster Provider.
@@ -95,10 +103,15 @@ func New(localMgr manager.Manager, opts Options) (*Provider, error) {
 		forOpts = append(forOpts, builder.WithPredicates(labelPredicate))
 	}
 
+	controllerName := opts.ControllerName
+	if controllerName == "" {
+		controllerName = "projectcontrolplane"
+	}
+
 	controllerBuilder := builder.ControllerManagedBy(localMgr).
 		For(&project, forOpts...).
 		WithOptions(controller.Options{MaxConcurrentReconciles: 1}).
-		Named("projectcontrolplane")
+		Named(controllerName)
 
 	if err := controllerBuilder.Complete(p); err != nil {
 		return nil, fmt.Errorf("failed to create controller: %w", err)


### PR DESCRIPTION
# fix: register Notes webhooks on all controller-manager replicas

## Summary

Creating or editing a Note or ClusterNote in staging failed admission with: `failed calling webhook "mnote.notes.miloapis.com": failed to call webhook: the server could not find the requested resource`.

When leader election is enabled on the core control plane, `milo-controller-manager` starts its admission webhook server on every replica (before leader election) so the webhook Service stays healthy, then registers controller-only logic on whichever replica wins leadership. That split had a gap: the pre-election path registered every core webhook except Notes/ClusterNotes (they need a multicluster manager to resolve a Note's subject when it lives in a project cluster, which wasn't available yet), and the leader-only path only registered them when webhooks were *not* already running on all replicas. Combined, the two conditions meant Notes/ClusterNotes webhooks were never registered anywhere, so every request to their endpoints hit a 404.

The fix builds a dedicated multicluster manager inside `startCoreControlPlaneWebhooks`, following the same provider/`EngageAlways`/local-cluster-engage pattern the quota system already uses, and registers the full webhook set (including Notes) against it. This runs on every replica, matching the rest of the core webhooks.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./cmd/milo/controller-manager/...`
- [x] `gofmt -l` reports no formatting issues
- [x] Deploy to staging and confirm creating/editing a Note or ClusterNote no longer 404s on any replica (not just the leader)

--

Related to:
- https://datum-inc.slack.com/archives/C0AKA02CNKT/p1785423206578239