### PR TITLE
fix(admission): exempt SelfSubjectAccessReview from suspended-project enforcement

### DIFF
--- a/internal/apiserver/admission/plugin/projectsuspension/admission.go
+++ b/internal/apiserver/admission/plugin/projectsuspension/admission.go
@@ -73,11 +73,18 @@ var (
 
 // accessReviewResources lists the resources that must never be blocked by
 // this plugin, regardless of project suspension state, so authorization
-// checks never depend on suspension. Mirrors the same allow-list pattern
-// used by internal/apiserver/admission/plugin/namespace/lifecycle.
+// checks never depend on suspension. Notably includes
+// selfsubjectaccessreviews: clients (e.g. cloud-portal) create one of
+// these to decide whether to even attempt a read (a UI "can I view this?"
+// check before rendering a detail page) — denying the review itself, not
+// just a write, would make suspension look like it revoked read access
+// entirely, which it must never do (reads are always allowed; see the
+// package doc comment).
 var accessReviewResources = map[schema.GroupResource]bool{
 	{Group: "authorization.k8s.io", Resource: "subjectaccessreviews"}:      true,
 	{Group: "authorization.k8s.io", Resource: "localsubjectaccessreviews"}: true,
+	{Group: "authorization.k8s.io", Resource: "selfsubjectaccessreviews"}:  true,
+	{Group: "authorization.k8s.io", Resource: "selfsubjectrulesreviews"}:   true,
 }
 
 // suspensionState is the cached result of resolving a project's suspension

--- a/internal/apiserver/admission/plugin/projectsuspension/admission_test.go
+++ b/internal/apiserver/admission/plugin/projectsuspension/admission_test.go
@@ -365,15 +365,31 @@ func TestValidate_SystemMastersExempt(t *testing.T) {
 	}
 }
 
+// TestValidate_AccessReviewExempt covers every authorization.k8s.io review
+// resource, including selfsubjectaccessreviews — clients (e.g. cloud-portal)
+// create one of these to decide whether to even attempt a read (a "can I
+// view this?" check before rendering a detail page). Denying the review
+// itself while suspended made read access look revoked, even though reads
+// are always supposed to be allowed regardless of suspension; this is a
+// regression test for that bug.
 func TestValidate_AccessReviewExempt(t *testing.T) {
-	p, _ := newTestPlugin(t, newUnstructuredProject("proj-1", true, resourcemanagerv1alpha1.ReasonFraud))
+	for _, resource := range []string{
+		"subjectaccessreviews",
+		"localsubjectaccessreviews",
+		"selfsubjectaccessreviews",
+		"selfsubjectrulesreviews",
+	} {
+		t.Run(resource, func(t *testing.T) {
+			p, _ := newTestPlugin(t, newUnstructuredProject("proj-1", true, resourcemanagerv1alpha1.ReasonFraud))
 
-	ctx := milorequest.WithProject(context.Background(), "proj-1")
-	sarGVR := schema.GroupVersionResource{Group: "authorization.k8s.io", Version: "v1", Resource: "localsubjectaccessreviews"}
-	_, attrs := newAttrs(ctx, admission.Create, nil, sarGVR)
+			ctx := milorequest.WithProject(context.Background(), "proj-1")
+			sarGVR := schema.GroupVersionResource{Group: "authorization.k8s.io", Version: "v1", Resource: resource}
+			_, attrs := newAttrs(ctx, admission.Create, nil, sarGVR)
 
-	if err := p.Validate(ctx, attrs, nil); err != nil {
-		t.Errorf("Validate() error = %v, want nil for access review requests even when suspended", err)
+			if err := p.Validate(ctx, attrs, nil); err != nil {
+				t.Errorf("Validate() error = %v, want nil for %s even when suspended", err, resource)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
The `ProjectSuspensionEnforcement` admission plugin was denying `SelfSubjectAccessReview`/`SelfSubjectRulesReview` creation while a project was suspended, since those resources weren't in its access-review exemption list. Clients (e.g. cloud-portal) create a `SelfSubjectAccessReview` to check "am I allowed to view this?" before rendering a page, so this made reads look denied during suspension even though reads must always be allowed regardless of suspension state.

Adds `selfsubjectaccessreviews` and `selfsubjectrulesreviews` to the plugin's `accessReviewResources` exemption map, alongside the existing `subjectaccessreviews`/`localsubjectaccessreviews` entries, plus a table-driven regression test covering all four resources.

Related to:
- https://github.com/datum-cloud/enhancements/issues/800