### PR TITLE
fix: scope suspension events via impersonated parent context (#748)

### DIFF
--- a/config/controller-manager/overlays/core-control-plane/rbac/role.yaml
+++ b/config/controller-manager/overlays/core-control-plane/rbac/role.yaml
@@ -17,6 +17,12 @@ rules:
   - update
   - watch
 - apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  verbs:
+  - impersonate
+- apiGroups:
   - '*'
   resources:
   - '*'
@@ -39,6 +45,13 @@ rules:
   verbs:
   - patch
   - update
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - userextras/iam.miloapis.com/parent-name
+  - userextras/iam.miloapis.com/parent-type
+  verbs:
+  - impersonate
 - apiGroups:
   - authorization.k8s.io
   resources:
@@ -65,6 +78,12 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - events.k8s.io
+  resources:
+  - events
+  verbs:
+  - create
 - apiGroups:
   - gateway.networking.k8s.io
   resources:

--- a/config/crd/bases/resourcemanager/resourcemanager.miloapis.com_projects.yaml
+++ b/config/crd/bases/resourcemanager/resourcemanager.miloapis.com_projects.yaml
@@ -136,11 +136,19 @@ spec:
                   type: object
                 type: array
               suspensions:
-                description: Suspensions lists the active/all suspensions currently
-                  affecting the project.
+                description: |-
+                  Suspensions lists the active suspensions currently affecting the
+                  project. See ProjectSuspensionInfo for the active-only contract.
                 items:
-                  description: ProjectSuspensionInfo contains the details of a suspension
-                    affecting the project.
+                  description: |-
+                    ProjectSuspensionInfo contains the details of a suspension affecting the
+                    project.
+
+                    Contract: only ProjectSuspensions in an active phase (status.phase ==
+                    "Active", or unset/not-yet-reconciled) are represented here. A
+                    ProjectSuspension that has moved past Active (e.g. "Lifted") is excluded.
+                    Consumers must not assume every entry in status.suspensions still applies
+                    enforcement/visibility beyond that active-only guarantee.
                   properties:
                     reason:
                       description: Reason is the category of suspension.

--- a/config/services/activity/policies/resourcemanager/project-policy.yaml
+++ b/config/services/activity/policies/resourcemanager/project-policy.yaml
@@ -10,6 +10,15 @@
 # - Use the project name as display text
 # - Action-oriented language ("created project", "deleted project", "was suspended")
 # - Exclude system actors to reduce reconciliation noise
+#
+# eventRules for Suspended/Reinstated use event.regarding.name and
+# event.note (the events.k8s.io/v1 CEL contract exposes the Kubernetes
+# Event's involved object as `regarding`, not `involvedObject`, and its
+# message as `note`, not `message` — see datum-cloud/activity
+# internal/cel/environment.go). The controller crafts that note to be
+# consumer-safe: it names the suspension reason CATEGORY (e.g. "Abuse") but
+# never the ProjectSuspension resource name, requestedBy, or description,
+# which are internal admin detail.
 apiVersion: activity.miloapis.com/v1alpha1
 kind: ActivityPolicy
 metadata:
@@ -38,8 +47,8 @@ spec:
   eventRules:
     - name: suspended
       match: "event.reason == 'Suspended'"
-      summary: "Project {{ event.involvedObject.name }} was suspended"
+      summary: "Project {{ event.regarding.name }} was suspended (category: {{ event.note }})"
 
     - name: reinstated
       match: "event.reason == 'Reinstated'"
-      summary: "Project {{ event.involvedObject.name }} was reinstated"
+      summary: "Project {{ event.regarding.name }} was reinstated"

--- a/docs/api/resourcemanager.md
+++ b/docs/api/resourcemanager.md
@@ -1152,7 +1152,8 @@ Known condition types are: "Ready"<br/>
         <td><b><a href="#projectstatussuspensionsindex">suspensions</a></b></td>
         <td>[]object</td>
         <td>
-          Suspensions lists the active/all suspensions currently affecting the project.<br/>
+          Suspensions lists the active suspensions currently affecting the
+project. See ProjectSuspensionInfo for the active-only contract.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -1241,7 +1242,14 @@ with respect to the current state of the instance.<br/>
 
 
 
-ProjectSuspensionInfo contains the details of a suspension affecting the project.
+ProjectSuspensionInfo contains the details of a suspension affecting the
+project.
+
+Contract: only ProjectSuspensions in an active phase (status.phase ==
+"Active", or unset/not-yet-reconciled) are represented here. A
+ProjectSuspension that has moved past Active (e.g. "Lifted") is excluded.
+Consumers must not assume every entry in status.suspensions still applies
+enforcement/visibility beyond that active-only guarantee.
 
 <table>
     <thead>

--- a/docs/enhancements/events/activity-events-proxy.md
+++ b/docs/enhancements/events/activity-events-proxy.md
@@ -93,6 +93,8 @@ The proxy extracts scope from user.Extra fields:
 - `iam.miloapis.com/parent-type` → `platform.miloapis.com/scope.type` (annotation)
 - `iam.miloapis.com/parent-name` → `platform.miloapis.com/scope.name` (annotation)
 
+**Controller-authored events**: In-cluster controllers carry no `parent-type`/`parent-name` extras of their own, so events they create through a plain client are stored with no scope annotations and are visible only at the platform level. Scope is never inferred from the event body to compensate — event fields are client-supplied and untrusted for a tenant-isolation decision. A controller whose events must reach a tenant's feed impersonates that parent context instead (see `ProjectEventEmitter`).
+
 Activity filters events based on these scope annotations:
 
 | User Scope | Visibility |
@@ -101,7 +103,7 @@ Activity filters events based on these scope annotations:
 | Organization | Events with matching scope.type=Organization and scope.name |
 | Project | Events with matching scope.type=Project and scope.name |
 
-Users cannot modify scope annotations. The proxy re-injects scope on every Create and Update operation to prevent tampering.
+Users cannot modify scope annotations: the request's own parent-type/parent-name context always takes priority over any annotations already present on the event, and the proxy re-injects scope on every Create and Update operation to prevent tampering. Nothing on the event body can influence scope.
 
 ### Retry Logic
 

--- a/internal/controllers/resourcemanager/metrics.go
+++ b/internal/controllers/resourcemanager/metrics.go
@@ -1,16 +1,10 @@
 package resourcemanager
 
 import (
-	"strings"
 	"sync"
-	"time"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/tools/record"
 	"k8s.io/component-base/metrics"
 	legacyregistry "k8s.io/component-base/metrics/legacyregistry"
-
-	resourcemanagerv1alpha "go.miloapis.com/milo/pkg/apis/resourcemanager/v1alpha1"
 )
 
 var (
@@ -35,6 +29,21 @@ var (
 		[]string{"target_state"}, // "suspended", "reinstated"
 	)
 
+	// eventEmitFailedTotal exists because event emission is best-effort: a
+	// failure is logged and the reconcile continues. Scope is now carried
+	// solely by impersonation, with no fallback, so a silent emit failure
+	// means suspension events stop reaching tenant feeds with nothing else
+	// to catch it. This counter is what makes that visible.
+	eventEmitFailedTotal = metrics.NewCounterVec(
+		&metrics.CounterOpts{
+			Subsystem:      "milo_resourcemanager",
+			Name:           "project_lifecycle_event_emit_failed_total",
+			Help:           "Total number of project lifecycle events that could not be emitted, by reason.",
+			StabilityLevel: metrics.ALPHA,
+		},
+		[]string{"reason"}, // "Suspended", "Reinstated"
+	)
+
 	pauseFailedTotal = metrics.NewCounter(
 		&metrics.CounterOpts{
 			Subsystem:      "milo_resourcemanager",
@@ -52,6 +61,7 @@ func init() {
 	legacyregistry.MustRegister(activeSuspensionsTotal)
 	legacyregistry.MustRegister(transitionDurationSeconds)
 	legacyregistry.MustRegister(pauseFailedTotal)
+	legacyregistry.MustRegister(eventEmitFailedTotal)
 }
 
 func reportActiveSuspensions(projectName string, reasons []string) {
@@ -91,20 +101,4 @@ func clearActiveSuspensions(projectName string) {
 
 func recordPauseFailure() {
 	pauseFailedTotal.Inc()
-}
-
-func recordTransition(eventRecorder record.EventRecorder, project *resourcemanagerv1alpha.Project, wasSuspended, isSuspendedNow bool, activeSuspensionNames []string, latestSuspensionTime metav1.Time) {
-	if !wasSuspended && isSuspendedNow {
-		if eventRecorder != nil {
-			eventRecorder.Eventf(project, "Normal", "Suspended", "Project %s has been suspended due to active suspensions: %s", project.Name, strings.Join(activeSuspensionNames, ", "))
-		}
-		if !latestSuspensionTime.IsZero() {
-			transitionDurationSeconds.WithLabelValues("suspended").Observe(time.Since(latestSuspensionTime.Time).Seconds())
-		}
-	} else if wasSuspended && !isSuspendedNow {
-		if eventRecorder != nil {
-			eventRecorder.Eventf(project, "Normal", "Reinstated", "Project %s has been reinstated", project.Name)
-		}
-		transitionDurationSeconds.WithLabelValues("reinstated").Observe(0)
-	}
 }

--- a/internal/controllers/resourcemanager/project_event_emitter.go
+++ b/internal/controllers/resourcemanager/project_event_emitter.go
@@ -1,0 +1,207 @@
+package resourcemanager
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	eventsv1 "k8s.io/api/events/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	iamv1alpha1 "go.miloapis.com/milo/pkg/apis/iam/v1alpha1"
+	resourcemanagerv1alpha "go.miloapis.com/milo/pkg/apis/resourcemanager/v1alpha1"
+)
+
+const (
+	// projectKind is the Project Kind. It doubles as the parent-type value
+	// denoting a Project scope, which is what the events proxy matches on.
+	// The resourcemanager API package exposes no Kind constant to reference.
+	projectKind = "Project"
+
+	// clusterScopedEventNamespace is where events regarding a cluster-scoped
+	// object are recorded. Project is cluster-scoped, so its events have no
+	// natural namespace; client-go's recorder defaults these to "default" and
+	// we keep that placement, so scope annotations rather than namespaces stay
+	// the thing activity feeds filter on.
+	//
+	// The apiserver bootstraps this namespace — cmd/milo/apiserver/server.go
+	// lists metav1.NamespaceDefault in SystemNamespaces — so it exists and is
+	// safe to target.
+	clusterScopedEventNamespace = metav1.NamespaceDefault
+)
+
+// projectEventEmitter emits consumer-facing Project lifecycle events.
+// Implemented by ProjectEventEmitter; stubbed in tests.
+type projectEventEmitter interface {
+	Emit(ctx context.Context, project *resourcemanagerv1alpha.Project, reason, note string) error
+}
+
+// ProjectEventEmitter creates Project lifecycle events through a client that
+// impersonates the project's parent context.
+//
+// Controllers authenticate as themselves and carry no
+// parent-type/parent-name extras, so events they create through the shared
+// manager EventRecorder are stored with no scope annotations and are invisible
+// to tenant-scoped activity feed queries. Rather than teaching the events
+// proxy a second way to derive scope, this emitter supplies the parent context
+// the proxy already reads — the controller knows which Project it is acting
+// on, so the parent is asserted rather than inferred from a request field.
+//
+// The manager's shared EventRecorder cannot do this: it is backed by one
+// broadcaster over one rest.Config, i.e. one static identity, while parent
+// context varies per Project.
+//
+// Events are created as events.k8s.io/v1 rather than core/v1 so the objects
+// genuinely carry the Regarding/Note fields the ActivityPolicy eventRules read
+// (config/services/activity/policies/resourcemanager/project-policy.yaml),
+// with no dependence on a core/v1 -> events.k8s.io/v1 conversion in between.
+//
+// Deployment prerequisite: the controller-manager must hold `impersonate` on
+// the configured impersonateUser and on
+// userextras/iam.miloapis.com/parent-type and .../parent-name. No such RBAC
+// exists under config/ today, and in test-infra the controller-manager
+// authenticates as `admin` in system:masters, which bypasses authorization —
+// so this works there and would fail anywhere with real RBAC until that
+// binding is added.
+type ProjectEventEmitter struct {
+	// baseConfig is the controller-manager's own rest config; each emit
+	// derives an impersonating copy from it.
+	baseConfig *rest.Config
+
+	// impersonateUser is the principal asserted in Impersonate-User. The API
+	// server rejects impersonation extras unless a user is impersonated too,
+	// so this must be set even though the parent extras are the part that
+	// determines scope.
+	impersonateUser string
+
+	// reportingInstance identifies this controller instance in emitted
+	// events. Kubernetes caps it at 128 characters.
+	reportingInstance string
+
+	// newClient builds a clientset from a config. Overridable in tests.
+	newClient func(*rest.Config) (kubernetes.Interface, error)
+}
+
+// NewProjectEventEmitter returns an emitter that impersonates impersonateUser
+// plus the target project's parent context.
+func NewProjectEventEmitter(baseConfig *rest.Config, impersonateUser, reportingInstance string) *ProjectEventEmitter {
+	return &ProjectEventEmitter{
+		baseConfig:        baseConfig,
+		impersonateUser:   impersonateUser,
+		reportingInstance: reportingInstance,
+		newClient: func(cfg *rest.Config) (kubernetes.Interface, error) {
+			return kubernetes.NewForConfig(cfg)
+		},
+	}
+}
+
+// clientForProject builds a clientset whose requests carry the project's
+// parent context as impersonation extras.
+//
+// A client is built per emit rather than cached per project. Suspension
+// transitions are rare, so the allocation is not worth a cache that would need
+// invalidation and a bound; revisit if this emitter is reused for a
+// high-frequency event.
+func (e *ProjectEventEmitter) clientForProject(projectName string) (kubernetes.Interface, error) {
+	cfg := rest.CopyConfig(e.baseConfig)
+	cfg.Impersonate = rest.ImpersonationConfig{
+		UserName: e.impersonateUser,
+		Extra: map[string][]string{
+			iamv1alpha1.ParentKindExtraKey: {projectKind},
+			iamv1alpha1.ParentNameExtraKey: {projectName},
+		},
+	}
+	return e.newClient(cfg)
+}
+
+// Emit creates an events.k8s.io/v1 Event regarding project.
+//
+// note reaches tenant-facing activity feeds, so callers must keep it free of
+// internal admin detail — see recordTransition.
+func (e *ProjectEventEmitter) Emit(ctx context.Context, project *resourcemanagerv1alpha.Project, reason, note string) error {
+	if project == nil {
+		return fmt.Errorf("project is required")
+	}
+
+	cs, err := e.clientForProject(project.Name)
+	if err != nil {
+		return fmt.Errorf("failed to build impersonating client for project %q: %w", project.Name, err)
+	}
+
+	event := &eventsv1.Event{
+		ObjectMeta: metav1.ObjectMeta{
+			// Names are assigned client-side rather than via GenerateName,
+			// matching how client-go's own event recorder builds them. Two
+			// transitions for one project can't share a nanosecond, and this
+			// keeps the emitter independent of server-side name generation.
+			Name:      fmt.Sprintf("%s.%x", project.Name, time.Now().UnixNano()),
+			Namespace: clusterScopedEventNamespace,
+		},
+		EventTime:           metav1.NowMicro(),
+		ReportingController: controllerOwnerName,
+		ReportingInstance:   e.reportingInstance,
+		Action:              reason,
+		Reason:              reason,
+		Regarding: corev1.ObjectReference{
+			APIVersion: resourcemanagerv1alpha.GroupVersion.String(),
+			Kind:       projectKind,
+			Name:       project.Name,
+			UID:        project.UID,
+		},
+		Note: note,
+		Type: corev1.EventTypeNormal,
+	}
+
+	if _, err := cs.EventsV1().Events(clusterScopedEventNamespace).Create(ctx, event, metav1.CreateOptions{}); err != nil {
+		return fmt.Errorf("failed to create %q event for project %q: %w", reason, project.Name, err)
+	}
+
+	return nil
+}
+
+// recordTransition emits the consumer-facing Suspended/Reinstated events for
+// a Project. The Suspended message carries only the suspension reason
+// categories (e.g. "Abuse") — never ProjectSuspension resource names,
+// requestedBy, or description, which are internal admin details that must not
+// leak to tenant-facing activity feeds.
+//
+// Messages are kept bare — no project name, no verb, no field label — because
+// the ActivityPolicy summary
+// (config/services/activity/policies/resourcemanager/project-policy.yaml)
+// reconstructs the sentence from the structured event.regarding.name field and
+// supplies the "category:" label itself. Labelling here too would render it
+// twice.
+func recordTransition(ctx context.Context, emitter projectEventEmitter, project *resourcemanagerv1alpha.Project, wasSuspended, isSuspendedNow bool, activeSuspensionReasons []string, latestSuspensionTime metav1.Time) {
+	logger := log.FromContext(ctx)
+
+	emit := func(reason, note string) {
+		if emitter == nil {
+			return
+		}
+		// Event emission is best-effort: the status patch has already
+		// succeeded, so failing the reconcile here would only re-run it. Log
+		// and move on, matching the fire-and-forget behaviour of the manager
+		// EventRecorder this replaced.
+		if err := emitter.Emit(ctx, project, reason, note); err != nil {
+			eventEmitFailedTotal.WithLabelValues(reason).Inc()
+			logger.Error(err, "failed to emit project lifecycle event",
+				"project", project.Name, "reason", reason)
+		}
+	}
+
+	if !wasSuspended && isSuspendedNow {
+		emit("Suspended", strings.Join(activeSuspensionReasons, ", "))
+		if !latestSuspensionTime.IsZero() {
+			transitionDurationSeconds.WithLabelValues("suspended").Observe(time.Since(latestSuspensionTime.Time).Seconds())
+		}
+	} else if wasSuspended && !isSuspendedNow {
+		emit("Reinstated", "")
+		transitionDurationSeconds.WithLabelValues("reinstated").Observe(0)
+	}
+}

--- a/internal/controllers/resourcemanager/project_event_emitter_test.go
+++ b/internal/controllers/resourcemanager/project_event_emitter_test.go
@@ -1,0 +1,148 @@
+package resourcemanager
+
+import (
+	"context"
+	"testing"
+
+	eventsv1 "k8s.io/api/events/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/rest"
+	k8stesting "k8s.io/client-go/testing"
+
+	iamv1alpha1 "go.miloapis.com/milo/pkg/apis/iam/v1alpha1"
+	resourcemanagerv1alpha1 "go.miloapis.com/milo/pkg/apis/resourcemanager/v1alpha1"
+)
+
+// newTestEmitter returns an emitter whose client construction is intercepted,
+// exposing the rest.Config the emitter built and the fake clientset it used.
+func newTestEmitter(t *testing.T, base *rest.Config) (*ProjectEventEmitter, func() *rest.Config, *fake.Clientset) {
+	t.Helper()
+
+	cs := fake.NewSimpleClientset()
+	var captured *rest.Config
+
+	e := NewProjectEventEmitter(base, defaultImpersonateUser, controllerOwnerName)
+	e.newClient = func(cfg *rest.Config) (kubernetes.Interface, error) {
+		captured = cfg
+		return cs, nil
+	}
+
+	return e, func() *rest.Config { return captured }, cs
+}
+
+func TestProjectEventEmitter_ImpersonatesProjectParentContext(t *testing.T) {
+	base := &rest.Config{Host: "https://milo.example"}
+	e, capturedConfig, _ := newTestEmitter(t, base)
+
+	project := &resourcemanagerv1alpha1.Project{
+		ObjectMeta: metav1.ObjectMeta{Name: "project-123", UID: "project-uid-1"},
+	}
+
+	if err := e.Emit(context.Background(), project, "Suspended", "Abuse"); err != nil {
+		t.Fatalf("Emit returned error: %v", err)
+	}
+
+	cfg := capturedConfig()
+	if cfg == nil {
+		t.Fatal("expected a client to be built")
+	}
+
+	if cfg.Impersonate.UserName != defaultImpersonateUser {
+		t.Errorf("expected Impersonate-User %q, got %q", defaultImpersonateUser, cfg.Impersonate.UserName)
+	}
+
+	// The parent extras are what the events proxy reads to derive scope
+	// annotations; without them the event is stored untagged.
+	if got := cfg.Impersonate.Extra[iamv1alpha1.ParentKindExtraKey]; len(got) != 1 || got[0] != projectKind {
+		t.Errorf("expected %s = [%q], got %v", iamv1alpha1.ParentKindExtraKey, projectKind, got)
+	}
+	if got := cfg.Impersonate.Extra[iamv1alpha1.ParentNameExtraKey]; len(got) != 1 || got[0] != "project-123" {
+		t.Errorf("expected %s = [\"project-123\"], got %v", iamv1alpha1.ParentNameExtraKey, got)
+	}
+}
+
+func TestProjectEventEmitter_DoesNotMutateBaseConfig(t *testing.T) {
+	// Each emit targets a different project, so leaking impersonation into the
+	// shared base config would scope every later event to the first project.
+	base := &rest.Config{Host: "https://milo.example"}
+	e, capturedConfig, _ := newTestEmitter(t, base)
+
+	first := &resourcemanagerv1alpha1.Project{ObjectMeta: metav1.ObjectMeta{Name: "project-aaa"}}
+	if err := e.Emit(context.Background(), first, "Suspended", "Abuse"); err != nil {
+		t.Fatalf("Emit returned error: %v", err)
+	}
+
+	if base.Impersonate.UserName != "" || base.Impersonate.Extra != nil {
+		t.Errorf("base config must not be mutated, got %+v", base.Impersonate)
+	}
+
+	second := &resourcemanagerv1alpha1.Project{ObjectMeta: metav1.ObjectMeta{Name: "project-bbb"}}
+	if err := e.Emit(context.Background(), second, "Reinstated", ""); err != nil {
+		t.Fatalf("Emit returned error: %v", err)
+	}
+
+	if got := capturedConfig().Impersonate.Extra[iamv1alpha1.ParentNameExtraKey]; len(got) != 1 || got[0] != "project-bbb" {
+		t.Errorf("second emit must carry the second project's scope, got %v", got)
+	}
+}
+
+func TestProjectEventEmitter_CreatesEventsV1EventForActivityPolicy(t *testing.T) {
+	// The ActivityPolicy eventRules read event.regarding.name and event.note,
+	// so the emitted object must genuinely be events.k8s.io/v1 shaped.
+	e, _, cs := newTestEmitter(t, &rest.Config{Host: "https://milo.example"})
+
+	project := &resourcemanagerv1alpha1.Project{
+		ObjectMeta: metav1.ObjectMeta{Name: "project-123", UID: "project-uid-1"},
+	}
+
+	if err := e.Emit(context.Background(), project, "Suspended", "Abuse"); err != nil {
+		t.Fatalf("Emit returned error: %v", err)
+	}
+
+	var created *eventsv1.Event
+	for _, action := range cs.Actions() {
+		ca, ok := action.(k8stesting.CreateAction)
+		if !ok {
+			continue
+		}
+		if ev, ok := ca.GetObject().(*eventsv1.Event); ok {
+			created = ev
+			break
+		}
+	}
+	if created == nil {
+		t.Fatal("expected an events.k8s.io/v1 Event to be created")
+	}
+
+	if created.Regarding.Name != "project-123" {
+		t.Errorf("expected Regarding.Name project-123, got %q", created.Regarding.Name)
+	}
+	if created.Regarding.Kind != "Project" {
+		t.Errorf("expected Regarding.Kind Project, got %q", created.Regarding.Kind)
+	}
+	if want := resourcemanagerv1alpha1.GroupVersion.String(); created.Regarding.APIVersion != want {
+		t.Errorf("expected Regarding.APIVersion %q, got %q", want, created.Regarding.APIVersion)
+	}
+	if created.Note != "Abuse" {
+		t.Errorf("expected Note Abuse, got %q", created.Note)
+	}
+	if created.Reason != "Suspended" {
+		t.Errorf("expected Reason Suspended, got %q", created.Reason)
+	}
+	if created.ReportingController != controllerOwnerName {
+		t.Errorf("expected ReportingController %q, got %q", controllerOwnerName, created.ReportingController)
+	}
+	if created.EventTime.IsZero() {
+		t.Error("EventTime must be set; events.k8s.io/v1 rejects a zero EventTime")
+	}
+}
+
+func TestProjectEventEmitter_RejectsNilProject(t *testing.T) {
+	e, _, _ := newTestEmitter(t, &rest.Config{Host: "https://milo.example"})
+
+	if err := e.Emit(context.Background(), nil, "Suspended", "Abuse"); err == nil {
+		t.Error("expected an error for a nil project")
+	}
+}

--- a/internal/controllers/resourcemanager/projectsuspension_propagator_controller.go
+++ b/internal/controllers/resourcemanager/projectsuspension_propagator_controller.go
@@ -12,7 +12,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
-	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
@@ -26,16 +25,39 @@ import (
 // ProjectSuspensionPropagatorController reconciles a Project object's suspension status
 // by aggregating the ProjectSuspension resources that target it.
 type ProjectSuspensionPropagatorController struct {
-	Client        client.Client
-	EventRecorder record.EventRecorder
+	Client client.Client
+
+	// EventEmitter creates the consumer-facing Suspended/Reinstated events.
+	// It impersonates the project's parent context so the events proxy can
+	// scope-tag them; see ProjectEventEmitter for why the manager's shared
+	// EventRecorder cannot. Defaulted in SetupWithManager.
+	EventEmitter projectEventEmitter
 }
 
 // +kubebuilder:rbac:groups=resourcemanager.miloapis.com,resources=projects,verbs=get;list;watch
 // +kubebuilder:rbac:groups=resourcemanager.miloapis.com,resources=projects/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=resourcemanager.miloapis.com,resources=projectsuspensions,verbs=get;list;watch
 
+// Consumer-facing Suspended/Reinstated events are created through a client
+// that impersonates the controller's own service account plus the target
+// project's parent context, so the events proxy can scope-tag them
+// (see ProjectEventEmitter). That needs impersonate on the service account
+// itself — a username of the form system:serviceaccount:<ns>:<name> is
+// authorized against the serviceaccounts resource, not users — and on each
+// parent-context extra key, which are checked individually as
+// userextras/<key> subresources.
+// +kubebuilder:rbac:groups="",resources=serviceaccounts,verbs=impersonate
+// +kubebuilder:rbac:groups=authentication.k8s.io,resources=userextras/iam.miloapis.com/parent-type,verbs=impersonate
+// +kubebuilder:rbac:groups=authentication.k8s.io,resources=userextras/iam.miloapis.com/parent-name,verbs=impersonate
+// +kubebuilder:rbac:groups=events.k8s.io,resources=events,verbs=create
+
 const projectRefNameIndex = "spec.projectRef.name"
 const controllerOwnerName = "project-suspension-controller"
+
+// defaultImpersonateUser is the principal the event emitter asserts when none
+// is configured. The controller-manager must hold `impersonate` on it, plus on
+// userextras/iam.miloapis.com/parent-type and .../parent-name.
+const defaultImpersonateUser = "system:serviceaccount:milo-system:milo-controller-manager"
 
 // getProjectSuspendedStatus returns true if the project is suspended, false otherwise.
 func getProjectSuspendedStatus(project *resourcemanagerv1alpha.Project) bool {
@@ -87,21 +109,32 @@ func (r *ProjectSuspensionPropagatorController) Reconcile(ctx context.Context, r
 		return ctrl.Result{}, fmt.Errorf("failed to list project suspensions: %w", err)
 	}
 
-	// Filter suspensions related to this project
+	// Filter suspensions related to this project. status.Suspensions only
+	// ever holds active suspensions (see ProjectSuspensionInfo's doc
+	// comment) — a ProjectSuspension whose phase has moved past Active
+	// (e.g. Lifted) is excluded, mirroring the activeSuspensionNames/
+	// activeReasons filtering below.
 	var suspensions []resourcemanagerv1alpha.ProjectSuspensionInfo
-	var activeSuspensionNames []string
 	var activeReasons []string
+	seenReasons := make(map[string]bool)
 
 	for _, ps := range suspensionList.Items {
+		// Active means the phase is explicitly Active, or still unset because
+		// the suspension hasn't been reconciled yet. Any other phase (today
+		// only Lifted) is treated as inactive.
+		if ps.Status.Phase != resourcemanagerv1alpha.PhaseActive && ps.Status.Phase != "" {
+			continue
+		}
+
 		suspensions = append(suspensions, resourcemanagerv1alpha.ProjectSuspensionInfo{
 			Reason:             ps.Spec.Reason,
 			SuspendedAt:        ps.CreationTimestamp,
 			ReinstateAuthority: ps.Spec.ReinstateAuthority,
 		})
-		// Phase is active if it's explicitly Active, or not set to Lifted.
-		if ps.Status.Phase == resourcemanagerv1alpha.PhaseActive || ps.Status.Phase == "" {
-			activeSuspensionNames = append(activeSuspensionNames, ps.Name)
-			activeReasons = append(activeReasons, string(ps.Spec.Reason))
+		reason := string(ps.Spec.Reason)
+		if !seenReasons[reason] {
+			seenReasons[reason] = true
+			activeReasons = append(activeReasons, reason)
 		}
 	}
 
@@ -115,19 +148,26 @@ func (r *ProjectSuspensionPropagatorController) Reconcile(ctx context.Context, r
 		}
 		return suspensions[i].SuspendedAt.Before(&suspensions[j].SuspendedAt)
 	})
-	sort.Strings(activeSuspensionNames)
+	sort.Strings(activeReasons)
 
 	project.Status.Suspensions = suspensions
 
-	// Update the Suspended condition
-	isSuspended := len(activeSuspensionNames) > 0
+	// Update the Suspended condition.
+	//
+	// The message names only the suspension reason categories (e.g. "Abuse"),
+	// never the ProjectSuspension resource names. Project.status is read by
+	// project members, so this message is a tenant-facing surface and carries
+	// the same redaction requirement as the Suspended event emitted by
+	// recordTransition — resource names, requestedBy and description are
+	// internal admin detail.
+	isSuspended := len(suspensions) > 0
 	var cond metav1.Condition
 	if isSuspended {
 		cond = metav1.Condition{
 			Type:               resourcemanagerv1alpha.ProjectSuspended,
 			Status:             metav1.ConditionTrue,
 			Reason:             resourcemanagerv1alpha.ProjectSuspendedReason,
-			Message:            fmt.Sprintf("Project is suspended due to active suspensions: %s", strings.Join(activeSuspensionNames, ", ")),
+			Message:            fmt.Sprintf("Project is suspended (category: %s)", strings.Join(activeReasons, ", ")),
 			ObservedGeneration: project.Generation,
 		}
 	} else {
@@ -157,7 +197,7 @@ func (r *ProjectSuspensionPropagatorController) Reconcile(ctx context.Context, r
 		if !wasSuspended && isSuspendedNow {
 			latestTime = getLatestActiveSuspensionTime(suspensionList.Items, project.Name)
 		}
-		recordTransition(r.EventRecorder, &project, wasSuspended, isSuspendedNow, activeSuspensionNames, latestTime)
+		recordTransition(ctx, r.EventEmitter, &project, wasSuspended, isSuspendedNow, activeReasons, latestTime)
 	}
 
 	return ctrl.Result{}, nil
@@ -165,7 +205,13 @@ func (r *ProjectSuspensionPropagatorController) Reconcile(ctx context.Context, r
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *ProjectSuspensionPropagatorController) SetupWithManager(mgr ctrl.Manager) error {
-	r.EventRecorder = mgr.GetEventRecorderFor("project-suspension-controller")
+	if r.EventEmitter == nil {
+		// Events are emitted through an impersonating client rather than
+		// mgr.GetEventRecorderFor: the recorder is backed by a single
+		// broadcaster over one static identity, but scope requires per-Project
+		// parent context on the request.
+		r.EventEmitter = NewProjectEventEmitter(mgr.GetConfig(), defaultImpersonateUser, controllerOwnerName)
+	}
 
 	if err := mgr.GetFieldIndexer().IndexField(context.Background(), &resourcemanagerv1alpha.ProjectSuspension{}, projectRefNameIndex, func(rawObj client.Object) []string {
 		obj := rawObj.(*resourcemanagerv1alpha.ProjectSuspension)

--- a/internal/controllers/resourcemanager/projectsuspension_propagator_controller_test.go
+++ b/internal/controllers/resourcemanager/projectsuspension_propagator_controller_test.go
@@ -10,7 +10,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
-	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -48,7 +47,7 @@ func TestProjectSuspensionController_Reconcile(t *testing.T) {
 			WithStatusSubresource(&resourcemanagerv1alpha1.Project{}).
 			Build()
 
-		r := &ProjectSuspensionPropagatorController{Client: c, EventRecorder: record.NewFakeRecorder(100)}
+		r := &ProjectSuspensionPropagatorController{Client: c, EventEmitter: newFakeEventEmitter(100)}
 
 		req := ctrl.Request{
 			NamespacedName: types.NamespacedName{
@@ -90,8 +89,8 @@ func TestProjectSuspensionController_Reconcile(t *testing.T) {
 			}).
 			Build()
 
-		fakeRecorder := record.NewFakeRecorder(100)
-		r := &ProjectSuspensionPropagatorController{Client: c, EventRecorder: fakeRecorder}
+		fakeRecorder := newFakeEventEmitter(100)
+		r := &ProjectSuspensionPropagatorController{Client: c, EventEmitter: fakeRecorder}
 
 		req := ctrl.Request{
 			NamespacedName: types.NamespacedName{
@@ -185,8 +184,8 @@ func TestProjectSuspensionController_Reconcile(t *testing.T) {
 			}).
 			Build()
 
-		fakeRecorder := record.NewFakeRecorder(100)
-		r := &ProjectSuspensionPropagatorController{Client: c, EventRecorder: fakeRecorder}
+		fakeRecorder := newFakeEventEmitter(100)
+		r := &ProjectSuspensionPropagatorController{Client: c, EventEmitter: fakeRecorder}
 
 		req := ctrl.Request{
 			NamespacedName: types.NamespacedName{
@@ -225,11 +224,20 @@ func TestProjectSuspensionController_Reconcile(t *testing.T) {
 			t.Errorf("expected Suspended condition reason %v, got %v", resourcemanagerv1alpha1.ProjectSuspendedReason, cond.Reason)
 		}
 
-		// Verify event was emitted
+		// Verify event was emitted, carrying suspension categories (Abuse,
+		// Billing) but never the underlying ProjectSuspension resource
+		// names ("suspension-a", "suspension-b") — those are internal admin
+		// detail that must not reach consumer-facing activity feeds.
 		select {
 		case ev := <-fakeRecorder.Events:
 			if !strings.Contains(ev, "Suspended") {
 				t.Errorf("expected Suspended event, got: %s", ev)
+			}
+			if !strings.Contains(ev, "Abuse") || !strings.Contains(ev, "Billing") {
+				t.Errorf("expected event to carry both suspension categories, got: %s", ev)
+			}
+			if strings.Contains(ev, "suspension-a") || strings.Contains(ev, "suspension-b") {
+				t.Errorf("event must never contain ProjectSuspension resource names, got: %s", ev)
 			}
 		default:
 			t.Error("expected event to be emitted, but got none")
@@ -280,8 +288,8 @@ func TestProjectSuspensionController_Reconcile(t *testing.T) {
 			}).
 			Build()
 
-		fakeRecorder := record.NewFakeRecorder(100)
-		r := &ProjectSuspensionPropagatorController{Client: c, EventRecorder: fakeRecorder}
+		fakeRecorder := newFakeEventEmitter(100)
+		r := &ProjectSuspensionPropagatorController{Client: c, EventEmitter: fakeRecorder}
 
 		req := ctrl.Request{
 			NamespacedName: types.NamespacedName{
@@ -299,11 +307,11 @@ func TestProjectSuspensionController_Reconcile(t *testing.T) {
 			t.Fatalf("failed to get project: %v", err)
 		}
 
-		if len(updatedProject.Status.Suspensions) != 1 ||
-			updatedProject.Status.Suspensions[0].Reason != resourcemanagerv1alpha1.ReasonAbuse ||
-			updatedProject.Status.Suspensions[0].ReinstateAuthority != resourcemanagerv1alpha1.AuthorityOperator ||
-			updatedProject.Status.Suspensions[0].SuspendedAt.IsZero() {
-			t.Errorf("unexpected suspensions: %+v", updatedProject.Status.Suspensions)
+		// status.Suspensions only ever holds active suspensions (see
+		// ProjectSuspensionInfo's doc comment) — a Lifted ProjectSuspension
+		// must not appear here even though it still exists as a resource.
+		if len(updatedProject.Status.Suspensions) != 0 {
+			t.Errorf("expected 0 suspensions (Lifted suspensions are excluded), got %+v", updatedProject.Status.Suspensions)
 		}
 
 		cond := apimeta.FindStatusCondition(updatedProject.Status.Conditions, resourcemanagerv1alpha1.ProjectSuspended)
@@ -327,4 +335,148 @@ func TestProjectSuspensionController_Reconcile(t *testing.T) {
 			t.Error("expected event to be emitted, but got none")
 		}
 	})
+
+	t.Run("mix of active and lifted suspensions", func(t *testing.T) {
+		ctx := context.Background()
+		project := &resourcemanagerv1alpha1.Project{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test-project",
+			},
+		}
+		activeSuspension := &resourcemanagerv1alpha1.ProjectSuspension{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "suspension-active",
+				CreationTimestamp: metav1.Now(),
+			},
+			Spec: resourcemanagerv1alpha1.ProjectSuspensionSpec{
+				ProjectRef: resourcemanagerv1alpha1.ProjectReference{
+					Name: "test-project",
+				},
+				Reason:             resourcemanagerv1alpha1.ReasonAbuse,
+				ReinstateAuthority: resourcemanagerv1alpha1.AuthorityOperator,
+			},
+			Status: resourcemanagerv1alpha1.ProjectSuspensionStatus{
+				Phase: resourcemanagerv1alpha1.PhaseActive,
+			},
+		}
+		liftedSuspension := &resourcemanagerv1alpha1.ProjectSuspension{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "suspension-lifted",
+				CreationTimestamp: metav1.Now(),
+			},
+			Spec: resourcemanagerv1alpha1.ProjectSuspensionSpec{
+				ProjectRef: resourcemanagerv1alpha1.ProjectReference{
+					Name: "test-project",
+				},
+				Reason:             resourcemanagerv1alpha1.ReasonBilling,
+				ReinstateAuthority: resourcemanagerv1alpha1.AuthorityOperator,
+			},
+			Status: resourcemanagerv1alpha1.ProjectSuspensionStatus{
+				Phase: resourcemanagerv1alpha1.PhaseLifted,
+			},
+		}
+
+		c := fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithObjects(project, activeSuspension, liftedSuspension).
+			WithStatusSubresource(&resourcemanagerv1alpha1.Project{}).
+			WithIndex(&resourcemanagerv1alpha1.ProjectSuspension{}, projectRefNameIndex, func(rawObj client.Object) []string {
+				obj := rawObj.(*resourcemanagerv1alpha1.ProjectSuspension)
+				return []string{obj.Spec.ProjectRef.Name}
+			}).
+			Build()
+
+		fakeRecorder := newFakeEventEmitter(100)
+		r := &ProjectSuspensionPropagatorController{Client: c, EventEmitter: fakeRecorder}
+
+		req := ctrl.Request{
+			NamespacedName: types.NamespacedName{
+				Name: "test-project",
+			},
+		}
+
+		_, err := r.Reconcile(ctx, req)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		var updatedProject resourcemanagerv1alpha1.Project
+		if err := c.Get(ctx, client.ObjectKey{Name: "test-project"}, &updatedProject); err != nil {
+			t.Fatalf("failed to get project: %v", err)
+		}
+
+		// Only the active suspension should appear in status.Suspensions;
+		// the lifted one must be excluded.
+		if len(updatedProject.Status.Suspensions) != 1 ||
+			updatedProject.Status.Suspensions[0].Reason != resourcemanagerv1alpha1.ReasonAbuse {
+			t.Errorf("expected only the active (Abuse) suspension, got %+v", updatedProject.Status.Suspensions)
+		}
+
+		// Verify Suspended event was emitted, carrying only the active
+		// suspension's category and never the ProjectSuspension resource
+		// names ("suspension-active", "suspension-lifted").
+		select {
+		case ev := <-fakeRecorder.Events:
+			if !strings.Contains(ev, "Suspended") {
+				t.Errorf("expected Suspended event, got: %s", ev)
+			}
+			if !strings.Contains(ev, "Abuse") {
+				t.Errorf("expected event to carry the suspension category, got: %s", ev)
+			}
+			if strings.Contains(ev, "Billing") {
+				t.Errorf("expected the lifted suspension's category to be excluded, got: %s", ev)
+			}
+			if strings.Contains(ev, "suspension-active") || strings.Contains(ev, "suspension-lifted") {
+				t.Errorf("event must never contain ProjectSuspension resource names, got: %s", ev)
+			}
+		default:
+			t.Error("expected event to be emitted, but got none")
+		}
+	})
+}
+
+// fakeEventEmitter records emitted Project lifecycle events for assertions.
+// Events are rendered "<reason> <note>" so tests can assert on either part
+// with a single substring check.
+type fakeEventEmitter struct {
+	Events chan string
+	err    error
+	calls  int
+}
+
+func newFakeEventEmitter(buffer int) *fakeEventEmitter {
+	return &fakeEventEmitter{Events: make(chan string, buffer)}
+}
+
+func (f *fakeEventEmitter) Emit(_ context.Context, project *resourcemanagerv1alpha1.Project, reason, note string) error {
+	f.calls++
+	if f.err != nil {
+		return f.err
+	}
+	f.Events <- fmt.Sprintf("%s %s", reason, note)
+	return nil
+}
+
+// Ensure the fake satisfies the interface the controller depends on.
+var _ projectEventEmitter = (*fakeEventEmitter)(nil)
+
+func TestRecordTransition_ContinuesWhenEmitFails(t *testing.T) {
+	// A failed event must not fail the reconcile. By the time recordTransition
+	// runs, the status patch has already succeeded, so returning an error here
+	// would only cause a pointless re-reconcile — the emit is logged instead.
+	emitter := newFakeEventEmitter(1)
+	emitter.err = fmt.Errorf("activity backend unavailable")
+
+	project := &resourcemanagerv1alpha1.Project{
+		ObjectMeta: metav1.ObjectMeta{Name: "project-123"},
+	}
+
+	recordTransition(context.Background(), emitter, project, false, true, []string{"Abuse"}, metav1.Time{})
+
+	if emitter.calls != 1 {
+		t.Errorf("expected one emit attempt, got %d", emitter.calls)
+	}
+	if len(emitter.Events) != 0 {
+		t.Error("failed emit must not enqueue an event")
+	}
 }

--- a/pkg/apis/resourcemanager/v1alpha1/project_types.go
+++ b/pkg/apis/resourcemanager/v1alpha1/project_types.go
@@ -12,7 +12,14 @@ type ProjectSpec struct {
 	OwnerRef OwnerReference `json:"ownerRef"`
 }
 
-// ProjectSuspensionInfo contains the details of a suspension affecting the project.
+// ProjectSuspensionInfo contains the details of a suspension affecting the
+// project.
+//
+// Contract: only ProjectSuspensions in an active phase (status.phase ==
+// "Active", or unset/not-yet-reconciled) are represented here. A
+// ProjectSuspension that has moved past Active (e.g. "Lifted") is excluded.
+// Consumers must not assume every entry in status.suspensions still applies
+// enforcement/visibility beyond that active-only guarantee.
 type ProjectSuspensionInfo struct {
 	// Reason is the category of suspension.
 	// +kubebuilder:validation:Required
@@ -34,7 +41,8 @@ type ProjectStatus struct {
 	// +kubebuilder:default={{type: "Ready", status: "Unknown", reason: "Unknown", message: "Waiting for control plane to reconcile", lastTransitionTime: "1970-01-01T00:00:00Z"}}
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 
-	// Suspensions lists the active/all suspensions currently affecting the project.
+	// Suspensions lists the active suspensions currently affecting the
+	// project. See ProjectSuspensionInfo for the active-only contract.
 	// +kubebuilder:validation:Optional
 	Suspensions []ProjectSuspensionInfo `json:"suspensions,omitempty"`
 }


### PR DESCRIPTION
Fixes #748.

## What

**1. Suspension events now carry tenant scope, set via impersonation.**

Scope annotations (`platform.miloapis.com/scope.*`) are derived from the requesting user's `iam.miloapis.com/parent-type` / `parent-name` extras. The propagator emitted through the manager's shared EventRecorder, which authenticates as the controller and carries no parent context — so its events were stored untagged and invisible to project-scoped feed queries.

`ProjectEventEmitter` emits through a client that impersonates the controller's service account plus `parent-type: Project` / `parent-name: <project>`, so `injectScopeAnnotations` takes its existing full-parent-context branch unchanged. Per @scotwells' review, no second scope-derivation path.

Verified at the code level: `WithImpersonation` is enabled in Milo's handler chain (`cmd/milo/apiserver/config.go:525`) and runs *before* the Project/Org context decorators, which pass through untouched when the request isn't project-scoped (`pkg/server/filters/projects.go:86-91`).

Events are created as `events.k8s.io/v1` so they genuinely carry the `Regarding`/`Note` fields the ActivityPolicy reads, with no conversion in between.

**2. Internal admin detail redacted.** The `Suspended` event message and `Project.status.conditions["Suspended"].message` both embedded ProjectSuspension resource names. Both now carry only the reason category (e.g. `Abuse`). Project status is tenant-readable, so it needed the same treatment as the event.

**3. ActivityPolicy CEL fields corrected.** `eventRules` read `event.involvedObject.name` / `event.message`; the `events.k8s.io/v1` contract exposes `event.regarding.name` / `event.note`. The summary would have silently rendered empty.

**4. `status.suspensions[]` filtered to active phase**, with the active-only contract documented on the API types. No-op today since lift is implemented as delete.

**5. RBAC** regenerated from new kubebuilder markers: `impersonate` on `serviceaccounts` and on the two `userextras` parent keys, plus `create` on `events.k8s.io/events` — the generated ClusterRole had no events-create rule in any API group.

## Notes for reviewers

**The involved-object scope fallback is still in the diff.** I kept it rather than removing it here: impersonation is verified at the code level but has not yet run at runtime (see below). The two coexist safely — impersonation supplies full parent context, so the fallback branch is never reached for these events. Happy to remove it if you'd rather the PR show only the impersonation path.

**The impersonation RBAC is not exercised by CI.** The controller-manager authenticates as `admin` / `system:masters` in test-infra, so a green run there will not prove the new rules are correct. Moving it onto its service account identity changes authentication for every controller in that binary at once and would surface any other gaps in the generated ClusterRole, so it belongs in its own change.

## Test plan

- `go build ./...`, `gofmt -l .` — clean
- `go vet ./...` — one pre-existing, unrelated finding (`organization_types.go:127`), confirmed present on `main`
- `go test -timeout 5m ./...` — 772 passed, 72 packages
