### PR TITLE
test(events): pin the scope-injection invariant

### DIFF
--- a/internal/apiserver/events/dynamic_test.go
+++ b/internal/apiserver/events/dynamic_test.go
@@ -78,6 +78,34 @@ func TestInjectScopeAnnotations_PlatformScope(t *testing.T) {
 	assert.Empty(t, event.Annotations)
 }
 
+func TestInjectScopeAnnotations_InvolvedObjectNeverSetsScope(t *testing.T) {
+	// The involved object is client-supplied and must never influence scope.
+	// Here it names a different Project than the request's parent context;
+	// the request context has to win.
+	ctx := contextWithUser(&authuser.DefaultInfo{
+		Name: "alice",
+		Extra: map[string][]string{
+			ExtraKeyParentType: {"Project"},
+			ExtraKeyParentName: {"project-alice"},
+		},
+	})
+	event := &corev1.Event{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-event"},
+		InvolvedObject: corev1.ObjectReference{
+			APIVersion: "resourcemanager.miloapis.com/v1alpha1",
+			Kind:       "Project",
+			Name:       "project-other",
+		},
+	}
+
+	err := injectScopeAnnotations(ctx, event)
+
+	require.NoError(t, err)
+	assert.Equal(t, "Project", event.Annotations[ScopeTypeAnnotation])
+	assert.Equal(t, "project-alice", event.Annotations[ScopeNameAnnotation],
+		"scope must come from the request context, never the involved object")
+}
+
 func TestInjectScopeAnnotations_PreservesExistingAnnotations(t *testing.T) {
 	// Existing annotations should be preserved, scope annotations added
 	ctx := contextWithUser(&authuser.DefaultInfo{
@@ -136,6 +164,33 @@ func TestInjectScopeAnnotations_PartialScope(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.Empty(t, event.Annotations)
+}
+
+func TestInjectScopeAnnotations_IncompleteContextIgnoresInvolvedObject(t *testing.T) {
+	// A request without complete parent context leaves the event unannotated;
+	// the involved object must not be used to complete it, even when it names
+	// a perfectly valid Project.
+	ctx := contextWithUser(&authuser.DefaultInfo{
+		Name: "mallory",
+		Extra: map[string][]string{
+			ExtraKeyParentType: {"Project"},
+			// Missing ExtraKeyParentName
+		},
+	})
+	event := &corev1.Event{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-event"},
+		InvolvedObject: corev1.ObjectReference{
+			APIVersion: "resourcemanager.miloapis.com/v1alpha1",
+			Kind:       "Project",
+			Name:       "victim-project",
+		},
+	}
+
+	err := injectScopeAnnotations(ctx, event)
+
+	require.NoError(t, err)
+	assert.Empty(t, event.Annotations,
+		"incomplete parent context must not be completed from the client-supplied involved object")
 }
 
 func TestInjectScopeAnnotations_OverwritesScope(t *testing.T) {

--- a/internal/apiserver/events/eventsv1_rest.go
+++ b/internal/apiserver/events/eventsv1_rest.go
@@ -273,7 +273,12 @@ func (r *EventsV1REST) ConvertToTable(ctx context.Context, object runtime.Object
 	return table, nil
 }
 
-// injectEventsV1ScopeAnnotations adds scope annotations to an events.k8s.io/v1 Event
+// injectEventsV1ScopeAnnotations adds scope annotations to an events.k8s.io/v1 Event.
+//
+// See injectScopeAnnotations (scope.go) for the shared rules: scope comes only
+// from the request's parent-type/parent-name context, never from the event body
+// (the Regarding object included), and a request without full parent context
+// leaves the event unannotated.
 func injectEventsV1ScopeAnnotations(ctx context.Context, event *eventsv1.Event) error {
 	userInfo, ok := apirequest.UserFrom(ctx)
 	if !ok {
@@ -285,7 +290,6 @@ func injectEventsV1ScopeAnnotations(ctx context.Context, event *eventsv1.Event) 
 	parentType := getFirstExtra(extras, ExtraKeyParentType)
 	parentName := getFirstExtra(extras, ExtraKeyParentName)
 
-	// Events without scope context are normal (e.g., system components, platform-level operations)
 	if parentType == "" || parentName == "" {
 		return nil
 	}

--- a/internal/apiserver/events/eventsv1_rest_test.go
+++ b/internal/apiserver/events/eventsv1_rest_test.go
@@ -1,0 +1,115 @@
+package events
+
+import (
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	eventsv1 "k8s.io/api/events/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/watch"
+	authuser "k8s.io/apiserver/pkg/authentication/user"
+	apirequest "k8s.io/apiserver/pkg/endpoints/request"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// mockEventsV1Backend implements the EventsV1Backend interface for testing.
+type mockEventsV1Backend struct {
+	createFunc func(ctx context.Context, namespace string, event *eventsv1.Event) (*eventsv1.Event, error)
+}
+
+func (m *mockEventsV1Backend) CreateEventsV1Event(ctx context.Context, namespace string, event *eventsv1.Event) (*eventsv1.Event, error) {
+	if m.createFunc != nil {
+		return m.createFunc(ctx, namespace, event)
+	}
+	return event, nil
+}
+
+func (m *mockEventsV1Backend) GetEventsV1Event(ctx context.Context, namespace, name string) (*eventsv1.Event, error) {
+	return &eventsv1.Event{}, nil
+}
+
+func (m *mockEventsV1Backend) ListEventsV1Events(ctx context.Context, namespace string, opts *metav1.ListOptions) (*eventsv1.EventList, error) {
+	return &eventsv1.EventList{}, nil
+}
+
+func (m *mockEventsV1Backend) UpdateEventsV1Event(ctx context.Context, namespace string, event *eventsv1.Event) (*eventsv1.Event, error) {
+	return event, nil
+}
+
+func (m *mockEventsV1Backend) DeleteEventsV1Event(ctx context.Context, namespace, name string, opts *metav1.DeleteOptions) error {
+	return nil
+}
+
+func (m *mockEventsV1Backend) WatchEventsV1Events(ctx context.Context, namespace string, opts *metav1.ListOptions) (watch.Interface, error) {
+	return nil, nil
+}
+
+func TestInjectEventsV1ScopeAnnotations_RegardingObjectNeverSetsScope(t *testing.T) {
+	// Regarding is client-supplied; the request's parent context must win.
+	ctx := apirequest.WithUser(context.Background(), &authuser.DefaultInfo{
+		Name: "alice",
+		Extra: map[string][]string{
+			ExtraKeyParentType: {"Project"},
+			ExtraKeyParentName: {"project-alice"},
+		},
+	})
+	event := &eventsv1.Event{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-event"},
+		Regarding: corev1.ObjectReference{
+			APIVersion: "resourcemanager.miloapis.com/v1alpha1",
+			Kind:       "Project",
+			Name:       "project-other",
+		},
+	}
+
+	err := injectEventsV1ScopeAnnotations(ctx, event)
+
+	require.NoError(t, err)
+	assert.Equal(t, "Project", event.Annotations[ScopeTypeAnnotation])
+	assert.Equal(t, "project-alice", event.Annotations[ScopeNameAnnotation],
+		"scope must come from the request context, never the regarding object")
+}
+
+func TestEventsV1REST_Create_LeavesControllerEventUnscoped(t *testing.T) {
+	// A controller that does not impersonate a parent context gets no scope
+	// annotations, however its Regarding object is populated. Reaching a
+	// tenant feed requires impersonation, not inference.
+	var capturedEvent *eventsv1.Event
+	backend := &mockEventsV1Backend{
+		createFunc: func(ctx context.Context, namespace string, event *eventsv1.Event) (*eventsv1.Event, error) {
+			capturedEvent = event.DeepCopy()
+			return event, nil
+		},
+	}
+
+	r := NewEventsV1REST(backend)
+
+	ctx := apirequest.WithUser(context.Background(), &authuser.DefaultInfo{
+		Name: "system:serviceaccount:milo-system:project-suspension-controller",
+	})
+	ctx = apirequest.WithNamespace(ctx, "default")
+
+	event := &eventsv1.Event{
+		ObjectMeta: metav1.ObjectMeta{Name: "project-suspended.xyz"},
+		Regarding: corev1.ObjectReference{
+			APIVersion: "resourcemanager.miloapis.com/v1alpha1",
+			Kind:       "Project",
+			Name:       "project-999",
+		},
+		Reason: "Suspended",
+	}
+
+	result, err := r.Create(ctx, event, nil, &metav1.CreateOptions{})
+
+	require.NoError(t, err)
+	assert.NotNil(t, result)
+	require.NotNil(t, capturedEvent, "backend should have been called")
+	assert.Empty(t, capturedEvent.Annotations[ScopeTypeAnnotation])
+	assert.Empty(t, capturedEvent.Annotations[ScopeNameAnnotation])
+}
+
+// Ensure the mock backend implements the full EventsV1Backend interface.
+var _ EventsV1Backend = (*mockEventsV1Backend)(nil)

--- a/internal/apiserver/events/rest_test.go
+++ b/internal/apiserver/events/rest_test.go
@@ -118,6 +118,21 @@ func TestREST_Create_InjectsScopeAnnotations(t *testing.T) {
 			},
 			wantNoScopeInjection: true,
 		},
+		{
+			name: "controller service account without parent context is left unscoped",
+			user: &authuser.DefaultInfo{
+				Name: "system:serviceaccount:milo-system:project-suspension-controller",
+			},
+			event: &corev1.Event{
+				ObjectMeta: metav1.ObjectMeta{Name: "project-suspended.jkl"},
+				InvolvedObject: corev1.ObjectReference{
+					APIVersion: "resourcemanager.miloapis.com/v1alpha1",
+					Kind:       "Project",
+					Name:       "project-999",
+				},
+				Reason: "Suspended",
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/apiserver/events/scope.go
+++ b/internal/apiserver/events/scope.go
@@ -6,6 +6,8 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	apirequest "k8s.io/apiserver/pkg/endpoints/request"
+
+	iamv1alpha1 "go.miloapis.com/milo/pkg/apis/iam/v1alpha1"
 )
 
 const (
@@ -14,13 +16,31 @@ const (
 	// ScopeNameAnnotation indicates the name of the scoped resource
 	ScopeNameAnnotation = "platform.miloapis.com/scope.name"
 
-	// ExtraKeyParentType is the user.Extra key containing the parent resource type
-	ExtraKeyParentType = "iam.miloapis.com/parent-type"
-	// ExtraKeyParentName is the user.Extra key containing the parent resource name
-	ExtraKeyParentName = "iam.miloapis.com/parent-name"
+	// ExtraKeyParentType is the user.Extra key containing the parent resource type.
+	// Aliased to the canonical constant so emitters and readers of this key
+	// cannot drift apart.
+	ExtraKeyParentType = iamv1alpha1.ParentKindExtraKey
+	// ExtraKeyParentName is the user.Extra key containing the parent resource name.
+	ExtraKeyParentName = iamv1alpha1.ParentNameExtraKey
 )
 
-// injectScopeAnnotations adds scope annotations to a core/v1 Event based on user context
+// injectScopeAnnotations adds scope annotations to a core/v1 Event based on the
+// authenticated request's parent context.
+//
+// Scope comes only from the request's parent-type/parent-name context — set by
+// the parent-context auth filters for end-user requests, or asserted by an
+// impersonating caller. It always overwrites any scope annotations already on
+// the event, and nothing carried on the event body, the involved object
+// included, can influence it. Event fields are client-supplied and therefore
+// untrusted for a tenant-isolation decision.
+//
+// Controllers whose events must reach a tenant's activity feed impersonate that
+// parent context rather than relying on inference here; see ProjectEventEmitter
+// in internal/controllers/resourcemanager.
+//
+// Requests carrying no parent context, or only half of it, leave the event
+// unannotated. That is normal for system components and platform-level
+// operations.
 func injectScopeAnnotations(ctx context.Context, event *corev1.Event) error {
 	userInfo, ok := apirequest.UserFrom(ctx)
 	if !ok {
@@ -32,7 +52,6 @@ func injectScopeAnnotations(ctx context.Context, event *corev1.Event) error {
 	parentType := getFirstExtra(extras, ExtraKeyParentType)
 	parentName := getFirstExtra(extras, ExtraKeyParentName)
 
-	// Events without scope context are normal (e.g., system components, platform-level operations)
 	if parentType == "" || parentName == "" {
 		return nil
 	}

--- a/pkg/server/filters/audit_scope.go
+++ b/pkg/server/filters/audit_scope.go
@@ -7,6 +7,8 @@ import (
 	"k8s.io/apiserver/pkg/authentication/user"
 	"k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/klog/v2"
+
+	iamv1alpha1 "go.miloapis.com/milo/pkg/apis/iam/v1alpha1"
 )
 
 const (
@@ -25,9 +27,10 @@ const (
 	ScopeTypeProject      = "Project"
 	ScopeTypeUser         = "User"
 
-	// User extra keys (from iam.miloapis.com/v1alpha1/doc.go)
-	ParentTypeExtraKey = "iam.miloapis.com/parent-type"
-	ParentNameExtraKey = "iam.miloapis.com/parent-name"
+	// User extra keys, aliased to iam.miloapis.com/v1alpha1 so there is a
+	// single source of truth for the wire values.
+	ParentTypeExtraKey = iamv1alpha1.ParentKindExtraKey
+	ParentNameExtraKey = iamv1alpha1.ParentNameExtraKey
 )
 
 // AuditScopeAnnotationDecorator adds platform scope annotations to audit events


### PR DESCRIPTION
Split out of #749 to keep that PR to the controller-side change.

Scope for an event comes only from the request's `parent-type`/`parent-name` context, never from the event body. That rule was implicit — the involved object was simply never read — so nothing would have failed if someone started reading it. Review on #749 made the rule explicit; this pins it.

- Tests asserting the involved/regarding object cannot set scope, on both the `core/v1` and `events.k8s.io/v1` paths, including when parent context is incomplete.
- First coverage for `injectEventsV1ScopeAnnotations`.
- The invariant documented on `injectScopeAnnotations`.
- `ExtraKeyParentType`/`Name` and the audit-scope filter's copies aliased to the canonical `iam.miloapis.com/v1alpha1` constants — three definitions of the same two strings become one.

No behaviour change.

## Test plan

- `go build ./...`, `gofmt -l .` — clean
- `go test ./internal/apiserver/events/... ./pkg/server/filters/...` — pass