### PR TITLE
test(resourcemanager): disable global configmap quota policy during project deletion blocked resources e2e test

### DIFF
--- a/test/resource-management/project-deletion-blocked-resources/chainsaw-test.yaml
+++ b/test/resource-management/project-deletion-blocked-resources/chainsaw-test.yaml
@@ -66,6 +66,9 @@ spec:
               kubectl --kubeconfig kubeconfig-project-namespace -n blocked-ns patch configmap held-resource \
                 --type=merge -p '{"metadata":{"finalizers":null}}' >/dev/null 2>&1
 
+              kubectl --kubeconfig kubeconfig-main patch claimcreationpolicy project-configmap-claim-policy \
+                --type=merge -p '{"spec":{"disabled":true}}' >/dev/null 2>&1 || true
+
               for project in test-blocked-default-project test-blocked-namespace-project; do
                 kubectl --kubeconfig kubeconfig-main delete project "${project}" --wait=false >/dev/null 2>&1
               done
@@ -241,6 +244,10 @@ spec:
       description: Remove the organization and user the test created
       cluster: main
       try:
+        - script:
+            content: |
+              kubectl --kubeconfig kubeconfig-main patch claimcreationpolicy project-configmap-claim-policy \
+                --type=merge -p '{"spec":{"disabled":false}}' >/dev/null 2>&1 || true
         - delete:
             ref:
               apiVersion: resourcemanager.miloapis.com/v1alpha1


### PR DESCRIPTION
## Summary

Fixes e2e test failure in `chainsaw/project-deletion-blocked-resources`.

### Cause
When the test creates `ConfigMap` resources (`held-resource`) inside project control planes, Milo's global quota policy (`project-configmap-claim-policy`) intercepts the request and generates a `ResourceClaim`. Because the test organization has no `ResourceGrant` allocated for `core.miloapis.com/configmaps`, admission denies resource creation with `403 Forbidden` (`You've reached your quota for this resource type`).

### Solution
- Temporarily patch `project-configmap-claim-policy` to `disabled: true` during `clear-previous-run` in `chainsaw-test.yaml`.
- Re-enable the policy (`disabled: false`) during test cleanup.

## Testing
- Verified locally with `task test:end-to-end -- resource-management/project-deletion-blocked-resources` (Passed: 1, Failed: 0).
