### PR TITLE
chore: label milo alerts with owning service

### DIFF
--- a/config/telemetry/alerts/iam/policy-bindings.yaml
+++ b/config/telemetry/alerts/iam/policy-bindings.yaml
@@ -19,6 +19,7 @@ spec:
             severity: critical
             category: readiness
             team: platform
+            service: milo
           annotations:
             runbook_url: "https://github.com/milo-os/milo/blob/main/docs/runbooks/policy-bindings-not-ready.md"
             summary: "{{ $value }} policy bindings are not ready"

--- a/config/telemetry/alerts/resources-manager/organization-memberships.yaml
+++ b/config/telemetry/alerts/resources-manager/organization-memberships.yaml
@@ -19,6 +19,7 @@ spec:
             severity: warning
             category: readiness
             team: platform
+            service: milo
           annotations:
             runbook_url: "https://github.com/milo-os/milo/blob/main/docs/runbooks/organization-memberships-not-ready.md"
             summary: "{{ $value }} organization memberships are not ready"

--- a/config/telemetry/alerts/resources-manager/projects.yaml
+++ b/config/telemetry/alerts/resources-manager/projects.yaml
@@ -14,6 +14,8 @@ spec:
           labels:
             severity: critical
             slo_violation: "true"
+            service: milo
+            team: platform
           annotations:
             runbook_url: "https://github.com/milo-os/milo/blob/main/docs/runbooks/project-stuck-creating-slo-violation.md"
             summary: "Project {{ $labels.resource_name }} is stuck creating for over 60 seconds"

--- a/config/telemetry/alerts/resources-manager/projectsuspensions.yaml
+++ b/config/telemetry/alerts/resources-manager/projectsuspensions.yaml
@@ -23,6 +23,7 @@ spec:
             severity: warning
             category: readiness
             team: platform
+            service: milo
           annotations:
             runbook_url: "https://github.com/milo-os/milo/blob/main/docs/runbooks/project-suspension-not-ready.md"
             summary: "Project suspension {{ $labels.resource_name }} is not ready"
@@ -49,6 +50,7 @@ spec:
             severity: warning
             category: readiness
             team: platform
+            service: milo
           annotations:
             runbook_url: "https://github.com/milo-os/milo/blob/main/docs/runbooks/project-reinstatement-failed.md"
             summary: "Project {{ $labels.resource_name }} failed to reinstate"


### PR DESCRIPTION
## Summary

Five Milo alerting rules fired without any label naming the service that owns them, so Alertmanager had nothing to route or attribute on and every one of them landed in the same shared channel. This adds the owning service label to all five, and the owning team label to the single rule that carried neither. Operators can now page the owning team directly and attribute these alerts on dashboards alongside the rules that already declared ownership.

> [!NOTE]
> Labels are added only, never overwritten, and no expression, threshold, duration, or annotation changes.

## Test plan

- [x] Kustomize validation passes across the whole repository
- [x] All five rules render with both ownership labels
- [x] No other alerting rule changed
- [ ] Prometheus rule unit tests still pass

Related to datum-cloud/infra#3983
